### PR TITLE
fix: add `implicit-std = false` to fix failing LSP test

### DIFF
--- a/sway-lsp/tests/fixtures/workspace/test-contract/Forc.toml
+++ b/sway-lsp/tests/fixtures/workspace/test-contract/Forc.toml
@@ -3,5 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "test-contract"
+implicit-std = false
 
 [dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/workspace/test-library/Forc.toml
+++ b/sway-lsp/tests/fixtures/workspace/test-library/Forc.toml
@@ -3,5 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "lib.sw"
 license = "Apache-2.0"
 name = "test-library"
+implicit-std = false
 
 [dependencies]
+std = { path = "../../../../../sway-lib-std" }


### PR DESCRIPTION
## Description
The `sync_with_updates_to_manifest_in_workspace` test [was failing](https://github.com/FuelLabs/sway/actions/runs/14633300994/job/41059472756?pr=7112) because I forgot to specify `implicit-std = false` in the `Forc.toml` which meant it was trying to fetch when it shouldn't have. 


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
