### PR TITLE
feat: forc call json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,6 +3113,7 @@ name = "forc-tracing"
 version = "0.68.2"
 dependencies = [
  "ansiterm",
+ "regex",
  "tracing",
  "tracing-subscriber",
  "tracing-test",

--- a/docs/book/src/testing/testing_with_forc_call.md
+++ b/docs/book/src/testing/testing_with_forc_call.md
@@ -68,7 +68,39 @@ forc call \
 
 ## Usage
 
-The basic syntax for `forc call` is:
+Forc call has **3** usage modes:
+
+### List functions
+
+Syntax for `forc call` for listing supported functions from the ABI - with example command to perform call operation:
+
+```bash
+forc call --abi <ABI-PATH/URL> <CONTRACT_ID> --list-functions
+```
+
+Where the following arguments are required:
+
+- `ABI-PATH/URL` is the path or URL to the contract's JSON ABI file
+- `CONTRACT_ID` is the ID of the deployed contract you want to interact with 
+
+### Transfer assets
+
+Syntax for `forc call` for transferring assets:
+
+```bash
+forc call <RECEIVER_ADDRESS> --amount <AMOUNT> --mode=live
+```
+
+Where the following arguments are required:
+
+- `RECEIVER_ADDRESS` is address of the receiver (identity or contract).
+- `AMOUNT` is the amount of assets to transfer.
+
+Note: only live mode `--mode=live` is supported; transfers cannot be simulated.
+
+### Call contracts
+
+Syntax for `forc call` for contract calls:
 
 ```bash
 forc call [OPTIONS] --abi <ABI-PATH/URL> <CONTRACT_ID> <SELECTOR> [ARGS]...

--- a/forc-plugins/forc-client/src/bin/call.rs
+++ b/forc-plugins/forc-client/src/bin/call.rs
@@ -1,10 +1,18 @@
 use clap::Parser;
-use forc_tracing::{init_tracing_subscriber, println_error};
+use forc_tracing::{init_tracing_subscriber, println_error, TracingSubscriberOptions};
 
 #[tokio::main]
 async fn main() {
-    init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Call::parse();
+
+    // Initialize tracing with verbosity from command
+    init_tracing_subscriber(TracingSubscriberOptions {
+        verbosity: Some(command.verbosity),
+        writer_mode: Some(command.output.clone().into()),
+        regex_filter: Some("forc_tracing".to_string()),
+        ..Default::default()
+    });
+
     let operation = match command.validate_and_get_operation() {
         Ok(operation) => operation,
         Err(err) => {

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -316,7 +316,7 @@ pub struct Command {
     pub external_contracts: Option<Vec<ContractId>>,
 
     /// Output format for the call result
-    #[clap(long, default_value = "default", help_heading = "OUTPUT")]
+    #[clap(long, short = 'o', default_value = "default", help_heading = "OUTPUT")]
     pub output: OutputFormat,
 
     /// Set verbosity levels; currently only supports max 2 levels

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -57,23 +57,9 @@ pub enum OutputFormat {
     Default,
     /// Raw unformatted output
     Raw,
+    /// JSON output with full tracing information (logs, errors, and result)
+    Json,
 }
-
-/// Verbosity level for log output
-#[derive(Debug, Clone, PartialEq, Default)]
-#[repr(transparent)]
-pub struct Verbosity(pub u8);
-
-impl Verbosity {
-    /// Verbose mode (-v)
-    pub(crate) fn v1(&self) -> bool {
-        self.0 >= 1
-    }
-
-    /// Very Verbose mode (-vv)
-    pub(crate) fn v2(&self) -> bool {
-        self.0 >= 2
-    }
 }
 
 impl From<u8> for Verbosity {

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -356,32 +356,35 @@ pub mod tests {
         // test_empty_no_return
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_empty_no_return", vec![]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "()");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "()");
 
         // test_empty
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_empty", vec![]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "()");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "()");
 
         // test_unit
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_unit", vec!["()"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "()");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "()");
 
         // test_u8
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_u8", vec!["255"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "255");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "255");
 
         // test_u16
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_u16", vec!["65535"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "65535");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "65535");
 
         // test_u32
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_u32", vec!["4294967295"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "4294967295");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "4294967295"
+        );
 
         // test_u64
         let cmd = get_contract_call_cmd(
@@ -393,7 +396,7 @@ pub mod tests {
         );
         let operation = cmd.validate_and_get_operation().unwrap();
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "18446744073709551615"
         );
 
@@ -407,7 +410,7 @@ pub mod tests {
         );
         let operation = cmd.validate_and_get_operation().unwrap();
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "340282366920938463463374607431768211455"
         );
 
@@ -421,7 +424,7 @@ pub mod tests {
         );
         let operation = cmd.validate_and_get_operation().unwrap();
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "115792089237316195423570985008687907853269984665640564039457584007913129639935"
         );
 
@@ -435,7 +438,7 @@ pub mod tests {
         );
         let operation = cmd.validate_and_get_operation().unwrap();
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "0x0000000000000000000000000000000000000000000000000000000000000042"
         );
 
@@ -450,24 +453,24 @@ pub mod tests {
         let operation = cmd.validate_and_get_operation().unwrap();
         cmd.external_contracts = Some(vec![]);
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "0x0000000000000000000000000000000000000000000000000000000000000042"
         );
 
         // test_bytes
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_bytes", vec!["0x42"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "0x42");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "0x42");
 
         // test bytes without 0x prefix
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_bytes", vec!["42"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "0x42");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "0x42");
 
         // test_str
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_str", vec!["fuel"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "fuel");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "fuel");
 
         // test str array
         let cmd = get_contract_call_cmd(
@@ -478,7 +481,10 @@ pub mod tests {
             vec!["fuel rocks"],
         );
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "fuel rocks");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "fuel rocks"
+        );
 
         // test str array - fails if length mismatch
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_str_array", vec!["fuel"]);
@@ -497,12 +503,18 @@ pub mod tests {
             vec!["fuel rocks 42"],
         );
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "fuel rocks 42");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "fuel rocks 42"
+        );
 
         // test tuple
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_tuple", vec!["(42, true)"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "(42, true)");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "(42, true)"
+        );
 
         // test array
         let cmd = get_contract_call_cmd(
@@ -514,7 +526,7 @@ pub mod tests {
         );
         let operation = cmd.validate_and_get_operation().unwrap();
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "[42, 42, 42, 42, 42, 42, 42, 42, 42, 42]"
         );
 
@@ -533,12 +545,16 @@ pub mod tests {
             .await
             .unwrap()
             .result
+            .unwrap()
             .starts_with("[42, 42, 0,"));
 
         // test_vector
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_vector", vec!["[42, 42]"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "[42, 42]");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "[42, 42]"
+        );
 
         // test_vector - fails if different types
         let cmd =
@@ -552,7 +568,10 @@ pub mod tests {
         // test_struct - Identity { name: str[2], id: u64 }
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_struct", vec!["{fu, 42}"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "{fu, 42}");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "{fu, 42}"
+        );
 
         // test_struct - fails if incorrect inner attribute length
         let cmd =
@@ -566,23 +585,35 @@ pub mod tests {
         // test_struct - succeeds if missing inner final attribute; default value is used
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_struct", vec!["{fu}"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "{fu, 0}");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "{fu, 0}"
+        );
 
         // test_struct - succeeds to use default values for all attributes if missing
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_struct", vec!["{}"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "{\0\0, 0}");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "{\0\0, 0}"
+        );
 
         // test_enum
         let cmd =
             get_contract_call_cmd(id, node_url, secret_key, "test_enum", vec!["(Active:true)"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "(Active:true)");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "(Active:true)"
+        );
 
         // test_enum - succeeds if using index
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_enum", vec!["(1:56)"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "(Pending:56)");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "(Pending:56)"
+        );
 
         // test_enum - fails if variant not found
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_enum", vec!["(A:true)"]);
@@ -611,17 +642,26 @@ pub mod tests {
         // test_option - encoded like an enum
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_option", vec!["(0:())"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "(None:())");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "(None:())"
+        );
 
         // test_option - encoded like an enum; none value ignored
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_option", vec!["(0:42)"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "(None:())");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "(None:())"
+        );
 
         // test_option - encoded like an enum; some value
         let cmd = get_contract_call_cmd(id, node_url, secret_key, "test_option", vec!["(1:42)"]);
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "(Some:42)");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "(Some:42)"
+        );
     }
 
     #[tokio::test]
@@ -638,7 +678,10 @@ pub mod tests {
             vec!["{42, fuel}"],
         );
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "{42, fuel}");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "{42, fuel}"
+        );
 
         // test_enum_with_generic
         let cmd = get_contract_call_cmd(
@@ -649,7 +692,10 @@ pub mod tests {
             vec!["(value:32)"],
         );
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "(value:32)");
+        assert_eq!(
+            call(operation, cmd).await.unwrap().result.unwrap(),
+            "(value:32)"
+        );
 
         // test_enum_with_complex_generic
         let cmd = get_contract_call_cmd(
@@ -661,7 +707,7 @@ pub mod tests {
         );
         let operation = cmd.validate_and_get_operation().unwrap();
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "(value:{42, fuel})"
         );
 
@@ -674,7 +720,7 @@ pub mod tests {
         );
         let operation = cmd.validate_and_get_operation().unwrap();
         assert_eq!(
-            call(operation, cmd).await.unwrap().result,
+            call(operation, cmd).await.unwrap().result.unwrap(),
             "(container:{{42, fuel}, fuel})"
         );
     }
@@ -721,12 +767,16 @@ pub mod tests {
         };
         // validate balance is unchanged (dry-run)
         assert_eq!(
-            call(operation.clone(), cmd.clone()).await.unwrap().result,
+            call(operation.clone(), cmd.clone())
+                .await
+                .unwrap()
+                .result
+                .unwrap(),
             "()"
         );
         assert_eq!(get_contract_balance(id_2, provider.clone()).await, 0);
         cmd.mode = cmd::call::ExecutionMode::Live;
-        assert_eq!(call(operation, cmd).await.unwrap().result, "()");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "()");
         assert_eq!(get_contract_balance(id_2, provider.clone()).await, 1);
         assert_eq!(get_contract_balance(id, provider.clone()).await, 1);
 
@@ -751,7 +801,7 @@ pub mod tests {
         };
         cmd.mode = cmd::call::ExecutionMode::Live;
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "()");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "()");
         assert_eq!(
             get_recipient_balance(random_wallet.address().clone(), provider.clone()).await,
             2
@@ -810,7 +860,7 @@ pub mod tests {
         };
         cmd.mode = cmd::call::ExecutionMode::Live;
         let operation = cmd.validate_and_get_operation().unwrap();
-        assert_eq!(call(operation, cmd).await.unwrap().result, "()");
+        assert_eq!(call(operation, cmd).await.unwrap().result.unwrap(), "()");
         assert_eq!(
             get_recipient_balance(random_wallet.address().clone(), provider.clone()).await,
             3

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -217,7 +217,7 @@ pub async fn call_function(
         &receipts,
         &tx_hash.to_string(),
         &program_abi,
-        result,
+        Some(result),
         &mode,
         &node,
         &verbosity,

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -177,7 +177,7 @@ pub(crate) fn process_transaction_output(
     receipts: &[Receipt],
     tx_hash: &str,
     program_abi: &sway_core::asm_generation::ProgramABI,
-    result: String,
+    result: Option<String>,
     mode: &cmd::call::ExecutionMode,
     node: &crate::NodeTarget,
     verbosity: &cmd::call::Verbosity,
@@ -212,8 +212,8 @@ pub(crate) fn process_transaction_output(
 
     // print tx hash and result
     forc_tracing::println_label_green("tx hash:", tx_hash);
-    if !result.is_empty() {
-        forc_tracing::println_label_green("result:", &result);
+    if let Some(result) = result.as_ref() {
+        forc_tracing::println_label_green("result:", result);
     }
 
     // display transaction url if live mode
@@ -228,7 +228,7 @@ pub(crate) fn process_transaction_output(
 
     Ok(CallResponse {
         tx_hash: tx_hash.to_string(),
-        result,
+        result: result.unwrap_or_default(),
         logs,
     })
 }

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -198,10 +198,10 @@ pub(crate) fn process_transaction_output(
     result: Option<String>,
     mode: &cmd::call::ExecutionMode,
     node: &crate::NodeTarget,
-    verbosity: &cmd::call::Verbosity,
+    verbosity: u8,
 ) -> Result<CallResponse> {
     // print receipts
-    if verbosity.v2() {
+    if verbosity >= 2 {
         let formatted_receipts = forc_util::tx_utils::format_log_receipts(receipts, true)?;
         forc_tracing::println_label_green("receipts:", &formatted_receipts);
     }
@@ -221,7 +221,7 @@ pub(crate) fn process_transaction_output(
         .collect::<Vec<_>>();
 
     // display logs if verbosity is set
-    if verbosity.v1() && !logs.is_empty() {
+    if verbosity >= 1 && !logs.is_empty() {
         forc_tracing::println_green_bold("logs:");
         for log in logs.iter() {
             println!("  {:#}", log);
@@ -246,7 +246,13 @@ pub(crate) fn process_transaction_output(
 
     Ok(CallResponse {
         tx_hash: tx_hash.to_string(),
-        result: result.unwrap_or_default(),
+        result,
+        receipts: if verbosity >= 2 {
+            Some(receipts.to_vec())
+        } else {
+            None
+        },
+        script: None,
         logs,
     })
 }

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -44,6 +44,10 @@ pub struct CallResponse {
 pub async fn call(operation: cmd::call::Operation, cmd: cmd::Call) -> anyhow::Result<CallResponse> {
     match operation {
         cmd::call::Operation::ListFunctions { contract_id, abi } => {
+            if let cmd::call::OutputFormat::Json = cmd.output {
+                return Err(anyhow!("JSON output is not supported for list functions"));
+            }
+
             let abi_str = load_abi(&abi).await?;
             let parsed_abi: ProgramABI = serde_json::from_str(&abi_str)?;
             let unified_program_abi = UnifiedProgramABI::from_counterpart(&parsed_abi)?;

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -23,14 +23,21 @@ use fuels::{
     crypto::SecretKey,
 };
 use fuels_core::types::{transaction::TxPolicies, AssetId};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use sway_core;
 
-#[derive(Debug, Default)]
+/// Response returned from a contract call operation
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CallResponse {
     pub tx_hash: String,
-    pub result: String,
+    pub result: Option<String>,
     pub logs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipts: Option<Vec<Receipt>>,
+    #[serde(rename = "Script", skip_serializing_if = "Option::is_none")]
+    pub script: Option<serde_json::Value>,
 }
 
 /// A command for calling a contract function.

--- a/forc-plugins/forc-client/src/op/call/transfer.rs
+++ b/forc-plugins/forc-client/src/op/call/transfer.rs
@@ -109,25 +109,30 @@ mod tests {
             ..Default::default()
         };
 
-        // should successfully transfer funds)
-        let result = transfer(
+        // should successfully transfer funds
+        let response = transfer(
             &wallet_sender,
             recipient_address,
             amount,
             *base_asset_id,
             tx_policies,
             &node,
-            &(0u8.into()),
+            0, // verbosity level
+            &mut std::io::stdout(),
         )
         .await
         .unwrap();
 
         // Verify response structure
         assert!(
-            !result.tx_hash.is_empty(),
+            !response.tx_hash.is_empty(),
             "Transaction hash should be returned"
         );
-        assert_eq!(result.result, "", "Result should be empty string");
+        assert_eq!(
+            response.result.unwrap(),
+            "",
+            "Result should be empty string"
+        );
 
         // Verify balance has increased by the transfer amount
         assert_eq!(
@@ -160,25 +165,30 @@ mod tests {
             ..Default::default()
         };
 
-        // should successfully transfer funds)
-        let result = transfer(
+        // should successfully transfer funds
+        let response = transfer(
             &wallet,
             Address::new(id.into()),
             amount,
             *base_asset_id,
             tx_policies,
             &node,
-            &(0u8.into()),
+            0, // verbosity level
+            &mut std::io::stdout(),
         )
         .await
         .unwrap();
 
         // Verify response structure
         assert!(
-            !result.tx_hash.is_empty(),
+            !response.tx_hash.is_empty(),
             "Transaction hash should be returned"
         );
-        assert_eq!(result.result, "", "Result should be empty string");
+        assert_eq!(
+            response.result.unwrap(),
+            "",
+            "Result should be empty string"
+        );
 
         // Verify balance has increased by the transfer amount
         let balance = provider

--- a/forc-plugins/forc-client/src/op/call/transfer.rs
+++ b/forc-plugins/forc-client/src/op/call/transfer.rs
@@ -50,7 +50,7 @@ pub async fn transfer(
         &tx_response.tx_status.receipts,
         &tx_response.tx_id.to_string(),
         &program_abi,
-        "".to_string(),
+        None,
         &crate::cmd::call::ExecutionMode::Live,
         node,
         verbosity,

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 ansiterm.workspace = true
+regex.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }
 

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -7,8 +7,9 @@ use std::{env, io};
 use tracing::{Level, Metadata};
 pub use tracing_subscriber::{
     self,
-    filter::{EnvFilter, LevelFilter},
+    filter::{filter_fn, EnvFilter, LevelFilter},
     fmt::{format::FmtSpan, MakeWriter},
+    layer::SubscriberExt,
 };
 
 const ACTION_COLUMN_WIDTH: usize = 12;
@@ -357,5 +358,30 @@ mod tests {
 
         let expected_action = "\x1b[1;31mRemoving\x1b[0m";
         assert!(logs_contain(&format!("     {} {}", expected_action, txt)));
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_json_mode_println_functions() {
+        JSON_MODE_ACTIVE.store(true, Ordering::SeqCst);
+
+        // Call various print functions and capture the output
+        println_label_green("Label", "Value");
+        assert!(logs_contain("Label: Value"));
+
+        println_action_green("Action", "Target");
+        assert!(logs_contain("Action Target"));
+
+        println_green("Green text");
+        assert!(logs_contain("Green text"));
+
+        println_warning("This is a warning");
+        assert!(logs_contain("This is a warning"));
+
+        println_error("This is an error");
+        assert!(logs_contain("This is an error"));
+
+        // Reset JSON mode for other tests
+        JSON_MODE_ACTIVE.store(false, Ordering::SeqCst);
     }
 }

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -4,7 +4,7 @@
 use crate::{
     capabilities, core::session::build_plan, lsp_ext, server_state::ServerState, utils::debug,
 };
-use forc_tracing::{tracing_subscriber, FmtSpan, StdioTracingWriter, TracingWriterMode};
+use forc_tracing::{tracing_subscriber, FmtSpan, TracingWriter};
 use lsp_types::{
     CodeLens, CompletionResponse, DocumentFormattingParams, DocumentSymbolResponse,
     InitializeResult, InlayHint, InlayHintParams, PrepareRenameResponse, RenameParams,
@@ -44,9 +44,7 @@ pub fn handle_initialize(
             .with_ansi(false)
             .with_max_level(config.logging.level)
             .with_span_events(FmtSpan::CLOSE)
-            .with_writer(StdioTracingWriter {
-                writer_mode: TracingWriterMode::Stderr,
-            })
+            .with_writer(TracingWriter::Stderr)
             .init();
     }
     tracing::info!("Initializing the Sway Language Server");


### PR DESCRIPTION
## Description

This PR adds JSON output support for `forc-call` CLI.
Additionally, it adds JSON support for `tracing-subscriber` in `forc-tracing` - with option to omit logs from other libraries (via regex).
- JSON tracing-subscriber ignores coloured output

### Changelog

This pull request introduces enhancements to the `forc-call` plugin, focusing on improving output formatting, streamlining verbosity handling, and updating test cases to reflect these changes.
The most significant updates include the addition of a JSON output format, the removal of the `Verbosity` struct, and modifications to test cases to handle optional results.

### Output Formatting Enhancements:
* Added a new `Json` variant to the `OutputFormat` enum for outputting full tracing information in JSON format. Implemented the `Write` trait for `OutputFormat` to handle different output styles. (`forc-plugins/forc-client/src/cmd/call.rs`, [forc-plugins/forc-client/src/cmd/call.rsR60-R87](diffhunk://#diff-466e2f9659cab303594eb73a846768ecdbc1a13030e5869cdac51ddde87dd313R60-R87))
* Updated the `Command` struct to include a short option (`-o`) for specifying the output format. (`forc-plugins/forc-client/src/cmd/call.rs`, [forc-plugins/forc-client/src/cmd/call.rsL319-R319](diffhunk://#diff-466e2f9659cab303594eb73a846768ecdbc1a13030e5869cdac51ddde87dd313L319-R319))

### Verbosity Handling Simplification:
* Removed the `Verbosity` struct and its associated methods. Verbosity is now directly represented as an integer (`cmd.verbosity`) for simplicity. (`forc-plugins/forc-client/src/cmd/call.rs`, [[1]](diffhunk://#diff-466e2f9659cab303594eb73a846768ecdbc1a13030e5869cdac51ddde87dd313R60-R87); `forc-plugins/forc-client/src/op/call/call_function.rs`, [[2]](diffhunk://#diff-7da99987eeed69f070b781a5692d3acc7028308b8538ca129d79452ccc057fdeL2-R2) [[3]](diffhunk://#diff-7da99987eeed69f070b781a5692d3acc7028308b8538ca129d79452ccc057fdeL54-L57) [[4]](diffhunk://#diff-7da99987eeed69f070b781a5692d3acc7028308b8538ca129d79452ccc057fdeL181-R185) [[5]](diffhunk://#diff-7da99987eeed69f070b781a5692d3acc7028308b8538ca129d79452ccc057fdeL216-R227)

### Test Case Updates:
* Modified test cases to handle optional results by calling `.unwrap()` on the `result` field where applicable. This ensures compatibility with changes to how results are processed. (`forc-plugins/forc-client/src/op/call/call_function.rs`, [[1]](diffhunk://#diff-7da99987eeed69f070b781a5692d3acc7028308b8538ca129d79452ccc057fdeL356-R387) through [[2]](diffhunk://#diff-7da99987eeed69f070b781a5692d3acc7028308b8538ca129d79452ccc057fdeL661-R710)

These changes improve the usability and maintainability of the `forc-call` plugin, making it more robust and user-friendly.

Note: This is a pre-requisite to resolve https://github.com/FuelLabs/sway/issues/7019; the output script in the JSON can be directly parsed into a `tx.json` file for `forc-debug`.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
