### PR TITLE
Replace Tokio Thread File Watcher with LSP Client File Watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,15 +3219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "fuel-abi-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,26 +4699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4909,26 +4880,6 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
-]
-
-[[package]]
-name = "kqueue"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]
@@ -5329,18 +5280,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -5490,36 +5429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "notify"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.9.0",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio 0.8.11",
- "walkdir",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "notify-debouncer-mini"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
-dependencies = [
- "crossbeam-channel",
- "log",
- "notify",
 ]
 
 [[package]]
@@ -8061,8 +7970,6 @@ dependencies = [
  "forc-util",
  "futures",
  "lsp-types",
- "notify",
- "notify-debouncer-mini",
  "parking_lot",
  "pretty_assertions",
  "proc-macro2",
@@ -8635,7 +8542,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,8 +180,6 @@ mark-flaky-tests = "1.0"
 mdbook = { version = "0.4", default-features = false }
 minifier = "0.3"
 normalize-path = "0.2"
-notify = "6.1"
-notify-debouncer-mini = "0.4"
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 object = "0.36"

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -17,8 +17,6 @@ forc-pkg.workspace = true
 forc-tracing.workspace = true
 forc-util.workspace = true
 lsp-types = { workspace = true, features = ["proposed"] }
-notify.workspace = true
-notify-debouncer-mini.workspace = true
 parking_lot.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -107,17 +107,11 @@ impl Session {
         self.sync.clone_manifest_dir_to_temp()?;
         // iterate over the project dir, parse all sway files
         let _ = self.store_sway_files(documents).await;
-        self.sync.watch_and_sync_manifest();
+        self.sync.sync_manifest();
         self.sync.manifest_dir().map_err(Into::into)
     }
 
     pub fn shutdown(&self) {
-        // shutdown the thread watching the manifest file
-        let handle = self.sync.notify_join_handle.read();
-        if let Some(join_handle) = &*handle {
-            join_handle.abort();
-        }
-
         // Delete the temporary directory.
         self.sync.remove_temp_dir();
     }

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -6,13 +6,9 @@ use dashmap::DashMap;
 use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
 use forc_pkg::PackageManifestFile;
 use lsp_types::Url;
-use notify::RecursiveMode;
-use notify_debouncer_mini::new_debouncer;
-use parking_lot::RwLock;
 use std::{
     fs,
     path::{Path, PathBuf},
-    time::Duration,
 };
 use sway_types::{SourceEngine, Span};
 use sway_utils::{
@@ -20,8 +16,6 @@ use sway_utils::{
     SWAY_EXTENSION,
 };
 use tempfile::Builder;
-use tokio::task::JoinHandle;
-use tracing::error;
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub enum Directory {
@@ -32,7 +26,6 @@ pub enum Directory {
 #[derive(Debug)]
 pub struct SyncWorkspace {
     pub directories: DashMap<Directory, PathBuf>,
-    pub notify_join_handle: RwLock<Option<JoinHandle<()>>>,
 }
 
 impl SyncWorkspace {
@@ -41,7 +34,6 @@ impl SyncWorkspace {
     pub(crate) fn new() -> Self {
         Self {
             directories: DashMap::new(),
-            notify_join_handle: RwLock::new(None),
         }
     }
 
@@ -178,8 +170,8 @@ impl SyncWorkspace {
             .ok()
     }
 
-    /// Watch the manifest directory and check for any save events on Forc.toml
-    pub(crate) fn watch_and_sync_manifest(&self) {
+    /// Scan the Forc.toml and convert relative paths to absolute. Save into our temp directory.
+    pub(crate) fn sync_manifest(&self) {
         if let (Ok(manifest_dir), Some(manifest_path), Some(temp_manifest_path)) = (
             self.manifest_dir(),
             self.manifest_path(),
@@ -188,40 +180,7 @@ impl SyncWorkspace {
             if let Err(err) =
                 edit_manifest_dependency_paths(&manifest_dir, &manifest_path, &temp_manifest_path)
             {
-                error!("Failed to edit manifest dependency paths: {}", err);
-            }
-
-            let handle = tokio::spawn(async move {
-                let (tx, mut rx) = tokio::sync::mpsc::channel(10);
-                // Setup debouncer. No specific tickrate, max debounce time 500 milliseconds
-                let mut debouncer = new_debouncer(Duration::from_millis(500), move |event| {
-                    if let Ok(e) = event {
-                        let _ = tx.blocking_send(e);
-                    }
-                })
-                .unwrap();
-
-                debouncer
-                    .watcher()
-                    .watch(&manifest_dir, RecursiveMode::NonRecursive)
-                    .unwrap();
-                while let Some(_events) = rx.recv().await {
-                    // Rescan the Forc.toml and convert
-                    // relative paths to absolute. Save into our temp directory.
-                    if let Err(err) = edit_manifest_dependency_paths(
-                        &manifest_dir,
-                        &manifest_path,
-                        &temp_manifest_path,
-                    ) {
-                        error!("Failed to edit manifest dependency paths: {}", err);
-                    }
-                }
-            });
-
-            // Store the join handle so we can clean up the thread on shutdown
-            {
-                let mut join_handle = self.notify_join_handle.write();
-                *join_handle = Some(handle);
+                tracing::error!("Failed to edit manifest dependency paths: {}", err);
             }
         }
     }

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -41,13 +41,7 @@ impl SyncWorkspace {
     /// the current workspace.
     pub fn resync(&self) -> Result<(), LanguageServerError> {
         self.clone_manifest_dir_to_temp()?;
-        if let (Ok(manifest_dir), Some(manifest_path), Some(temp_manifest_path)) = (
-            self.manifest_dir(),
-            self.manifest_path(),
-            self.temp_manifest_path(),
-        ) {
-            edit_manifest_dependency_paths(&manifest_dir, &manifest_path, &temp_manifest_path)?;
-        }
+        self.sync_manifest();
         Ok(())
     }
 

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -164,7 +164,7 @@ impl SyncWorkspace {
             .ok()
     }
 
-    /// Scan the Forc.toml and convert relative paths to absolute. Save into our temp directory.
+    /// Read the Forc.toml and convert relative paths to absolute. Save into our temp directory.
     pub(crate) fn sync_manifest(&self) {
         if let (Ok(manifest_dir), Some(manifest_path), Some(temp_manifest_path)) = (
             self.manifest_dir(),

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -27,6 +27,10 @@ pub enum LanguageServerError {
     ProgramsIsNone,
     #[error("Unable to acquire a semaphore permit for parsing")]
     UnableToAcquirePermit,
+    #[error("Client is not initialized")]
+    ClientNotInitialized,
+    #[error("Client request error: {0}")]
+    ClientRequestError(String),
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -158,14 +158,15 @@ pub(crate) async fn handle_did_change_watched_files(
     state: &ServerState,
     params: DidChangeWatchedFilesParams,
 ) -> Result<(), LanguageServerError> {
-    eprintln!("Received DidChangeWatchedFiles notification");
     for event in params.changes {
         let (uri, session) = state.uri_and_session_from_workspace(&event.uri).await?;
 
         match event.typ {
             FileChangeType::CHANGED => {
-                session.sync.sync_manifest();
-                // TODO: Recompile the project
+                if event.uri.to_string().contains("Forc.toml") {
+                    session.sync.sync_manifest();
+                    // TODO: Recompile the project
+                }
             }
             FileChangeType::DELETED => {
                 state.pid_locked_files.remove_dirty_flag(&event.uri)?;

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -165,7 +165,7 @@ pub(crate) async fn handle_did_change_watched_files(
             FileChangeType::CHANGED => {
                 if event.uri.to_string().contains("Forc.toml") {
                     session.sync.sync_manifest();
-                    // TODO: Recompile the project
+                    // TODO: Recompile the project | see https://github.com/FuelLabs/sway/issues/7103
                 }
             }
             FileChangeType::DELETED => {

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -21,7 +21,7 @@ use sway_utils::PerformanceData;
 use tower_lsp::jsonrpc::Result;
 use tracing::metadata::LevelFilter;
 
-pub async fn handle_initialize(
+pub fn handle_initialize(
     state: &ServerState,
     params: &lsp_types::InitializeParams,
 ) -> Result<InitializeResult> {
@@ -35,11 +35,6 @@ pub async fn handle_initialize(
     // Start a thread that will shutdown the server if the client process is no longer active.
     if let Some(client_pid) = params.process_id {
         state.spawn_client_heartbeat(client_pid as usize);
-    }
-
-    // Register a file system watcher for Forc.toml files with the client.
-    if let Err(err) = state.register_forc_toml_watcher().await {
-        tracing::error!("Failed to register Forc.toml file watcher: {}", err);
     }
 
     // Initializing tracing library based on the user's config

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -21,7 +21,7 @@ use sway_utils::PerformanceData;
 use tower_lsp::jsonrpc::Result;
 use tracing::metadata::LevelFilter;
 
-pub fn handle_initialize(
+pub async fn handle_initialize(
     state: &ServerState,
     params: &lsp_types::InitializeParams,
 ) -> Result<InitializeResult> {
@@ -36,6 +36,9 @@ pub fn handle_initialize(
     if let Some(client_pid) = params.process_id {
         state.spawn_client_heartbeat(client_pid as usize);
     }
+
+    // Register a file system watcher for Forc.toml files with the client.
+    state.register_forc_toml_watcher().await;
 
     // Initializing tracing library based on the user's config
     let config = state.config.read();

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -38,7 +38,9 @@ pub async fn handle_initialize(
     }
 
     // Register a file system watcher for Forc.toml files with the client.
-    state.register_forc_toml_watcher().await;
+    if let Err(err) = state.register_forc_toml_watcher().await {
+        tracing::error!("Failed to register Forc.toml file watcher: {}", err);
+    }
 
     // Initializing tracing library based on the user's config
     let config = state.config.read();

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -23,11 +23,14 @@ use tower_lsp::{jsonrpc::Result, LanguageServer};
 #[tower_lsp::async_trait]
 impl LanguageServer for ServerState {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        request::handle_initialize(self, &params).await
+        request::handle_initialize(self, &params)
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        let _p = tracing::trace_span!("parse_text").entered();
+        // Register a file system watcher for Forc.toml files with the client.
+        if let Err(err) = self.register_forc_toml_watcher().await {
+            tracing::error!("Failed to register Forc.toml file watcher: {}", err);
+        }
         tracing::info!("Sway Language Server Initialized");
     }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -23,7 +23,7 @@ use tower_lsp::{jsonrpc::Result, LanguageServer};
 #[tower_lsp::async_trait]
 impl LanguageServer for ServerState {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        request::handle_initialize(self, &params)
+        request::handle_initialize(self, &params).await
     }
 
     async fn initialized(&self, _: InitializedParams) {

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -13,7 +13,10 @@ use crossbeam_channel::{Receiver, Sender};
 use dashmap::{mapref::multiple::RefMulti, DashMap};
 use forc_pkg::manifest::GenericManifestFile;
 use forc_pkg::PackageManifestFile;
-use lsp_types::{Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, Registration, Url, WatchKind};
+use lsp_types::{
+    Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern,
+    Registration, Url, WatchKind,
+};
 use parking_lot::{Mutex, RwLock};
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -141,7 +144,7 @@ impl ServerState {
         } else {
             tracing::info!("Successfully registered Forc.toml file watcher");
         }
-    }     
+    }
 
     /// Spawns a new thread dedicated to handling compilation tasks. This thread listens for
     /// `TaskMessage` instances sent over a channel and processes them accordingly.

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -13,7 +13,7 @@ use crossbeam_channel::{Receiver, Sender};
 use dashmap::{mapref::multiple::RefMulti, DashMap};
 use forc_pkg::manifest::GenericManifestFile;
 use forc_pkg::PackageManifestFile;
-use lsp_types::{Diagnostic, Url};
+use lsp_types::{Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, Registration, Url, WatchKind};
 use parking_lot::{Mutex, RwLock};
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -114,6 +114,34 @@ impl ServerState {
             ..Default::default()
         }
     }
+
+    /// Registers a file system watcher for Forc.toml files with the client.
+    pub async fn register_forc_toml_watcher(&self) {
+        let client = self
+            .client
+            .as_ref()
+            .expect("Client is guaranteed to be set by the time this is called");
+
+        let watchers = vec![FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/Forc.toml".to_string()),
+            kind: Some(WatchKind::Create | WatchKind::Change),
+        }];
+        let registration_options = DidChangeWatchedFilesRegistrationOptions { watchers };
+        let registration = Registration {
+            id: "forc-toml-watcher".to_string(),
+            method: "workspace/didChangeWatchedFiles".to_string(),
+            register_options: Some(
+                serde_json::to_value(registration_options)
+                    .expect("Failed to serialize registration options"),
+            ),
+        };
+
+        if let Err(err) = client.register_capability(vec![registration]).await {
+            tracing::error!("Failed to register Forc.toml file watcher: {}", err);
+        } else {
+            tracing::info!("Successfully registered Forc.toml file watcher");
+        }
+    }     
 
     /// Spawns a new thread dedicated to handling compilation tasks. This thread listens for
     /// `TaskMessage` instances sent over a channel and processes them accordingly.

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -67,6 +67,18 @@ pub(crate) async fn exit_notification(service: &mut LspService<ServerState>) {
     assert_eq!(response, Ok(None));
 }
 
+pub(crate) async fn did_change_watched_files_notification(
+    service: &mut LspService<ServerState>,
+    params: DidChangeWatchedFilesParams,
+) {
+    let params: serde_json::value::Value = serde_json::to_value(params).unwrap();
+    let did_change_watched_files = Request::build("workspace/didChangeWatchedFiles")
+        .params(params)
+        .finish();
+    let response = call_request(service, did_change_watched_files).await;
+    assert_eq!(response, Ok(None));
+}
+
 pub(crate) async fn did_open_notification(
     service: &mut LspService<ServerState>,
     uri: &Url,

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -141,7 +141,7 @@ fn initialize() {
             initialization_options: None,
             ..Default::default()
         };
-        let _ = request::handle_initialize(&server, &params).await;
+        let _ = request::handle_initialize(&server, &params);
     });
 }
 

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -180,8 +180,14 @@ fn sync_with_updates_to_manifest_in_workspace() {
         manifest_content.push_str(test_lib_string);
         fs::write(&test_contract_manifest, &manifest_content).unwrap();
 
-        // wait for 500 milliseconds to give the debouncer time to pick up the change
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        // notify the server that the manifest file has changed
+        let params = DidChangeWatchedFilesParams {
+            changes: vec![FileEvent {
+                uri: uri.clone(),
+                typ: FileChangeType::CHANGED,
+            }],
+        };
+        lsp::did_change_watched_files_notification(&mut service, params).await;
 
         // Check that the build plan now has 3 items
         let (_, session) = service

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -141,7 +141,7 @@ fn initialize() {
             initialization_options: None,
             ..Default::default()
         };
-        let _ = request::handle_initialize(&server, &params);
+        let _ = request::handle_initialize(&server, &params).await;
     });
 }
 


### PR DESCRIPTION
## Description
This PR replaces our custom Tokio-based thread watcher for `Forc.toml` files with the built-in LSP `didChangeWatchedFiles` notification system. The changes:

* Remove the Tokio thread-based file watching system and associated cleanup code
* Implement client-side file watching registration during initialization
* Handle `Forc.toml` file changes through the LSP notification protocol
* Update tests to use the new notification system
* Simplify manifest syncing with a direct approach

This approach is more efficient as it leverages the client's native file watching capabilities rather than spawning a separate thread. The PR maintains the same functionality while reducing resource usage and complexity.

Note: This doesn't yet implement the recompilation on `Forc.toml` changes as mentioned in issue #7103, but adds a TODO placeholder for that functionality.

This PR is a precursor to #7139

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
