### PR TITLE
sway-lsp: Fix the double read-lock bug in session

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -232,7 +232,6 @@ impl Session {
         let compiled_program = &*self.compiled_program.read();
         if let Some(TypedAstToken::TypedFunctionDeclaration(fn_decl)) = fn_token.as_typed() {
             if let Some(program) = &compiled_program.typed {
-                let engines = self.engines.read();
                 return Some(capabilities::completion::to_completion_items(
                     &program.namespace,
                     &engines,


### PR DESCRIPTION
## Description

Fix #7144

way-lsp contains a possible double read-lock bug.

The lock is a parking_lot::RwLock:
The first read lock is on L227 in completion_items
The second read lock is on L235 in completion_items
https://github.com/FuelLabs/sway/blob/324f04fbab358a8e7eb729d03e0293605755ba5a/sway-lsp/src/core/session.rs#L227-L235

The solution is to remove the redundant second read lock
After the fix, the possible double read-lock will be eliminated, and the performance may be better.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
