### PR TITLE
Add documentation for the `abi` keyword for LSP

### DIFF
--- a/sway-lsp/src/utils/keyword_docs.rs
+++ b/sway-lsp/src/utils/keyword_docs.rs
@@ -680,6 +680,36 @@ impl KeywordDocs {
             mod continue_keyword {}
         };
 
+        let abi_keyword: ItemMod = parse_quote! {
+            /// Defines an Application Binary Interface (ABI).
+            ///
+            /// An `abi` block defines a set of methods that a contract exposes externally. It acts as the
+            /// public interface for interacting with a smart contract. Only one `abi` block is allowed per
+            /// contract.
+            ///
+            /// The methods defined within an `abi` block must be implemented in an associated [`impl`] block
+            /// for the contract.
+            ///
+            /// ```sway
+            /// contract;
+            ///
+            /// abi MyContract {
+            ///     #[storage(read, write)]
+            ///     fn update_counter(amount: u64) -> u64;
+            /// }
+            ///
+            /// impl MyContract for Contract {
+            ///     #[storage(read, write)]
+            ///     fn update_counter(amount: u64) -> u64 {
+            ///         let current = storage.counter;
+            ///         storage.counter = current + amount;
+            ///         storage.counter
+            ///     }
+            /// }
+            /// ```
+            mod abi_keyword {}
+        };
+
         // TODO
         let str_keyword: ItemMod = parse_quote! {
             mod str_keyword {}
@@ -723,11 +753,6 @@ impl KeywordDocs {
         // TODO
         let mod_keyword: ItemMod = parse_quote! {
             mod mod_keyword {}
-        };
-
-        // TODO
-        let abi_keyword: ItemMod = parse_quote! {
-            mod abi_keyword {}
         };
 
         // TODO


### PR DESCRIPTION
## Description
As the title says.

There's a corresponding PR in the vscode plugin for correct syntax highlighting when hovering over the `abi` keyword here https://github.com/FuelLabs/sway-vscode-plugin/pull/193

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
