### PR TITLE
forc-call: missing contract retrieval refactor

### DIFF
--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -4,7 +4,7 @@ use crate::{
         call::{FuncType, Verbosity},
     },
     op::call::{
-        missing_contracts::get_missing_contracts,
+        missing_contracts::determine_missing_contracts,
         parser::{param_type_val_to_token, token_to_string},
         CallResponse, Either,
     },
@@ -99,14 +99,13 @@ pub async fn call_function(
             .collect(),
         None => {
             // Automatically retrieve missing contract addresses from the call
-            let external_contracts = get_missing_contracts(
-                call.clone(),
+            let external_contracts = determine_missing_contracts(
+                &call,
                 wallet.provider(),
                 &tx_policies,
                 &variable_output_policy,
                 &log_decoder,
                 &wallet,
-                None,
             )
             .await?;
             if !external_contracts.is_empty() {

--- a/forc-plugins/forc-client/src/op/call/missing_contracts.rs
+++ b/forc-plugins/forc-client/src/op/call/missing_contracts.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
-use fuel_tx::{PanicReason, Receipt};
-use fuels::programs::calls::{traits::TransactionTuner, ContractCall};
+use fuels::programs::calls::{
+    traits::TransactionTuner, utils::find_ids_of_missing_contracts, ContractCall,
+};
 use fuels_accounts::{
     provider::Provider,
     signers::private_key::PrivateKeySigner,
@@ -12,68 +13,37 @@ use fuels_core::types::{
 
 /// Get the missing contracts from a contract call by dry-running the transaction
 /// to find contracts that are not explicitly listed in the call's `external_contracts` field.
-pub async fn get_missing_contracts(
-    mut call: ContractCall,
+/// Note: This function is derived from `determine_missing_contracts` in `fuels-rs`
+pub async fn determine_missing_contracts(
+    call: &ContractCall,
     provider: &Provider,
     tx_policies: &TxPolicies,
     variable_output_policy: &VariableOutputPolicy,
     log_decoder: &fuels_core::codec::LogDecoder,
     account: &Wallet<Unlocked<PrivateKeySigner>>,
-    max_attempts: Option<u64>,
 ) -> Result<Vec<Bech32ContractId>> {
-    let max_attempts = max_attempts.unwrap_or(10);
+    let tb = call
+        .transaction_builder(*tx_policies, *variable_output_policy, account)
+        .await
+        .expect("Failed to initialize transaction builder");
 
-    for attempt in 1..=max_attempts {
-        forc_tracing::println_warning(&format!(
-            "Executing dry-run attempt {} to find missing contracts",
-            attempt
-        ));
+    let tx = call
+        .build_tx(tb, account)
+        .await
+        .expect("Failed to build transaction");
 
-        let tb = call
-            .transaction_builder(*tx_policies, *variable_output_policy, account)
-            .await
-            .expect("Failed to initialize transaction builder");
-        let tx = call
-            .build_tx(tb, account)
-            .await
-            .expect("Failed to build transaction");
-
-        match provider
-            .dry_run(tx)
-            .await?
-            .take_receipts_checked(Some(log_decoder))
-        {
-            Ok(_) => return Ok(call.external_contracts),
-            Err(fuels_core::types::errors::Error::Transaction(
-                fuels::types::errors::transaction::Reason::Failure { receipts, .. },
-            )) => {
-                let contract_id = find_id_of_missing_contract(&receipts)?;
-                call.external_contracts.push(contract_id);
-            }
-            Err(err) => bail!(err),
+    match provider
+        .dry_run(tx)
+        .await?
+        .take_receipts_checked(Some(log_decoder))
+    {
+        Ok(_) => Ok(vec![]),
+        Err(fuels_core::types::errors::Error::Transaction(
+            fuels::types::errors::transaction::Reason::Failure { receipts, .. },
+        )) => {
+            let missing_contracts = find_ids_of_missing_contracts(&receipts);
+            Ok(missing_contracts)
         }
+        Err(err) => bail!(err),
     }
-    bail!("Max attempts reached while finding missing contracts")
-}
-
-fn find_id_of_missing_contract(receipts: &[Receipt]) -> Result<Bech32ContractId> {
-    for receipt in receipts {
-        match receipt {
-            Receipt::Panic {
-                reason,
-                contract_id,
-                ..
-            } if *reason.reason() == PanicReason::ContractNotInInputs => {
-                let contract_id = contract_id
-                    .expect("panic caused by a contract not in inputs must have a contract id");
-                return Ok(Bech32ContractId::from(contract_id));
-            }
-            Receipt::Panic { reason, .. } => {
-                // If it's a panic but not ContractNotInInputs, include the reason
-                bail!("Contract execution panicked with reason: {:?}", reason);
-            }
-            _ => continue,
-        }
-    }
-    bail!("No contract found in receipts: {:?}", receipts)
 }


### PR DESCRIPTION
## Description

Using `fuels-rs` SDK to retrieve missing contracts for a forc-call query.

This function/improvement was introduced in the `fuels-rs` sdk here: https://github.com/FuelLabs/fuels-rs/pull/1628

Addresses: https://github.com/FuelLabs/sway/issues/7113

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
