### PR TITLE
Remove double IR-compilation of contract methods

### DIFF
--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -377,7 +377,7 @@ async fn test_simple_deploy() {
     node.kill().unwrap();
     let expected = vec![DeployedPackage::Contract(DeployedContract {
         id: ContractId::from_str(
-            "7338571226a3a07d411acc73bf31821d7315365e3e04e309f5055f0b567431fb",
+            "edd41822e8df9b4db6f8ff5ec094926c1ca46f5aa8bc499155085b5b85e84726",
         )
         .unwrap(),
         proxy: None,
@@ -421,7 +421,7 @@ async fn test_deploy_submit_only() {
     node.kill().unwrap();
     let expected = vec![DeployedPackage::Contract(DeployedContract {
         id: ContractId::from_str(
-            "7338571226a3a07d411acc73bf31821d7315365e3e04e309f5055f0b567431fb",
+            "edd41822e8df9b4db6f8ff5ec094926c1ca46f5aa8bc499155085b5b85e84726",
         )
         .unwrap(),
         proxy: None,
@@ -468,12 +468,12 @@ async fn test_deploy_fresh_proxy() {
     node.kill().unwrap();
     let impl_contract = DeployedPackage::Contract(DeployedContract {
         id: ContractId::from_str(
-            "7338571226a3a07d411acc73bf31821d7315365e3e04e309f5055f0b567431fb",
+            "edd41822e8df9b4db6f8ff5ec094926c1ca46f5aa8bc499155085b5b85e84726",
         )
         .unwrap(),
         proxy: Some(
             ContractId::from_str(
-                "2d4f046d31ee52218c189d0c4f30ac74490ab73b0747b4b95908b1ca7f7f7976",
+                "f1c07ddc6181e46e9ba1a7ade21946cf9f0730aaf9a04c9ecdf91e528ba77f86",
             )
             .unwrap(),
         ),

--- a/forc/tests/cli_integration.rs
+++ b/forc/tests/cli_integration.rs
@@ -49,10 +49,10 @@ fn test_forc_test_raw_logs() -> Result<(), rexpect::error::Error> {
     // Assert that the output is correct
     process.exp_string("      test test_log_4")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12300,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12248,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
     process.exp_string("      test test_log_2")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12300,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12248,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
 
     process.process.exit()?;
     Ok(())
@@ -74,11 +74,11 @@ fn test_forc_test_both_logs() -> Result<(), rexpect::error::Error> {
     process.exp_string("      test test_log_4")?;
     process.exp_string("Decoded log value: 4, log rb: 1515152261580153489")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12300,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12248,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
     process.exp_string("      test test_log_2")?;
     process.exp_string("Decoded log value: 2, log rb: 1515152261580153489")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12300,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12248,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
     process.process.exit()?;
     Ok(())
 }

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -18,7 +18,7 @@ use super::{
 
 use sway_error::{error::CompileError, handler::Handler};
 use sway_ir::{metadata::combine as md_combine, *};
-use sway_types::{Ident, Spanned};
+use sway_types::{Ident, Span, Spanned};
 
 use std::{cell::Cell, collections::HashMap, sync::Arc};
 
@@ -159,7 +159,16 @@ pub(super) fn compile_contract(
     )
     .map_err(|err| vec![err])?;
 
-    if let Some(entry_function) = entry_function {
+    // In the case of the new encoding, we need to compile only the entry function.
+    // The compilation of the entry function will recursively compile all the
+    // ABI methods and the fallback function, if specified.
+    if context.experimental.new_encoding {
+        let Some(entry_function) = entry_function else {
+            return Err(vec![CompileError::Internal(
+                "Entry function not specified when compiling contract with new encoding.",
+                Span::dummy(),
+            )]);
+        };
         compile_entry_function(
             engines,
             context,
@@ -171,29 +180,28 @@ pub(super) fn compile_contract(
             None,
             cache,
         )?;
-    }
+    } else {
+        // In the case of the encoding v0, we need to compile individual ABI entries
+        // and the fallback function.
+        for decl in abi_entries {
+            compile_encoding_v0_abi_method(
+                context,
+                &mut md_mgr,
+                module,
+                decl,
+                logged_types_map,
+                messages_types_map,
+                engines,
+                cache,
+            )?;
+        }
 
-    for decl in abi_entries {
-        compile_abi_method(
-            context,
-            &mut md_mgr,
-            module,
-            decl,
-            logged_types_map,
-            messages_types_map,
-            engines,
-            cache,
-        )?;
-    }
-
-    if !context.experimental.new_encoding {
-        // Fallback function needs to be compiled
         for decl in declarations {
             if let ty::TyDecl::FunctionDecl(decl) = decl {
                 let decl_id = decl.decl_id;
                 let decl = engines.de().get(&decl_id);
                 if decl.is_fallback() {
-                    compile_abi_method(
+                    compile_encoding_v0_abi_method(
                         context,
                         &mut md_mgr,
                         module,
@@ -694,7 +702,7 @@ fn compile_fn(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn compile_abi_method(
+fn compile_encoding_v0_abi_method(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
@@ -704,33 +712,32 @@ fn compile_abi_method(
     engines: &Engines,
     cache: &mut CompiledFunctionCache,
 ) -> Result<Function, Vec<CompileError>> {
+    assert!(
+        !context.experimental.new_encoding,
+        "`new_encoding` was true while calling `compile_encoding_v0_abi_method`"
+    );
+
     // Use the error from .to_fn_selector_value() if possible, else make an CompileError::Internal.
     let handler = Handler::default();
     let ast_fn_decl = engines.de().get_function(ast_fn_decl);
 
-    // method selector is only used for encoding v0
-    let selector = if context.experimental.new_encoding {
-        None
-    } else {
-        let get_selector_result = ast_fn_decl.to_fn_selector_value(&handler, engines);
-        let (errors, _warnings) = handler.consume();
-        let selector = match get_selector_result.ok() {
-            Some(selector) => selector,
-            None => {
-                return if !errors.is_empty() {
-                    Err(vec![errors[0].clone()])
-                } else {
-                    Err(vec![CompileError::InternalOwned(
-                        format!(
-                            "Cannot generate selector for ABI method: {}",
-                            ast_fn_decl.name.as_str()
-                        ),
-                        ast_fn_decl.name.span(),
-                    )])
-                };
-            }
-        };
-        Some(selector)
+    let get_selector_result = ast_fn_decl.to_fn_selector_value(&handler, engines);
+    let (errors, _warnings) = handler.consume();
+    let selector = match get_selector_result.ok() {
+        Some(selector) => selector,
+        None => {
+            return if !errors.is_empty() {
+                Err(vec![errors[0].clone()])
+            } else {
+                Err(vec![CompileError::InternalOwned(
+                    format!(
+                        "Cannot generate selector for ABI method: {}",
+                        ast_fn_decl.name.as_str()
+                    ),
+                    ast_fn_decl.name.span(),
+                )])
+            };
+        }
     };
 
     compile_fn(
@@ -744,7 +751,7 @@ fn compile_abi_method(
         !context.experimental.new_encoding,
         // ABI methods are always original entries
         true,
-        selector,
+        Some(selector),
         logged_types_map,
         messages_types_map,
         None,

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -216,7 +216,7 @@ fn module_to_doc<'a>(
     })
     .append(Doc::indent(
         4,
-        Doc::list_sep(
+        Doc::List(
             module
                 .global_variables
                 .iter()
@@ -241,9 +241,13 @@ fn module_to_doc<'a>(
                     )
                 })
                 .collect(),
-            Doc::line(Doc::Empty),
         ),
     ))
+    .append(if !module.global_variables.is_empty() {
+        Doc::line(Doc::Empty)
+    } else {
+        Doc::Empty
+    })
     .append(Doc::indent(
         4,
         Doc::list_sep(

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_deprecated/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_deprecated/stdout.snap
@@ -182,4 +182,4 @@ warning: Function is deprecated
 ____
 
   Compiled contract "attributes_deprecated" with 19 warnings.
-    Finished release [optimized + fuel] target(s) [1.056 KB] in ???
+    Finished release [optimized + fuel] target(s) [1.008 KB] in ???

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/stdout.snap
@@ -8,7 +8,7 @@ output:
    Compiling library std (test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-core)
    Compiling library panicking_lib (test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib)
    Compiling contract panicking_contract (test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract)
-    Finished release [optimized + fuel] target(s) [8.208 KB] in ???
+    Finished release [optimized + fuel] target(s) [8.168 KB] in ???
      Running 11 tests, filtered 0 tests
 
 tested -- panicking_contract
@@ -37,10 +37,10 @@ Revert code: ffffffff00000003
       test test_generic_panic_with_str ... ok (???, 2068 gas)
 Decoded log value: AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
 Revert code: ffffffff00000001
-      test test_generic_panic_with_different_str_same_revert_code ... ok (???, 1761 gas)
+      test test_generic_panic_with_different_str_same_revert_code ... ok (???, 1750 gas)
 Decoded log value: AsciiString { data: "generic panic with different string" }, log rb: 10098701174489624218
 Revert code: ffffffff00000001
-      test test_generic_panic_with_error_type_enum ... ok (???, 1890 gas)
+      test test_generic_panic_with_error_type_enum ... ok (???, 1880 gas)
 Decoded log value: A, log rb: 5503570629422409978
 Revert code: ffffffff00000002
       test test_generic_panic_with_error_type_enum_different_variant_same_revert_code ... ok (???, 2043 gas)

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x14ed3cd06c2947248f69d54bfa681fe40d26267be84df7e19e253622b7921bbe;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x601848bef87baa5fb799e4bedab0dca3baa6da459663ca8808ceb68632db4061; // AUTO-CONTRACT-ID ../../test_contracts/array_of_structs_contract --release
+const CONTRACT_ID = 0xff1e465593a247c32f9b53d7cf651a17fce6160f748ac6d46a369d889a939adb; // AUTO-CONTRACT-ID ../../test_contracts/array_of_structs_contract --release
 
 fn get_address() -> Option<std::address::Address> {
     Some(CONTRACT_ID.into())

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
@@ -9,12 +9,12 @@ use test_fuel_coin_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const FUEL_COIN_CONTRACT_ID = 0xec2277ebe007ade87e3d797c3b1e070dcd542d5ef8f038b471f262ef9cebc87c;
 #[cfg(experimental_new_encoding = true)]
-const FUEL_COIN_CONTRACT_ID = 0x9c0dc897a9f6033f011b393b3c45e493e431afb7bb840ae9bd1a33c83576027a; // AUTO-CONTRACT-ID ../../test_contracts/test_fuel_coin_contract --release
+const FUEL_COIN_CONTRACT_ID = 0x106ac7fa5a711e09843af5c0a9b76602c0e89d7321ef6e92fde6f812a7550d72; // AUTO-CONTRACT-ID ../../test_contracts/test_fuel_coin_contract --release
 
 #[cfg(experimental_new_encoding = false)]
 const BALANCE_CONTRACT_ID = 0xf6cd545152ac83225e8e7df2efb5c6fa6e37bc9b9e977b5ea8103d28668925df;
 #[cfg(experimental_new_encoding = true)]
-const BALANCE_CONTRACT_ID = 0xdf39b17a0e16748239c93f2520383a50e51f2519c1b087eb9139f3916fad883b; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
+const BALANCE_CONTRACT_ID = 0x05db562355bd5cb6ba5bb7198c693964c6dc91bc4cd99c1183fa191a0635a290; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
 
 fn main() -> bool {
     let default_gas = 1_000_000_000_000;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
@@ -5,7 +5,7 @@ use balance_test_abi::BalanceTest;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xf6cd545152ac83225e8e7df2efb5c6fa6e37bc9b9e977b5ea8103d28668925df;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xdf39b17a0e16748239c93f2520383a50e51f2519c1b087eb9139f3916fad883b; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
+const CONTRACT_ID = 0x05db562355bd5cb6ba5bb7198c693964c6dc91bc4cd99c1183fa191a0635a290; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
 
 fn main() -> bool {
     let balance_test_contract = abi(BalanceTest, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x94db39f409a31b9f2ebcadeea44378e419208c20de90f5d8e1e33dc1523754cb;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x0352c7bdc81351dc7cd4492634427aea9a7510d76b48dbaf030d3c23574b2c94; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
+const CONTRACT_ID = 0x8be6299315daa11cdda1a4633e3e9f2c0b3626d90bf3e22427404b4523391d65; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
@@ -5,7 +5,7 @@ use contract_with_type_aliases_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0cbeb6efe3104b460be769bdc4ea101ebf16ccc16f2d7b667ec3e1c7f5ce35b5;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xce3e15c876e12191467ed399df1e678c11805395334ceb13ebf808ef69bc638a; // AUTO-CONTRACT-ID ../../test_contracts/contract_with_type_aliases --release
+const CONTRACT_ID = 0x426fe90d83e647002f912b18948752a3c0827149e5a19f4f9acc5e40933b4b11; // AUTO-CONTRACT-ID ../../test_contracts/contract_with_type_aliases --release
 
 fn main() {
     let caller = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -6,7 +6,7 @@ use dynamic_contract_call::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xd1b4047af7ef111c023ab71069e01dc2abfde487c0a0ce1268e4f447e6c6e4c2;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x67b9fcb5067d92d235ec95ce1d8359e620e90739d5bbd64b033ca8732b0f6479; // AUTO-CONTRACT-ID ../../test_contracts/increment_contract --release
+const CONTRACT_ID = 0x0c52e3139b53f027ccfec854404e4547d86965c6718d3d87a0a0c5b2bb8ea5f9; // AUTO-CONTRACT-ID ../../test_contracts/increment_contract --release
 
 fn main() -> bool {
     let the_abi = abi(Incrementor, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -6,7 +6,7 @@ use context_testing_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x6054c11cda000f5990373a4d61929396165be4dfdd61d5b7bd26da60ab0d8577;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x3fde98984d2360b0ecf4f23011ff057db9711c457c6cc0480cc14f65462feed2; // AUTO-CONTRACT-ID ../../test_contracts/context_testing_contract --release
+const CONTRACT_ID = 0xa63673aa65ad568c6343fb7329dfbadcedf956aaf2efbd069aeaec5944e08494; // AUTO-CONTRACT-ID ../../test_contracts/context_testing_contract --release
 
 fn main() -> bool {
     let gas: u64 = u64::max();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x3bc28acd66d327b8c1b9624c1fabfc07e9ffa1b5d71c2832c3bfaaf8f4b805e9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x8d7200b20cb50676a66255fddbf2aa13565ad92ab42122e59e7868b7f74695c3; // AUTO-CONTRACT-ID ../../test_contracts/storage_access_contract --release
+const CONTRACT_ID = 0x4eb6d2a6d5f916bcace10ee79914adcd51226ad1f64062f48eb13c0ff953cc2e; // AUTO-CONTRACT-ID ../../test_contracts/storage_access_contract --release
 
 fn main() -> bool {
     let caller = abi(StorageAccess, CONTRACT_ID);


### PR DESCRIPTION
## Description

This PR removes the double compilation of contract methods in the IR, in the case of new encoding.

The contract methods were first compiled as a part of the compilation of the `__entry` function, and afterwards, again separately. The contract methods compiled in the second compilation pass were later on removed as not reachable.

The issue was brought to the surface in a test written by @hal3e in [fuel-rs PR that integrates ABI errors](https://github.com/FuelLabs/fuels-rs/pull/1651). In that particular test, because of the double compilation, a `panic` expression in a contract method got compiled twice and produced two same entries in the ABI JSON.

Removing the double compilation resulted in a small reduction of bytecode size and gas usage. In some tests bytecode size got reduced for ~50 bytes and the gas usage for ~30 gas units.

Additionally, the PR adjusts the printing of IR global variables, to be the same as printing of configurables and locals, without the spaces between individual entries.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.