### PR TITLE
ci: publish lib-std on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -903,9 +903,42 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
+  publish-sway-lib-std:
+    needs: publish
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Publish sway-lib-std
+        run: |
+          cd sway-lib-std
+          cargo run --locked -p forc-publish
+        env:
+          FORC_PUB_TOKEN: ${{ secrets.FORCPUB_TOKEN }}
+
+      - name: Notify if Job Fails
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
+          footer: ""
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
+
   build-publish-release-image:
     # Build & Publish Docker Image Per Sway Release
-    needs: publish
+    needs: [publish, publish-sway-lib-std]
     runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       contents: read
@@ -962,7 +995,7 @@ jobs:
     name: Build and upload forc binaries to release
     runs-on: ${{ matrix.job.os }}
     if: github.event_name == 'release' && github.event.action == 'published'
-    needs: publish
+    needs: [publish, publish-sway-lib-std]
     strategy:
       matrix:
         job:

--- a/forc-plugins/forc-publish/README.md
+++ b/forc-plugins/forc-publish/README.md
@@ -4,7 +4,7 @@ Forc subcommand for uploading a package to the registry.
 
 ## Authentication
 
-Requires either the `--token` argument to be passed, or a `~/.forc/credentials.toml` file like this:
+Requires either the `--token` argument to be passed, the environment variable `FORC_PUB_TOKEN`, or a `~/.forc/credentials.toml` file like this:
 
 ```toml
 [registry]

--- a/forc-plugins/forc-publish/src/credentials.rs
+++ b/forc-plugins/forc-publish/src/credentials.rs
@@ -30,6 +30,10 @@ pub fn get_auth_token(
         return Ok(token);
     }
 
+    if let Some(token) = std::env::var("FORC_PUB_TOKEN").ok() {
+        return Ok(token);
+    }
+
     let credentials_path = credentials_dir
         .unwrap_or(user_forc_directory())
         .join(CREDENTIALS_FILE);
@@ -87,6 +91,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::tempdir;
 
@@ -95,6 +100,15 @@ mod test {
         let token = Some("cli_token".to_string());
         let result = get_auth_token(token, None).unwrap();
         assert_eq!(result, "cli_token");
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_auth_token_from_env() {
+        std::env::set_var("FORC_PUB_TOKEN", "env_token");
+        let result = get_auth_token(None, None).unwrap();
+        std::env::remove_var("FORC_PUB_TOKEN");
+        assert_eq!(result, "env_token");
     }
 
     #[test]

--- a/forc-plugins/forc-publish/src/credentials.rs
+++ b/forc-plugins/forc-publish/src/credentials.rs
@@ -30,7 +30,7 @@ pub fn get_auth_token(
         return Ok(token);
     }
 
-    if let Some(token) = std::env::var("FORC_PUB_TOKEN").ok() {
+    if let Ok(token) = std::env::var("FORC_PUB_TOKEN") {
         return Ok(token);
     }
 


### PR DESCRIPTION
## Description

Related https://github.com/FuelLabs/sway/issues/7040

Publish sway `std` library to https://forc.pub/ when a release is created.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
