### PR TITLE
`assert_eq` requires `PartialEq` instead of `Eq`

### DIFF
--- a/sway-lib-std/src/assert.sw
+++ b/sway-lib-std/src/assert.sw
@@ -61,7 +61,7 @@ pub fn assert(condition: bool) {
 #[cfg(experimental_new_encoding = false)]
 pub fn assert_eq<T>(v1: T, v2: T)
 where
-    T: Eq,
+    T: PartialEq,
 {
     if (v1 != v2) {
         log(v1);
@@ -73,7 +73,7 @@ where
 #[cfg(experimental_new_encoding = true)]
 pub fn assert_eq<T>(v1: T, v2: T)
 where
-    T: Eq + AbiEncode,
+    T: PartialEq + AbiEncode,
 {
     if (v1 != v2) {
         log(v1);
@@ -105,7 +105,7 @@ where
 #[cfg(experimental_new_encoding = false)]
 pub fn assert_ne<T>(v1: T, v2: T)
 where
-    T: Eq,
+    T: PartialEq,
 {
     if (v1 == v2) {
         log(v1);
@@ -117,7 +117,7 @@ where
 #[cfg(experimental_new_encoding = true)]
 pub fn assert_ne<T>(v1: T, v2: T)
 where
-    T: Eq + AbiEncode,
+    T: PartialEq + AbiEncode,
 {
     if (v1 == v2) {
         log(v1);


### PR DESCRIPTION
## Description

This PR changes the trait constraints on `assert_eq` and `assert_ne` from `Eq` to `PartialEq`. The `Eq` requirement was unnecessary strong, and is actually a "leftover" from the original implementation, before we introduced `PartialEq`. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.