### PR TITLE
improve dbg intrinsic with fflush

### DIFF
--- a/forc-test/src/ecal.rs
+++ b/forc-test/src/ecal.rs
@@ -5,27 +5,32 @@ use fuel_vm::{
 
 // ssize_t write(int fd, const void buf[.count], size_t count);
 pub const WRITE_SYSCALL: u64 = 1000;
+pub const FFLUSH_SYSCALL: u64 = 1001;
 
 #[derive(Debug, Clone)]
 pub enum Syscall {
     Write { fd: u64, bytes: Vec<u8> },
+    Fflush { fd: u64 },
     Unknown { ra: u64, rb: u64, rc: u64, rd: u64 },
 }
 
 impl Syscall {
     pub fn apply(&self) {
+        use std::io::Write;
+        use std::os::fd::FromRawFd;
         match self {
             Syscall::Write { fd, bytes } => {
                 let s = std::str::from_utf8(bytes.as_slice()).unwrap();
-
-                use std::io::Write;
-                use std::os::fd::FromRawFd;
 
                 let mut f = unsafe { std::fs::File::from_raw_fd(*fd as i32) };
                 write!(&mut f, "{}", s).unwrap();
 
                 // Dont close the fd
                 std::mem::forget(f);
+            }
+            Syscall::Fflush { fd } => {
+                let mut f = unsafe { std::fs::File::from_raw_fd(*fd as i32) };
+                let _ = f.flush();
             }
             Syscall::Unknown { ra, rb, rc, rd } => {
                 println!("Unknown ecal: {} {} {} {}", ra, rb, rc, rd);
@@ -98,6 +103,10 @@ impl EcalHandler for EcalSyscallHandler {
                 let count = regs[d.to_u8() as usize];
                 let bytes = vm.memory().read(addr, count).unwrap().to_vec();
                 Syscall::Write { fd, bytes }
+            }
+            FFLUSH_SYSCALL => {
+                let fd = regs[b.to_u8() as usize];
+                Syscall::Fflush { fd }
             }
             _ => {
                 let ra = regs[a.to_u8() as usize];

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -2050,6 +2050,7 @@ fn expr_func_app_to_expression_kind(
         //      f.print_str("[{current_file}:{current_line}:{current_col}] = ");
         //      let arg = arg;
         //      arg.fmt(f);
+        //      f.flush();
         //      arg
         // }"
         Some(Intrinsic::Dbg)
@@ -2221,6 +2222,29 @@ fn expr_func_app_to_expression_kind(
                     },
                     // f.print_str(<newline>);
                     ast_node_to_print_str(f_ident.clone(), "\n", &span),
+                    // f.flush();
+                    AstNode {
+                        content: AstNodeContent::Expression(Expression {
+                            kind: ExpressionKind::MethodApplication(Box::new(
+                                MethodApplicationExpression {
+                                    method_name_binding: TypeBinding {
+                                        inner: MethodName::FromModule {
+                                            method_name: BaseIdent::new_no_span("flush".into()),
+                                        },
+                                        type_arguments: TypeArgs::Regular(vec![]),
+                                        span: span.clone(),
+                                    },
+                                    contract_call_params: vec![],
+                                    arguments: vec![Expression {
+                                        kind: ExpressionKind::Variable(f_ident.clone()),
+                                        span: span.clone(),
+                                    }],
+                                },
+                            )),
+                            span: span.clone(),
+                        }),
+                        span: span.clone(),
+                    },
                     // arg
                     AstNode {
                         content: AstNodeContent::Expression(Expression {

--- a/sway-lib-std/src/debug.sw
+++ b/sway-lib-std/src/debug.sw
@@ -12,6 +12,13 @@ fn syscall_write(fd: u64, buf: raw_ptr, count: u64) {
     }
 }
 
+// int fflush(FILE *_Nullable stream);
+fn syscall_fflush(fd: u64) {
+    asm(id: 1001, fd: fd) {
+        ecal id fd zero zero;
+    }
+}
+
 pub struct DebugStruct {
     f: Formatter,
     has_fields: bool,
@@ -45,7 +52,7 @@ impl Formatter {
         let mut i = 63;
         while value > 0 {
             let digit = value % 10;
-            digits[i] = digit + 48; // ascii zero = 48 
+            digits[i] = digit + 48; // ascii zero = 48
             i -= 1;
             value = value / 10;
         }
@@ -61,7 +68,7 @@ impl Formatter {
             let digit = asm(v: value % 10) {
                 v: u8
             };
-            digits[i] = digit + 48; // ascii zero = 48 
+            digits[i] = digit + 48; // ascii zero = 48
             i -= 1;
             value = value / 10;
         }
@@ -77,7 +84,7 @@ impl Formatter {
             let digit = asm(v: value % 10) {
                 v: u8
             };
-            digits[i] = digit + 48; // ascii zero = 48 
+            digits[i] = digit + 48; // ascii zero = 48
             i -= 1;
             value = value / 10;
         }
@@ -93,7 +100,7 @@ impl Formatter {
             let digit = asm(v: value % 10) {
                 v: u8
             };
-            digits[i] = digit + 48; // ascii zero = 48 
+            digits[i] = digit + 48; // ascii zero = 48
             i -= 1;
             value = value / 10;
         }
@@ -114,7 +121,7 @@ impl Formatter {
             let digit = asm(v: digit % 10) {
                 v: u8
             };
-            digits[i] = digit + 48; // ascii zero = 48 
+            digits[i] = digit + 48; // ascii zero = 48
             i -= 1;
             value = value / 10;
         }
@@ -149,6 +156,10 @@ impl Formatter {
             f: self,
             has_fields: false,
         }
+    }
+
+    pub fn flush(self) {
+        syscall_fflush(STDERR);
     }
 }
 

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -416,6 +416,7 @@ impl TestContext {
                                     let s = std::str::from_utf8(bytes.as_slice()).unwrap();
                                     output.push_str(s);
                                 }
+                                Syscall::Fflush { .. } => {}
                                 Syscall::Unknown { ra, rb, rc, rd } => {
                                     let _ = writeln!(
                                         output,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/stdout.snap
@@ -7,6 +7,7 @@ ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 ecal $r4 $r2 $r3 $r0          ; ecal id fd buf count
+ecal $r2 $r1 $zero $zero      ; ecal id fd zero zero
 ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg --release --asm final | grep ecal

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg_release/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg_release/stdout.snap
@@ -7,10 +7,24 @@ ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 ecal $r4 $r2 $r3 $r0          ; ecal id fd buf count
+ecal $r2 $r1 $zero $zero      ; ecal id fd zero zero
 ecal $r3 $r0 $r1 $r2          ; ecal id fd buf count
 
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg_release --release --asm final | grep ecal
 ecal $r2 $r6 $r0 $r1          ; ecal id fd buf count
-ecal $r7 $r8 $r3 $r6          ; ecal id fd buf count
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r6 $r7 $r2 $r3          ; ecal id fd buf count
+ecal $r2 $r3 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r3 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
+ecal $r0 $r1 $zero $zero      ; ecal id fd zero zero
 ecal $r3 $r4 $r2 $r0          ; ecal id fd buf count
 ecal $r3 $r4 $r1 $r2          ; ecal id fd buf count


### PR DESCRIPTION
## Description

This PR brings a new syscall "fflush" to help `EcalHandler` know when the `__dbg` is finished and they flush their buffers. 

In theory, Linux `fflush` is not a syscall because it just flushes "user-space" buffers. As we do not have this difference, we are still going to call `fflush` as a syscall.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
