### PR TITLE
Fix `Eq` constraint in vec.sw `impl<T> PartialEq for Vec<T>`.

### DIFF
--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -890,7 +890,7 @@ impl<T> Clone for Vec<T> {
 
 impl<T> PartialEq for Vec<T>
 where
-    T: Eq,
+    T: PartialEq,
 {
     fn eq(self, other: Self) -> bool {
         if self.len() != other.len() {


### PR DESCRIPTION
Fixes a mistake where an `Eq` constraint was used where a `PartialEq` suffixes.
