### PR TITLE
Refactor: Move `SyncWorkspace` from `Session` into `ServerState`

### DIFF
--- a/examples/arrays/Forc.toml
+++ b/examples/arrays/Forc.toml
@@ -2,7 +2,7 @@
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
-name = "arrays"
+name = "array"
 
 [dependencies]
 std = { path = "../../sway-lib-std" }

--- a/examples/arrays/Forc.toml
+++ b/examples/arrays/Forc.toml
@@ -2,7 +2,7 @@
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
-name = "array"
+name = "arrays"
 
 [dependencies]
 std = { path = "../../sway-lib-std" }

--- a/examples/arrays/src/main.sw
+++ b/examples/arrays/src/main.sw
@@ -6,7 +6,6 @@ struct Foo {
 }
 
 fn main() {
-    let x = 65;
     // Array of integers with type ascription
     let array_of_integers: [u8; 5] = [1, 2, 3, 4, 5];
 

--- a/examples/arrays/src/main.sw
+++ b/examples/arrays/src/main.sw
@@ -6,6 +6,7 @@ struct Foo {
 }
 
 fn main() {
+    let x = 65;
     // Array of integers with type ascription
     let array_of_integers: [u8; 5] = [1, 2, 3, 4, 5];
 

--- a/sway-core/src/semantic_analysis/namespace/package.rs
+++ b/sway-core/src/semantic_analysis/namespace/package.rs
@@ -13,7 +13,7 @@ pub struct Package {
     // The contents of the package being compiled.
     root_module: Module,
     // Program id for the package.
-    program_id: ProgramId,
+    pub program_id: ProgramId,
     // True if the current package is a contract, false otherwise.
     is_contract_package: bool,
     // The external dependencies of the current package. Note that an external package is

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -13,7 +13,9 @@ fn benchmarks(c: &mut Criterion) {
 
     let build_plan = session
         .build_plan_cache
-        .get_or_update(&sync.workspace_manifest_path(), || session::build_plan(&uri))
+        .get_or_update(&sync.workspace_manifest_path(), || {
+            session::build_plan(&uri)
+        })
         .unwrap();
 
     let mut lsp_mode = Some(sway_core::LspConfig {

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -75,8 +75,8 @@ fn benchmarks(c: &mut Criterion) {
         .unwrap();
     c.bench_function("open_all_example_workspace_members", |b| {
         b.iter(|| {
+            let engines = Engines::default();
             for package_manifest in member_manifests.values() {
-                let engines = Engines::default();
                 let dir = Url::from_file_path(
                     package_manifest
                         .path()

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -75,7 +75,7 @@ fn benchmarks(c: &mut Criterion) {
         .unwrap();
     c.bench_function("open_all_example_workspace_members", |b| {
         b.iter(|| {
-            for (name, package_manifest) in &member_manifests {
+            for package_manifest in member_manifests.values() {
                 let engines = Engines::default();
                 let dir = Url::from_file_path(
                     package_manifest

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -13,7 +13,7 @@ fn benchmarks(c: &mut Criterion) {
 
     let build_plan = session
         .build_plan_cache
-        .get_or_update(&sync.manifest_path(), || session::build_plan(&uri))
+        .get_or_update(&sync.workspace_manifest_path(), || session::build_plan(&uri))
         .unwrap();
 
     let mut lsp_mode = Some(sway_core::LspConfig {

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -7,13 +7,13 @@ use tokio::runtime::Runtime;
 const NUM_DID_CHANGE_ITERATIONS: usize = 10;
 
 fn benchmarks(c: &mut Criterion) {
-    let (uri, session, _) = Runtime::new()
+    let (uri, session, _, sync) = Runtime::new()
         .unwrap()
         .block_on(async { black_box(super::compile_test_project().await) });
 
     let build_plan = session
         .build_plan_cache
-        .get_or_update(&session.sync.manifest_path(), || session::build_plan(&uri))
+        .get_or_update(&sync.manifest_path(), || session::build_plan(&uri))
         .unwrap();
 
     let mut lsp_mode = Some(sway_core::LspConfig {

--- a/sway-lsp/benches/lsp_benchmarks/mod.rs
+++ b/sway-lsp/benches/lsp_benchmarks/mod.rs
@@ -7,11 +7,13 @@ use std::{path::PathBuf, sync::Arc};
 use sway_lsp::core::{
     document::Documents,
     session::{self, Session},
+    sync::SyncWorkspace,
 };
 
-pub async fn compile_test_project() -> (Url, Arc<Session>, Documents) {
+pub async fn compile_test_project() -> (Url, Arc<Session>, Documents, SyncWorkspace) {
     let session = Arc::new(Session::new());
     let documents = Documents::new();
+    let sync = SyncWorkspace::new();
     let lsp_mode = Some(sway_core::LspConfig {
         optimized_build: false,
         file_versions: Default::default(),
@@ -26,9 +28,10 @@ pub async fn compile_test_project() -> (Url, Arc<Session>, Documents) {
         None,
         lsp_mode,
         session.clone(),
+        &sync,
     )
     .unwrap();
-    (uri, session, documents)
+    (uri, session, documents, sync)
 }
 
 pub fn sway_workspace_dir() -> PathBuf {

--- a/sway-lsp/benches/lsp_benchmarks/requests.rs
+++ b/sway-lsp/benches/lsp_benchmarks/requests.rs
@@ -9,7 +9,7 @@ use sway_lsp::{
 use tokio::runtime::Runtime;
 
 fn benchmarks(c: &mut Criterion) {
-    let (uri, session, documents) = Runtime::new()
+    let (uri, session, documents, sync) = Runtime::new()
         .unwrap()
         .block_on(async { black_box(super::compile_test_project().await) });
     let config = sway_lsp::config::Config::default();
@@ -46,6 +46,7 @@ fn benchmarks(c: &mut Criterion) {
                 &uri,
                 position,
                 LspClient::default(),
+                &sync,
             )
         })
     });
@@ -55,11 +56,11 @@ fn benchmarks(c: &mut Criterion) {
     });
 
     c.bench_function("find_all_references", |b| {
-        b.iter(|| session.token_references(&uri, position))
+        b.iter(|| session.token_references(&uri, position, &sync))
     });
 
     c.bench_function("goto_definition", |b| {
-        b.iter(|| session.token_definition_response(&uri, position))
+        b.iter(|| session.token_definition_response(&uri, position, &sync))
     });
 
     c.bench_function("inlay_hints", |b| {
@@ -74,7 +75,7 @@ fn benchmarks(c: &mut Criterion) {
     });
 
     c.bench_function("prepare_rename", |b| {
-        b.iter(|| capabilities::rename::prepare_rename(session.clone(), &uri, position))
+        b.iter(|| capabilities::rename::prepare_rename(session.clone(), &uri, position, &sync))
     });
 
     c.bench_function("rename", |b| {
@@ -84,6 +85,7 @@ fn benchmarks(c: &mut Criterion) {
                 "new_token_name".to_string(),
                 &uri,
                 position,
+                &sync,
             )
         })
     });

--- a/sway-lsp/benches/lsp_benchmarks/requests.rs
+++ b/sway-lsp/benches/lsp_benchmarks/requests.rs
@@ -47,7 +47,7 @@ fn benchmarks(c: &mut Criterion) {
                 &uri,
                 position,
                 LspClient::default(),
-                &sync,
+                sync,
             )
         })
     });
@@ -57,11 +57,11 @@ fn benchmarks(c: &mut Criterion) {
     });
 
     c.bench_function("find_all_references", |b| {
-        b.iter(|| session.token_references(&uri, position, &sync))
+        b.iter(|| session.token_references(&uri, position, sync))
     });
 
     c.bench_function("goto_definition", |b| {
-        b.iter(|| session.token_definition_response(&uri, position, &sync))
+        b.iter(|| session.token_definition_response(&uri, position, sync))
     });
 
     c.bench_function("inlay_hints", |b| {
@@ -76,7 +76,7 @@ fn benchmarks(c: &mut Criterion) {
     });
 
     c.bench_function("prepare_rename", |b| {
-        b.iter(|| capabilities::rename::prepare_rename(session.clone(), &uri, position, &sync))
+        b.iter(|| capabilities::rename::prepare_rename(session.clone(), &uri, position, sync))
     });
 
     c.bench_function("rename", |b| {
@@ -86,7 +86,7 @@ fn benchmarks(c: &mut Criterion) {
                 "new_token_name".to_string(),
                 &uri,
                 position,
-                &sync,
+                sync,
             )
         })
     });

--- a/sway-lsp/benches/lsp_benchmarks/token_map.rs
+++ b/sway-lsp/benches/lsp_benchmarks/token_map.rs
@@ -3,7 +3,7 @@ use lsp_types::Position;
 use tokio::runtime::Runtime;
 
 fn benchmarks(c: &mut Criterion) {
-    let (uri, session, _) = Runtime::new()
+    let (uri, session, _, _) = Runtime::new()
         .unwrap()
         .block_on(async { black_box(super::compile_test_project().await) });
     let engines = session.engines.read();

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -77,12 +77,7 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds a single type to the list of related types.
-    fn add_related_type(
-        &mut self,
-        name: String,
-        span: &Span,
-        callpath: CallPath,
-    ) {
+    fn add_related_type(&mut self, name: String, span: &Span, callpath: CallPath) {
         if let Ok(mut uri) = get_url_from_span(self.engines.se(), span) {
             let converted_url = self.sync.temp_to_workspace_url(&uri);
             if let Ok(url) = converted_url {
@@ -99,10 +94,7 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds all implementations of the given [`TyTraitDecl`] to the list of implementations.
-    pub fn add_implementations_for_trait(
-        &mut self,
-        trait_decl: &TyTraitDecl,
-    ) {
+    pub fn add_implementations_for_trait(&mut self, trait_decl: &TyTraitDecl) {
         if let Some(namespace) = self.session.namespace() {
             let call_path =
                 CallPath::from(trait_decl.name.clone()).to_fullpath(self.engines, &namespace);
@@ -125,11 +117,7 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds implementations of the given type to the list of implementations using the [`TypeId`].
-    pub fn add_implementations_for_type(
-        &mut self,
-        decl_span: &Span,
-        type_id: TypeId,
-    ) {
+    pub fn add_implementations_for_type(&mut self, decl_span: &Span, type_id: TypeId) {
         if let Some(namespace) = self.session.namespace() {
             let impl_spans = TraitMap::get_impl_spans_for_type(
                 namespace.current_module(),
@@ -142,11 +130,7 @@ impl<'a> HoverLinkContents<'a> {
 
     /// Adds implementations to the list of implementation spans, with the declaration span first.
     /// Ensure that all paths are converted to workspace paths before adding them.
-    fn add_implementations(
-        &mut self,
-        decl_span: &Span,
-        mut impl_spans: Vec<Span>,
-    ) {
+    fn add_implementations(&mut self, decl_span: &Span, mut impl_spans: Vec<Span>) {
         let mut all_spans = vec![decl_span.clone()];
         all_spans.append(&mut impl_spans);
         all_spans.dedup();

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -77,7 +77,13 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds a single type to the list of related types.
-    fn add_related_type(&mut self, name: String, span: &Span, callpath: CallPath, sync: &SyncWorkspace) {
+    fn add_related_type(
+        &mut self,
+        name: String,
+        span: &Span,
+        callpath: CallPath,
+        sync: &SyncWorkspace,
+    ) {
         if let Ok(mut uri) = get_url_from_span(self.engines.se(), span) {
             let converted_url = sync.temp_to_workspace_url(&uri);
             if let Ok(url) = converted_url {
@@ -94,7 +100,11 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds all implementations of the given [`TyTraitDecl`] to the list of implementations.
-    pub fn add_implementations_for_trait(&mut self, trait_decl: &TyTraitDecl, sync: &SyncWorkspace) {
+    pub fn add_implementations_for_trait(
+        &mut self,
+        trait_decl: &TyTraitDecl,
+        sync: &SyncWorkspace,
+    ) {
         if let Some(namespace) = self.session.namespace() {
             let call_path =
                 CallPath::from(trait_decl.name.clone()).to_fullpath(self.engines, &namespace);
@@ -117,7 +127,12 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds implementations of the given type to the list of implementations using the [`TypeId`].
-    pub fn add_implementations_for_type(&mut self, decl_span: &Span, type_id: TypeId, sync: &SyncWorkspace) {
+    pub fn add_implementations_for_type(
+        &mut self,
+        decl_span: &Span,
+        type_id: TypeId,
+        sync: &SyncWorkspace,
+    ) {
         if let Some(namespace) = self.session.namespace() {
             let impl_spans = TraitMap::get_impl_spans_for_type(
                 namespace.current_module(),
@@ -130,7 +145,12 @@ impl<'a> HoverLinkContents<'a> {
 
     /// Adds implementations to the list of implementation spans, with the declaration span first.
     /// Ensure that all paths are converted to workspace paths before adding them.
-    fn add_implementations(&mut self, decl_span: &Span, mut impl_spans: Vec<Span>, sync: &SyncWorkspace) {
+    fn add_implementations(
+        &mut self,
+        decl_span: &Span,
+        mut impl_spans: Vec<Span>,
+        sync: &SyncWorkspace,
+    ) {
         let mut all_spans = vec![decl_span.clone()];
         all_spans.append(&mut impl_spans);
         all_spans.dedup();

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{session::Session, token::get_range_from_span},
+    core::{session::Session, sync::SyncWorkspace, token::get_range_from_span},
     utils::document::get_url_from_span,
 };
 use std::sync::Arc;
@@ -43,7 +43,7 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds the given type and any related type parameters to the list of related types.
-    pub fn add_related_types(&mut self, type_id: &TypeId) {
+    pub fn add_related_types(&mut self, type_id: &TypeId, sync: &SyncWorkspace) {
         let type_info = self.engines.te().get(*type_id);
         match &*type_info {
             TypeInfo::Enum(decl_id) => {
@@ -52,11 +52,12 @@ impl<'a> HoverLinkContents<'a> {
                     decl.name().to_string(),
                     &decl.span(),
                     decl.call_path.clone(),
+                    sync,
                 );
                 decl.generic_parameters
                     .iter()
                     .filter_map(|x| x.as_type_parameter())
-                    .for_each(|type_param| self.add_related_types(&type_param.type_id));
+                    .for_each(|type_param| self.add_related_types(&type_param.type_id, sync));
             }
             TypeInfo::Struct(decl_id) => {
                 let decl = self.engines.de().get_struct(decl_id);
@@ -64,20 +65,21 @@ impl<'a> HoverLinkContents<'a> {
                     decl.name().to_string(),
                     &decl.span(),
                     decl.call_path.clone(),
+                    sync,
                 );
                 decl.generic_parameters
                     .iter()
                     .filter_map(|x| x.as_type_parameter())
-                    .for_each(|type_param| self.add_related_types(&type_param.type_id));
+                    .for_each(|type_param| self.add_related_types(&type_param.type_id, sync));
             }
             _ => {}
         }
     }
 
     /// Adds a single type to the list of related types.
-    fn add_related_type(&mut self, name: String, span: &Span, callpath: CallPath) {
+    fn add_related_type(&mut self, name: String, span: &Span, callpath: CallPath, sync: &SyncWorkspace) {
         if let Ok(mut uri) = get_url_from_span(self.engines.se(), span) {
-            let converted_url = self.session.sync.temp_to_workspace_url(&uri);
+            let converted_url = sync.temp_to_workspace_url(&uri);
             if let Ok(url) = converted_url {
                 uri = url;
             }
@@ -92,51 +94,48 @@ impl<'a> HoverLinkContents<'a> {
     }
 
     /// Adds all implementations of the given [`TyTraitDecl`] to the list of implementations.
-    pub fn add_implementations_for_trait(&mut self, trait_decl: &TyTraitDecl) {
+    pub fn add_implementations_for_trait(&mut self, trait_decl: &TyTraitDecl, sync: &SyncWorkspace) {
         if let Some(namespace) = self.session.namespace() {
             let call_path =
                 CallPath::from(trait_decl.name.clone()).to_fullpath(self.engines, &namespace);
             let impl_spans =
                 TraitMap::get_impl_spans_for_trait_name(namespace.current_module(), &call_path);
-            self.add_implementations(&trait_decl.span(), impl_spans);
+            self.add_implementations(&trait_decl.span(), impl_spans, sync);
         }
     }
 
     /// Adds implementations of the given type to the list of implementations using the [`TyDecl`].
-    pub fn add_implementations_for_decl(&mut self, ty_decl: &TyDecl) {
+    pub fn add_implementations_for_decl(&mut self, ty_decl: &TyDecl, sync: &SyncWorkspace) {
         if let Some(namespace) = self.session.namespace() {
             let impl_spans = TraitMap::get_impl_spans_for_decl(
                 namespace.current_module(),
                 self.engines,
                 ty_decl,
             );
-            self.add_implementations(&ty_decl.span(self.engines), impl_spans);
+            self.add_implementations(&ty_decl.span(self.engines), impl_spans, sync);
         }
     }
 
     /// Adds implementations of the given type to the list of implementations using the [`TypeId`].
-    pub fn add_implementations_for_type(&mut self, decl_span: &Span, type_id: TypeId) {
+    pub fn add_implementations_for_type(&mut self, decl_span: &Span, type_id: TypeId, sync: &SyncWorkspace) {
         if let Some(namespace) = self.session.namespace() {
             let impl_spans = TraitMap::get_impl_spans_for_type(
                 namespace.current_module(),
                 self.engines,
                 &type_id,
             );
-            self.add_implementations(decl_span, impl_spans);
+            self.add_implementations(decl_span, impl_spans, sync);
         }
     }
 
     /// Adds implementations to the list of implementation spans, with the declaration span first.
     /// Ensure that all paths are converted to workspace paths before adding them.
-    fn add_implementations(&mut self, decl_span: &Span, mut impl_spans: Vec<Span>) {
+    fn add_implementations(&mut self, decl_span: &Span, mut impl_spans: Vec<Span>, sync: &SyncWorkspace) {
         let mut all_spans = vec![decl_span.clone()];
         all_spans.append(&mut impl_spans);
         all_spans.dedup();
         for span in &all_spans {
-            let span_result = self
-                .session
-                .sync
-                .temp_to_workspace_span(self.engines.se(), span);
+            let span_result = sync.temp_to_workspace_span(self.engines.se(), span);
             if let Ok(span) = span_result {
                 self.implementations.push(span);
             }

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -156,8 +156,7 @@ fn hover_format(
                 ty::TyDecl::VariableDecl(var_decl) => {
                     let type_name =
                         format!("{}", engines.help_out(var_decl.type_ascription.type_id()));
-                    hover_link_contents
-                        .add_related_types(&var_decl.type_ascription.type_id());
+                    hover_link_contents.add_related_types(&var_decl.type_ascription.type_id());
                     Some(format_variable_hover(
                         var_decl.mutability.is_mutable(),
                         &type_name,

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -146,7 +146,7 @@ fn hover_format(
     };
 
     // Used to collect all the information we need to generate links for the hover component.
-    let mut hover_link_contents = HoverLinkContents::new(session, engines);
+    let mut hover_link_contents = HoverLinkContents::new(session, engines, sync);
 
     let sway_block = token
         .as_typed()
@@ -157,7 +157,7 @@ fn hover_format(
                     let type_name =
                         format!("{}", engines.help_out(var_decl.type_ascription.type_id()));
                     hover_link_contents
-                        .add_related_types(&var_decl.type_ascription.type_id(), sync);
+                        .add_related_types(&var_decl.type_ascription.type_id());
                     Some(format_variable_hover(
                         var_decl.mutability.is_mutable(),
                         &type_name,
@@ -166,7 +166,7 @@ fn hover_format(
                 }
                 ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
                     let struct_decl = decl_engine.get_struct(decl_id);
-                    hover_link_contents.add_implementations_for_decl(decl, sync);
+                    hover_link_contents.add_implementations_for_decl(decl);
                     Some(format_visibility_hover(
                         struct_decl.visibility,
                         decl.friendly_type_name(),
@@ -175,7 +175,7 @@ fn hover_format(
                 }
                 ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
                     let trait_decl = decl_engine.get_trait(decl_id);
-                    hover_link_contents.add_implementations_for_trait(&trait_decl, sync);
+                    hover_link_contents.add_implementations_for_trait(&trait_decl);
                     Some(format_visibility_hover(
                         trait_decl.visibility,
                         decl.friendly_type_name(),
@@ -184,7 +184,7 @@ fn hover_format(
                 }
                 ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
                     let enum_decl = decl_engine.get_enum(decl_id);
-                    hover_link_contents.add_implementations_for_decl(decl, sync);
+                    hover_link_contents.add_implementations_for_decl(decl);
                     Some(format_visibility_hover(
                         enum_decl.visibility,
                         decl.friendly_type_name(),
@@ -192,17 +192,17 @@ fn hover_format(
                     ))
                 }
                 ty::TyDecl::AbiDecl(ty::AbiDecl { .. }) => {
-                    hover_link_contents.add_implementations_for_decl(decl, sync);
+                    hover_link_contents.add_implementations_for_decl(decl);
                     Some(format!("{} {}", decl.friendly_type_name(), &ident_name))
                 }
                 _ => None,
             },
             TypedAstToken::TypedFunctionDeclaration(func) => {
-                hover_link_contents.add_related_types(&func.return_type.type_id(), sync);
+                hover_link_contents.add_related_types(&func.return_type.type_id());
                 Some(extract_fn_signature(&func.span()))
             }
             TypedAstToken::TypedFunctionParameter(param) => {
-                hover_link_contents.add_related_types(&param.type_argument.type_id(), sync);
+                hover_link_contents.add_related_types(&param.type_argument.type_id());
                 Some(format_name_with_type(
                     param.name.as_str(),
                     &param.type_argument.type_id(),
@@ -212,7 +212,6 @@ fn hover_format(
                 hover_link_contents.add_implementations_for_type(
                     &field.type_argument.span(),
                     field.type_argument.type_id(),
-                    sync,
                 );
                 Some(format_name_with_type(
                     field.name.as_str(),

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -156,7 +156,8 @@ fn hover_format(
                 ty::TyDecl::VariableDecl(var_decl) => {
                     let type_name =
                         format!("{}", engines.help_out(var_decl.type_ascription.type_id()));
-                    hover_link_contents.add_related_types(&var_decl.type_ascription.type_id(), sync);
+                    hover_link_contents
+                        .add_related_types(&var_decl.type_ascription.type_id(), sync);
                     Some(format_variable_hover(
                         var_decl.mutability.is_mutable(),
                         &type_name,

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -1,8 +1,6 @@
 use crate::{
     core::{
-        session::Session,
-        token::{SymbolKind, Token, TokenIdent, TypedAstToken},
-        token_map::TokenMapExt,
+        session::Session, sync::SyncWorkspace, token::{SymbolKind, Token, TokenIdent, TypedAstToken}, token_map::TokenMapExt
     },
     error::{LanguageServerError, RenameError},
     utils::document::get_url_from_path,
@@ -19,6 +17,7 @@ pub fn rename(
     new_name: String,
     url: &Url,
     position: Position,
+    sync: &SyncWorkspace,
 ) -> Result<WorkspaceEdit, LanguageServerError> {
     let _p = tracing::trace_span!("rename").entered();
     // Make sure the new name is not a keyword or a literal int type
@@ -76,7 +75,7 @@ pub fn rename(
         }
         if let Some(path) = &ident.path {
             let url = get_url_from_path(path).ok()?;
-            if let Some(url) = session.sync.to_workspace_url(url) {
+            if let Some(url) = sync.to_workspace_url(url) {
                 let edit = TextEdit::new(range, new_name.clone());
                 return Some((url, vec![edit]));
             };
@@ -102,6 +101,7 @@ pub fn prepare_rename(
     session: Arc<Session>,
     url: &Url,
     position: Position,
+    sync: &SyncWorkspace,
 ) -> Result<PrepareRenameResponse, LanguageServerError> {
     let t = session
         .token_map()
@@ -111,7 +111,7 @@ pub fn prepare_rename(
 
     // Only let through tokens that are in the users workspace.
     // tokens that are external to the users workspace cannot be renamed.
-    let _ = is_token_in_workspace(&session, &session.engines.read(), token)?;
+    let _ = is_token_in_workspace(&session.engines.read(), token, sync)?;
 
     // Make sure we don't allow renaming of tokens that
     // are keywords or intrinsics.
@@ -147,16 +147,16 @@ fn formatted_name(ident: &TokenIdent) -> String {
 
 /// Checks if the token is in the users workspace.
 fn is_token_in_workspace(
-    session: &Arc<Session>,
     engines: &Engines,
     token: &Token,
+    sync: &SyncWorkspace,
 ) -> Result<bool, LanguageServerError> {
     let decl_ident = token
         .declared_token_ident(engines)
         .ok_or(RenameError::TokenNotFound)?;
 
     // Check the span of the tokens definitions to determine if it's in the users workspace.
-    let temp_path = &session.sync.temp_dir()?;
+    let temp_path = &sync.temp_dir()?;
     if let Some(path) = &decl_ident.path {
         if !path.starts_with(temp_path) {
             return Err(LanguageServerError::RenameError(

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -1,6 +1,9 @@
 use crate::{
     core::{
-        session::Session, sync::SyncWorkspace, token::{SymbolKind, Token, TokenIdent, TypedAstToken}, token_map::TokenMapExt
+        session::Session,
+        sync::SyncWorkspace,
+        token::{SymbolKind, Token, TokenIdent, TypedAstToken},
+        token_map::TokenMapExt,
     },
     error::{LanguageServerError, RenameError},
     utils::document::get_url_from_path,

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -213,8 +213,8 @@ impl Documents {
         temp_dir: PathBuf,
     ) -> Result<(), LanguageServerError> {
         for path_str in get_sway_files(temp_dir).iter().filter_map(|fp| fp.to_str()) {
-            let text_doc = TextDocument::build_from_path(path_str).await?; 
-            self.store_document(text_doc)?; 
+            let text_doc = TextDocument::build_from_path(path_str).await?;
+            self.store_document(text_doc)?;
         }
         Ok(())
     }

--- a/sway-lsp/src/core/mod.rs
+++ b/sway-lsp/src/core/mod.rs
@@ -1,6 +1,6 @@
 pub mod document;
 pub mod session;
-pub(crate) mod sync;
+pub mod sync;
 pub(crate) mod token;
 pub mod token_map;
 pub mod token_map_ext;

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -125,7 +125,12 @@ impl Session {
         Ok(())
     }
 
-    pub fn token_references(&self, url: &Url, position: Position, sync: &SyncWorkspace) -> Option<Vec<Location>> {
+    pub fn token_references(
+        &self,
+        url: &Url,
+        position: Position,
+        sync: &SyncWorkspace,
+    ) -> Option<Vec<Location>> {
         let _p = tracing::trace_span!("token_references").entered();
         let token_references: Vec<_> = self
             .token_map
@@ -137,8 +142,7 @@ impl Session {
             .filter_map(|item| {
                 let path = item.key().path.as_ref()?;
                 let uri = Url::from_file_path(path).ok()?;
-                sync
-                    .to_workspace_url(uri)
+                sync.to_workspace_url(uri)
                     .map(|workspace_url| Location::new(workspace_url, item.key().range))
             })
             .collect();

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -473,7 +473,7 @@ pub fn parse_project(
 
     // Next check that the member path is present in the results.
     let found_program_for_member = results.iter().any(|(programs_opt, _handler)| {
-        programs_opt.as_ref().map_or(false, |programs| {
+        programs_opt.as_ref().is_some_and(|programs| {
             programs
                 .typed
                 .as_ref()
@@ -482,9 +482,7 @@ pub fn parse_project(
                     let program_id = typed.as_ref().namespace.current_package_ref().program_id();
                     engines.se().get_manifest_path_from_program_id(&program_id)
                 })
-                .map_or(false, |program_manifest_path| {
-                    program_manifest_path == *member_path
-                })
+                .is_some_and(|program_manifest_path| program_manifest_path == *member_path)
         })
     });
 

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -37,7 +37,7 @@ impl SyncWorkspace {
     }
 
     /// Clean up the temp directory that was created once the server closes down.
-    pub(crate) fn remove_temp_dir(&self) {
+    pub fn remove_temp_dir(&self) {
         if let Ok(dir) = self.temp_dir() {
             // The `temp_path` we store is `random_dir/project_name`.
             // So, we need to remove `random_dir` by getting the parent directory.
@@ -56,7 +56,7 @@ impl SyncWorkspace {
         }
     }
 
-    pub(crate) fn create_temp_dir_from_workspace(
+    pub fn create_temp_dir_from_workspace(
         &self,
         actual_workspace_root: &Path,
     ) -> Result<(), LanguageServerError> {
@@ -110,7 +110,7 @@ impl SyncWorkspace {
         Ok(())
     }
 
-    pub(crate) fn clone_manifest_dir_to_temp(&self) -> Result<(), DirectoryError> {
+    pub fn clone_manifest_dir_to_temp(&self) -> Result<(), DirectoryError> {
         copy_dir_contents(self.manifest_dir()?, self.temp_dir()?)
             .map_err(|_| DirectoryError::CopyContentsFailed)?;
 
@@ -118,7 +118,7 @@ impl SyncWorkspace {
     }
 
     /// Convert the Url path from the client to point to the same file in our temp folder
-    pub(crate) fn workspace_to_temp_url(&self, uri: &Url) -> Result<Url, DirectoryError> {
+    pub fn workspace_to_temp_url(&self, uri: &Url) -> Result<Url, DirectoryError> {
         convert_url(uri, &self.temp_dir()?, &self.manifest_dir()?)
     }
 
@@ -200,14 +200,14 @@ impl SyncWorkspace {
         }
     }
 
-    pub(crate) fn member_path(&self, temp_uri: &Url) -> Option<PathBuf> {
+    pub fn member_path(&self, temp_uri: &Url) -> Option<PathBuf> {
         let p = self.member_manifest_path(temp_uri)?;
         let dir = p.parent()?;
         Some(dir.to_path_buf())
     }
 
     /// Read the Forc.toml and convert relative paths to absolute. Save into our temp directory.
-    pub(crate) fn sync_manifest(&self) -> Result<(), LanguageServerError> {
+    pub fn sync_manifest(&self) -> Result<(), LanguageServerError> {
         let actual_manifest_dir = self.manifest_dir()?;
         let temp_manifest_dir = self.temp_dir()?;
 

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use dashmap::DashMap;
 use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
-use forc_pkg::PackageManifestFile;
 use lsp_types::Url;
 use std::{
     fs,

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -30,7 +30,7 @@ pub struct SyncWorkspace {
 impl SyncWorkspace {
     pub const LSP_TEMP_PREFIX: &'static str = "SWAY_LSP_TEMP_DIR";
 
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             directories: DashMap::new(),
         }

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -226,12 +226,11 @@ impl SyncWorkspace {
         // Load the manifest from the *actual* workspace root to determine if it's a package or workspace
         match ManifestFile::from_dir(&actual_manifest_dir) {
             Ok(ManifestFile::Package(pkg_manifest_file)) => {
-                // Single package: behave as before
                 let actual_pkg_manifest_path = pkg_manifest_file.path();
                 let temp_pkg_manifest_path = temp_manifest_dir.join(
                     actual_pkg_manifest_path
                         .file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)), // Corrected
+                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)),
                 );
                 tracing::debug!(
                     "Syncing single package manifest: {:?} to temp: {:?}",
@@ -239,9 +238,9 @@ impl SyncWorkspace {
                     temp_pkg_manifest_path
                 );
                 if let Err(err) = edit_manifest_dependency_paths(
-                    pkg_manifest_file.dir(),  // Original base for resolving relative paths
-                    actual_pkg_manifest_path, // Original Forc.toml
-                    &temp_pkg_manifest_path,  // Temp Forc.toml to write to
+                    pkg_manifest_file.dir(), 
+                    actual_pkg_manifest_path,
+                    &temp_pkg_manifest_path,
                 ) {
                     tracing::error!(
                         "Failed to edit manifest dependency paths for package {:?}: {}",
@@ -260,7 +259,6 @@ impl SyncWorkspace {
                                 Ok(actual_member_pkg_manifest) => {
                                     let actual_member_manifest_path =
                                         actual_member_pkg_manifest.path();
-                                    // Determine the relative path of the member from the workspace root
                                     if let Ok(relative_member_path) = actual_member_manifest_path
                                         .strip_prefix(&actual_manifest_dir)
                                     {
@@ -273,9 +271,9 @@ impl SyncWorkspace {
                                             temp_member_manifest_path
                                         );
                                         if let Err(err) = edit_manifest_dependency_paths(
-                                            actual_member_pkg_manifest.dir(), // Member's original dir for its relative paths
-                                            actual_member_manifest_path, // Member's original Forc.toml
-                                            &temp_member_manifest_path,  // Member's temp Forc.toml
+                                            actual_member_pkg_manifest.dir(),
+                                            actual_member_manifest_path,
+                                            &temp_member_manifest_path,
                                         ) {
                                             tracing::error!(
                                                 "Failed to edit manifest dependency paths for member {:?}: {}",
@@ -313,7 +311,7 @@ impl SyncWorkspace {
                 let temp_root_workspace_toml_path = temp_manifest_dir.join(
                     actual_root_workspace_toml_path
                         .file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)), // Corrected
+                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)),
                 );
                 tracing::debug!(
                     "Syncing root workspace manifest for patches: {:?} to temp: {:?}",

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -67,10 +67,9 @@ impl SyncWorkspace {
                 dir: actual_workspace_root.to_string_lossy().to_string(),
             })?;
 
-        // temp_dir_guard holds the `TempDir` object.
         let temp_dir_guard = Builder::new()
             .prefix(SyncWorkspace::LSP_TEMP_PREFIX)
-            .tempdir() // This creates a directory like /tmp/SWAY_LSP_TEMP_DIR_XYZ
+            .tempdir()
             .map_err(|_| DirectoryError::TempDirFailed)?;
             
         // Construct the path for our specific workspace clone *inside* the directory managed by temp_dir_guard.
@@ -100,46 +99,6 @@ impl SyncWorkspace {
         );
 
         Ok(())
-
-
-
-        // let manifest = PackageManifestFile::from_dir(manifest_dir).map_err(|_| {
-        //     DocumentError::ManifestFileNotFound {
-        //         dir: manifest_dir.to_string_lossy().to_string(),
-        //     }
-        // })?;
-
-        // // strip Forc.toml from the path to get the manifest directory
-        // let manifest_dir = manifest
-        //     .path()
-        //     .parent()
-        //     .ok_or(DirectoryError::ManifestDirNotFound)?;
-
-        // // extract the project name from the path
-        // let project_name = manifest_dir
-        //     .file_name()
-        //     .and_then(|name| name.to_str())
-        //     .ok_or(DirectoryError::CantExtractProjectName {
-        //         dir: manifest_dir.to_string_lossy().to_string(),
-        //     })?;
-
-        // // Create a new temporary directory that we can clone the current workspace into.
-        // let temp_dir = Builder::new()
-        //     .prefix(SyncWorkspace::LSP_TEMP_PREFIX)
-        //     .tempdir()
-        //     .map_err(|_| DirectoryError::TempDirFailed)?;
-
-        // let temp_path = temp_dir
-        //     .into_path()
-        //     .canonicalize()
-        //     .map_err(|_| DirectoryError::CanonicalizeFailed)?
-        //     .join(project_name);
-
-        // self.directories
-        //     .insert(Directory::Manifest, manifest_dir.to_path_buf());
-        // self.directories.insert(Directory::Temp, temp_path);
-
-        // Ok(())
     }
 
     pub(crate) fn clone_manifest_dir_to_temp(&self) -> Result<(), DirectoryError> {

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -37,14 +37,6 @@ impl SyncWorkspace {
         }
     }
 
-    /// Overwrite the contents of the tmp/folder with everything in
-    /// the current workspace.
-    pub fn resync(&self) -> Result<(), LanguageServerError> {
-        self.clone_manifest_dir_to_temp()?;
-        self.sync_manifest();
-        Ok(())
-    }
-
     /// Clean up the temp directory that was created once the
     /// server closes down.
     pub(crate) fn remove_temp_dir(&self) {

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -40,10 +40,10 @@ impl SyncWorkspace {
             // The `temp_path` we store is `random_dir/project_name`.
             // So, we need to remove `random_dir` by getting the parent directory.
             if let Some(parent_dir) = dir.parent() {
-                if parent_dir
-                    .file_name()
-                    .is_some_and(|name| name.to_string_lossy().starts_with(SyncWorkspace::LSP_TEMP_PREFIX))
-                {
+                if parent_dir.file_name().is_some_and(|name| {
+                    name.to_string_lossy()
+                        .starts_with(SyncWorkspace::LSP_TEMP_PREFIX)
+                }) {
                     if let Err(e) = fs::remove_dir_all(parent_dir) {
                         tracing::warn!("Failed to remove temp base dir {:?}: {}", parent_dir, e);
                     } else {

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -200,6 +200,12 @@ impl SyncWorkspace {
         }
     }
 
+    pub(crate) fn member_path(&self, temp_uri: &Url) -> Option<PathBuf> {
+        let p = self.member_manifest_path(temp_uri)?;
+        let dir = p.parent()?;
+        Some(dir.to_path_buf())
+    }
+
 
     pub(crate) fn sync_manifest(&self) {
         let actual_manifest_dir = match self.manifest_dir() {

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -40,12 +40,15 @@ impl SyncWorkspace {
     /// Clean up the temp directory that was created once the
     /// server closes down.
     pub(crate) fn remove_temp_dir(&self) {
-         if let Ok(dir) = self.temp_dir() {
+        if let Ok(dir) = self.temp_dir() {
             // The tempdir created by Builder is typically a randomly named directory.
             // The `temp_path` we store is `random_dir/project_name`.
             // So, we need to remove `random_dir` by getting the parent directory.
             if let Some(parent_dir) = dir.parent() {
-                if parent_dir.to_string_lossy().contains(SyncWorkspace::LSP_TEMP_PREFIX) {
+                if parent_dir
+                    .to_string_lossy()
+                    .contains(SyncWorkspace::LSP_TEMP_PREFIX)
+                {
                     if let Err(e) = fs::remove_dir_all(parent_dir) {
                         tracing::warn!("Failed to remove temp base dir {:?}: {}", parent_dir, e);
                     } else {
@@ -71,17 +74,25 @@ impl SyncWorkspace {
             .prefix(SyncWorkspace::LSP_TEMP_PREFIX)
             .tempdir()
             .map_err(|_| DirectoryError::TempDirFailed)?;
-            
+
         // Construct the path for our specific workspace clone *inside* the directory managed by temp_dir_guard.
         let temp_workspace_base = temp_dir_guard.path().join(root_dir_name);
 
         fs::create_dir_all(&temp_workspace_base).map_err(|io_err| {
-            tracing::error!("Failed to create subdirectory {:?} in temp: {}", temp_workspace_base, io_err);
+            tracing::error!(
+                "Failed to create subdirectory {:?} in temp: {}",
+                temp_workspace_base,
+                io_err
+            );
             DirectoryError::TempDirFailed
         })?;
-        
+
         let canonical_temp_path = temp_workspace_base.canonicalize().map_err(|io_err| {
-            tracing::warn!("Failed to canonicalize temp path {:?}: {}", temp_workspace_base, io_err);
+            tracing::warn!(
+                "Failed to canonicalize temp path {:?}: {}",
+                temp_workspace_base,
+                io_err
+            );
             DirectoryError::CanonicalizeFailed
         })?;
 

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -22,7 +22,7 @@ pub enum Directory {
     Temp,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SyncWorkspace {
     pub directories: DashMap<Directory, PathBuf>,
 }
@@ -31,9 +31,7 @@ impl SyncWorkspace {
     pub const LSP_TEMP_PREFIX: &'static str = "SWAY_LSP_TEMP_DIR";
 
     pub fn new() -> Self {
-        Self {
-            directories: DashMap::new(),
-        }
+        Self::default()
     }
 
     /// Clean up the temp directory that was created once the server closes down.

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -206,7 +206,6 @@ impl SyncWorkspace {
         Some(dir.to_path_buf())
     }
 
-
     pub(crate) fn sync_manifest(&self) {
         let actual_manifest_dir = match self.manifest_dir() {
             Ok(dir) => dir,
@@ -230,18 +229,24 @@ impl SyncWorkspace {
                 // Single package: behave as before
                 let actual_pkg_manifest_path = pkg_manifest_file.path();
                 let temp_pkg_manifest_path = temp_manifest_dir.join(
-                    actual_pkg_manifest_path.file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)) // Corrected
+                    actual_pkg_manifest_path
+                        .file_name()
+                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)), // Corrected
                 );
-                tracing::debug!("Syncing single package manifest: {:?} to temp: {:?}", actual_pkg_manifest_path, temp_pkg_manifest_path);
+                tracing::debug!(
+                    "Syncing single package manifest: {:?} to temp: {:?}",
+                    actual_pkg_manifest_path,
+                    temp_pkg_manifest_path
+                );
                 if let Err(err) = edit_manifest_dependency_paths(
-                    pkg_manifest_file.dir(), // Original base for resolving relative paths
+                    pkg_manifest_file.dir(),  // Original base for resolving relative paths
                     actual_pkg_manifest_path, // Original Forc.toml
                     &temp_pkg_manifest_path,  // Temp Forc.toml to write to
                 ) {
                     tracing::error!(
                         "Failed to edit manifest dependency paths for package {:?}: {}",
-                        actual_pkg_manifest_path, err
+                        actual_pkg_manifest_path,
+                        err
                     );
                 }
             }
@@ -253,16 +258,24 @@ impl SyncWorkspace {
                         for member_result in member_manifests_iter {
                             match member_result {
                                 Ok(actual_member_pkg_manifest) => {
-                                    let actual_member_manifest_path = actual_member_pkg_manifest.path();
+                                    let actual_member_manifest_path =
+                                        actual_member_pkg_manifest.path();
                                     // Determine the relative path of the member from the workspace root
-                                    if let Ok(relative_member_path) = actual_member_manifest_path.strip_prefix(&actual_manifest_dir) {
-                                        let temp_member_manifest_path = temp_manifest_dir.join(relative_member_path);
-                                        
-                                        tracing::debug!("Syncing workspace member manifest: {:?} to temp: {:?}", actual_member_manifest_path, temp_member_manifest_path);
+                                    if let Ok(relative_member_path) = actual_member_manifest_path
+                                        .strip_prefix(&actual_manifest_dir)
+                                    {
+                                        let temp_member_manifest_path =
+                                            temp_manifest_dir.join(relative_member_path);
+
+                                        tracing::debug!(
+                                            "Syncing workspace member manifest: {:?} to temp: {:?}",
+                                            actual_member_manifest_path,
+                                            temp_member_manifest_path
+                                        );
                                         if let Err(err) = edit_manifest_dependency_paths(
                                             actual_member_pkg_manifest.dir(), // Member's original dir for its relative paths
-                                            actual_member_manifest_path,      // Member's original Forc.toml
-                                            &temp_member_manifest_path,       // Member's temp Forc.toml
+                                            actual_member_manifest_path, // Member's original Forc.toml
+                                            &temp_member_manifest_path,  // Member's temp Forc.toml
                                         ) {
                                             tracing::error!(
                                                 "Failed to edit manifest dependency paths for member {:?}: {}",
@@ -270,17 +283,27 @@ impl SyncWorkspace {
                                             );
                                         }
                                     } else {
-                                        tracing::error!("Could not determine relative path for member: {:?}", actual_member_manifest_path);
+                                        tracing::error!(
+                                            "Could not determine relative path for member: {:?}",
+                                            actual_member_manifest_path
+                                        );
                                     }
                                 }
                                 Err(e) => {
-                                    tracing::error!("Failed to load workspace member manifest: {}", e);
+                                    tracing::error!(
+                                        "Failed to load workspace member manifest: {}",
+                                        e
+                                    );
                                 }
                             }
                         }
                     }
                     Err(e) => {
-                        tracing::error!("Failed to get member manifests for workspace {:?}: {}", actual_manifest_dir, e);
+                        tracing::error!(
+                            "Failed to get member manifests for workspace {:?}: {}",
+                            actual_manifest_dir,
+                            e
+                        );
                     }
                 }
                 // Optionally, sync the root workspace Forc.toml itself if it can have [patch] sections
@@ -288,10 +311,15 @@ impl SyncWorkspace {
                 // The current edit_manifest_dependency_paths handles patches.
                 let actual_root_workspace_toml_path = ws_manifest_file.path();
                 let temp_root_workspace_toml_path = temp_manifest_dir.join(
-                    actual_root_workspace_toml_path.file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)) // Corrected
+                    actual_root_workspace_toml_path
+                        .file_name()
+                        .unwrap_or_else(|| std::ffi::OsStr::new(MANIFEST_FILE_NAME)), // Corrected
                 );
-                tracing::debug!("Syncing root workspace manifest for patches: {:?} to temp: {:?}", actual_root_workspace_toml_path, temp_root_workspace_toml_path);
+                tracing::debug!(
+                    "Syncing root workspace manifest for patches: {:?} to temp: {:?}",
+                    actual_root_workspace_toml_path,
+                    temp_root_workspace_toml_path
+                );
                 if let Err(err) = edit_manifest_dependency_paths(
                     ws_manifest_file.dir(),
                     actual_root_workspace_toml_path,
@@ -302,12 +330,12 @@ impl SyncWorkspace {
                         actual_root_workspace_toml_path, err
                     );
                 }
-
             }
             Err(e) => {
                 tracing::error!(
                     "Failed to load manifest from actual directory {:?}: {}. Cannot sync manifest.",
-                    actual_manifest_dir, e
+                    actual_manifest_dir,
+                    e
                 );
             }
         }

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -41,8 +41,8 @@ impl SyncWorkspace {
             // So, we need to remove `random_dir` by getting the parent directory.
             if let Some(parent_dir) = dir.parent() {
                 if parent_dir
-                    .to_string_lossy()
-                    .contains(SyncWorkspace::LSP_TEMP_PREFIX)
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with(SyncWorkspace::LSP_TEMP_PREFIX))
                 {
                     if let Err(e) = fs::remove_dir_all(parent_dir) {
                         tracing::warn!("Failed to remove temp base dir {:?}: {}", parent_dir, e);

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -82,6 +82,15 @@ impl SyncWorkspace {
             DirectoryError::TempDirFailed
         })?;
 
+        let canonical_manifest_path = actual_workspace_root.canonicalize().map_err(|io_err| {
+            tracing::warn!(
+                "Failed to canonicalize manifest path {:?}: {}",
+                actual_workspace_root,
+                io_err
+            );
+            DirectoryError::CanonicalizeFailed
+        })?;
+
         let canonical_temp_path = temp_workspace_base.canonicalize().map_err(|io_err| {
             tracing::warn!(
                 "Failed to canonicalize temp path {:?}: {}",
@@ -92,7 +101,7 @@ impl SyncWorkspace {
         })?;
 
         self.directories
-            .insert(Directory::Manifest, actual_workspace_root.to_path_buf());
+            .insert(Directory::Manifest, canonical_manifest_path);
         self.directories
             .insert(Directory::Temp, canonical_temp_path.clone());
 

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -25,6 +25,8 @@ pub enum LanguageServerError {
     FormatError(FormatterError),
     #[error("No Programs were returned from the compiler")]
     ProgramsIsNone,
+    #[error("Member program not found in the compiler results")]
+    MemberProgramNotFound,
     #[error("Unable to acquire a semaphore permit for parsing")]
     UnableToAcquirePermit,
     #[error("Client is not initialized")]
@@ -70,6 +72,8 @@ pub enum DirectoryError {
     TempDirNotFound,
     #[error("Can't find manifest directory")]
     ManifestDirNotFound,
+    #[error("Can't find temporary member directory")]
+    TempMemberDirNotFound,
     #[error("Can't extract project name from {:?}", dir)]
     CantExtractProjectName { dir: String },
     #[error("Failed to create hidden .lsp_locks directory: {0}")]

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -11,8 +11,6 @@ pub enum LanguageServerError {
     DirectoryError(#[from] DirectoryError),
     #[error(transparent)]
     RenameError(#[from] RenameError),
-    #[error(transparent)]
-    TowerError(#[from] tower_lsp::jsonrpc::Error),
 
     // Top level errors
     #[error("Failed to create build plan. {0}")]

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -11,6 +11,8 @@ pub enum LanguageServerError {
     DirectoryError(#[from] DirectoryError),
     #[error(transparent)]
     RenameError(#[from] RenameError),
+    #[error(transparent)]
+    TowerError(#[from] tower_lsp::jsonrpc::Error),
 
     // Top level errors
     #[error("Failed to create build plan. {0}")]
@@ -31,6 +33,8 @@ pub enum LanguageServerError {
     ClientNotInitialized,
     #[error("Client request error: {0}")]
     ClientRequestError(String),
+    #[error("Global workspace not initialized")]
+    GlobalWorkspaceNotInitialized,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -35,6 +35,8 @@ pub enum LanguageServerError {
     ClientRequestError(String),
     #[error("Global workspace not initialized")]
     GlobalWorkspaceNotInitialized,
+    #[error("SyncWorkspace already initialized")]
+    SyncWorkspaceAlreadyInitialized,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -43,6 +43,8 @@ pub enum LanguageServerError {
 pub enum DocumentError {
     #[error("No document found at {:?}", path)]
     DocumentNotFound { path: String },
+    #[error("Workspace manifest not found. {:?}", err)]
+    WorkspaceManifestNotFound { err: String },
     #[error("Missing Forc.toml in {:?}", dir)]
     ManifestFileNotFound { dir: String },
     #[error("Cannot get member manifest files for the manifest at {:?}", dir)]

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -144,7 +144,6 @@ pub(crate) async fn handle_did_save_text_document(
     let (uri, session) = state
         .uri_and_session_from_workspace(&params.text_document.uri)
         .await?;
-    session.sync.resync()?;
     let file_versions = file_versions(&state.documents, &uri, None);
     send_new_compilation_request(state, session.clone(), &uri, None, false, file_versions);
     state.wait_for_parsing().await;

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -2,10 +2,11 @@
 //! Protocol. This module specifically handles notification messages sent by the Client.
 
 use crate::{
-    core::{document::Documents, session::Session},
-    error::LanguageServerError,
+    core::{document::Documents, session::Session, sync::SyncWorkspace},
+    error::{DocumentError, LanguageServerError},
     server_state::{CompilationContext, ServerState, TaskMessage},
 };
+use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidOpenTextDocumentParams,
     DidSaveTextDocumentParams, FileChangeType, Url,
@@ -20,6 +21,64 @@ pub async fn handle_did_open_text_document(
     state: &ServerState,
     params: DidOpenTextDocumentParams,
 ) -> Result<(), LanguageServerError> {
+    let file_uri = &params.text_document.uri;
+    tracing::info!("textDocument/didOpen: {:?}", file_uri);
+
+    // Get or initialize the global SyncWorkspace.
+    // get_or_try_init ensures the initialization closure runs only once.
+    let sync_workspace_arc = match state.sync_workspace.get() {
+        Some(sw_arc) => {
+            tracing::debug!("SyncWorkspace already initialized.");
+            sw_arc.clone()
+        }
+        None => {
+            // Not initialized, attempt to initialize.
+            // This closure will only run if the OnceLock is empty.
+            // It needs to be an async block if initialize_global_sync_workspace is async.
+            // However, get_or_try_init expects a FnOnce that returns Result, not async.
+            // So, we must block_on or handle this differently if init is async.
+            // For now, let's assume we can call an async helper and set it.
+            // A robust way for async init with OnceLock might need a small mutex or a dedicated future.
+
+            // Simpler approach: Check, then init if needed, then get. This might race if two didOpen arrive simultaneously.
+            // Using a lock specifically for this initialization is safer if get_or_try_init can't take an async fn.
+            // For now, let's assume a single-threaded context for this specific part or that races are unlikely
+            // for the very first file open. A dedicated init future in ServerState would be more robust.
+
+            // Let's use get_or_try_init by making the init fn sync or by adapting.
+            // Alternative: a dedicated initialization state/mutex in ServerState.
+
+            // For simplicity, let's call the async init and then try to set.
+            // This is NOT fully robust against races for the *very first* init.
+            // `OnceLock::get_or_init_async` would be ideal but is not in std yet.
+            // We will call our async helper and then try to set.
+            // If another thread sets it in between, .set() will fail, which is acceptable.
+            match initialize_global_sync_workspace(state, file_uri).await {
+                Ok(initialized_sw) => {
+                    match state.sync_workspace.set(initialized_sw.clone()) {
+                        Ok(()) => tracing::info!("Global SyncWorkspace successfully initialized and set."),
+                        Err(_) => tracing::info!("Global SyncWorkspace was already set by another concurrent operation."),
+                    }
+                    // Regardless of who set it, get the reference now.
+                    state.sync_workspace.get().unwrap().clone() // Should be Some now.
+                }
+                Err(e) => {
+                    tracing::error!("Failed to initialize global SyncWorkspace: {:?}. LSP functions requiring it may fail.", e);
+                    // Cannot proceed if SyncWorkspace failed to init.
+                    return Err(e); 
+                }
+            }
+        }
+    };
+    
+    // Convert the opened file's actual URI to its temporary URI
+    let temp_uri_for_opened_file = sync_workspace_arc.workspace_to_temp_url(file_uri)?;
+
+    // Ensure this specific document is loaded into the main document store using its temp URI
+    state.documents.handle_open_file(&temp_uri_for_opened_file).await;
+    tracing::debug!("Handled open for temp file: {:?}", temp_uri_for_opened_file);
+
+    // Get or create a session for the original file URI.
     let (uri, session) = state
         .uri_and_session_from_workspace(&params.text_document.uri)
         .await?;
@@ -180,4 +239,63 @@ pub(crate) async fn handle_did_change_watched_files(
         }
     }
     Ok(())
+}
+
+// In sway-lsp/src/handlers/notification.rs
+async fn initialize_global_sync_workspace(
+    state: &ServerState,
+    file_uri_triggering_init: &Url,
+) -> Result<Arc<SyncWorkspace>, LanguageServerError> {
+    tracing::info!(
+        "Performing one-time SyncWorkspace initialization triggered by: {:?}",
+        file_uri_triggering_init
+    );
+
+    let path = PathBuf::from(file_uri_triggering_init.path());
+    let search_dir = path.parent().unwrap_or(&path);
+
+    // Find the initial manifest (could be package or workspace)
+    let initial_manifest_file = ManifestFile::from_dir(search_dir).map_err(|e| {
+        tracing::error!("Failed to find any manifest for {:?}: {}", search_dir, e);
+        DocumentError::ManifestFileNotFound { dir: search_dir.to_string_lossy().into() }
+    })?;
+
+    // Determine the true workspace root.
+    // If the initial manifest is a package that's part of a workspace, get that workspace root.
+    // Otherwise, the initial manifest's directory is the root.
+    let actual_sync_root = match &initial_manifest_file {
+        ManifestFile::Package(pkg_mf) => {
+            // Check if this package is part of a workspace // TODO JOSH this is the wrong error type
+            match pkg_mf.workspace().map_err(|e| LanguageServerError::BuildPlanFailed(e))? {
+                Some(ws_mf) => {
+                    // It's part of a workspace, use the workspace's directory
+                    tracing::info!("Package {:?} is part of workspace {:?}. Using workspace root.", pkg_mf.path(), ws_mf.path());
+                    ws_mf.dir().to_path_buf()
+                }
+                None => {
+                    // It's a standalone package, use its directory
+                    tracing::info!("Package {:?} is standalone. Using package root.", pkg_mf.path());
+                    initial_manifest_file.dir().to_path_buf()
+                }
+            }
+        }
+        ManifestFile::Workspace(ws_mf) => {
+            // It's already a workspace manifest, use its directory
+            tracing::info!("Initial manifest is a workspace: {:?}. Using its root.", ws_mf.path());
+            initial_manifest_file.dir().to_path_buf()
+        }
+    };
+
+    tracing::info!("Determined actual root for SyncWorkspace: {:?}", actual_sync_root);
+
+    let sw = Arc::new(SyncWorkspace::new());
+    sw.create_temp_dir_from_workspace(&actual_sync_root)?; // Use the true workspace root
+    sw.clone_manifest_dir_to_temp()?; // This will now clone the entire workspace
+    sw.sync_manifest(); // This will now iterate through members if actual_sync_root is a workspace
+
+    let temp_dir_for_docs = sw.temp_dir()?;
+    state.documents.store_sway_files_from_temp(temp_dir_for_docs).await?;
+    tracing::info!("Initial document population complete for SyncWorkspace root: {:?}", actual_sync_root);
+
+    Ok(sw)
 }

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -2,11 +2,10 @@
 //! Protocol. This module specifically handles notification messages sent by the Client.
 
 use crate::{
-    core::{document::Documents, session::Session, sync::SyncWorkspace},
-    error::{DocumentError, LanguageServerError},
+    core::{document::Documents, session::Session},
+    error::LanguageServerError,
     server_state::{CompilationContext, ServerState, TaskMessage},
 };
-use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidOpenTextDocumentParams,
     DidSaveTextDocumentParams, FileChangeType, Url,
@@ -53,7 +52,7 @@ pub async fn handle_did_open_text_document(
             // `OnceLock::get_or_init_async` would be ideal but is not in std yet.
             // We will call our async helper and then try to set.
             // If another thread sets it in between, .set() will fail, which is acceptable.
-            match state.initialize_global_sync_workspace(file_uri).await {
+            match state.initialize_workspace_sync(file_uri).await {
                 Ok(initialized_sw) => {
                     match state.sync_workspace.set(initialized_sw.clone()) {
                         Ok(()) => {

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -56,8 +56,12 @@ pub async fn handle_did_open_text_document(
             match initialize_global_sync_workspace(state, file_uri).await {
                 Ok(initialized_sw) => {
                     match state.sync_workspace.set(initialized_sw.clone()) {
-                        Ok(()) => tracing::info!("Global SyncWorkspace successfully initialized and set."),
-                        Err(_) => tracing::info!("Global SyncWorkspace was already set by another concurrent operation."),
+                        Ok(()) => {
+                            tracing::info!("Global SyncWorkspace successfully initialized and set.")
+                        }
+                        Err(_) => tracing::info!(
+                            "Global SyncWorkspace was already set by another concurrent operation."
+                        ),
                     }
                     // Regardless of who set it, get the reference now.
                     state.sync_workspace.get().unwrap().clone() // Should be Some now.
@@ -65,17 +69,20 @@ pub async fn handle_did_open_text_document(
                 Err(e) => {
                     tracing::error!("Failed to initialize global SyncWorkspace: {:?}. LSP functions requiring it may fail.", e);
                     // Cannot proceed if SyncWorkspace failed to init.
-                    return Err(e); 
+                    return Err(e);
                 }
             }
         }
     };
-    
+
     // Convert the opened file's actual URI to its temporary URI
     let temp_uri_for_opened_file = sync_workspace_arc.workspace_to_temp_url(file_uri)?;
 
     // Ensure this specific document is loaded into the main document store using its temp URI
-    state.documents.handle_open_file(&temp_uri_for_opened_file).await;
+    state
+        .documents
+        .handle_open_file(&temp_uri_for_opened_file)
+        .await;
     tracing::debug!("Handled open for temp file: {:?}", temp_uri_for_opened_file);
 
     // Get or create a session for the original file URI.
@@ -257,7 +264,9 @@ async fn initialize_global_sync_workspace(
     // Find the initial manifest (could be package or workspace)
     let initial_manifest_file = ManifestFile::from_dir(search_dir).map_err(|e| {
         tracing::error!("Failed to find any manifest for {:?}: {}", search_dir, e);
-        DocumentError::ManifestFileNotFound { dir: search_dir.to_string_lossy().into() }
+        DocumentError::ManifestFileNotFound {
+            dir: search_dir.to_string_lossy().into(),
+        }
     })?;
 
     // Determine the true workspace root.
@@ -266,27 +275,43 @@ async fn initialize_global_sync_workspace(
     let actual_sync_root = match &initial_manifest_file {
         ManifestFile::Package(pkg_mf) => {
             // Check if this package is part of a workspace // TODO JOSH this is the wrong error type
-            match pkg_mf.workspace().map_err(|e| LanguageServerError::BuildPlanFailed(e))? {
+            match pkg_mf
+                .workspace()
+                .map_err(|e| LanguageServerError::BuildPlanFailed(e))?
+            {
                 Some(ws_mf) => {
                     // It's part of a workspace, use the workspace's directory
-                    tracing::info!("Package {:?} is part of workspace {:?}. Using workspace root.", pkg_mf.path(), ws_mf.path());
+                    tracing::info!(
+                        "Package {:?} is part of workspace {:?}. Using workspace root.",
+                        pkg_mf.path(),
+                        ws_mf.path()
+                    );
                     ws_mf.dir().to_path_buf()
                 }
                 None => {
                     // It's a standalone package, use its directory
-                    tracing::info!("Package {:?} is standalone. Using package root.", pkg_mf.path());
+                    tracing::info!(
+                        "Package {:?} is standalone. Using package root.",
+                        pkg_mf.path()
+                    );
                     initial_manifest_file.dir().to_path_buf()
                 }
             }
         }
         ManifestFile::Workspace(ws_mf) => {
             // It's already a workspace manifest, use its directory
-            tracing::info!("Initial manifest is a workspace: {:?}. Using its root.", ws_mf.path());
+            tracing::info!(
+                "Initial manifest is a workspace: {:?}. Using its root.",
+                ws_mf.path()
+            );
             initial_manifest_file.dir().to_path_buf()
         }
     };
 
-    tracing::info!("Determined actual root for SyncWorkspace: {:?}", actual_sync_root);
+    tracing::info!(
+        "Determined actual root for SyncWorkspace: {:?}",
+        actual_sync_root
+    );
 
     let sw = Arc::new(SyncWorkspace::new());
     sw.create_temp_dir_from_workspace(&actual_sync_root)?; // Use the true workspace root
@@ -294,8 +319,14 @@ async fn initialize_global_sync_workspace(
     sw.sync_manifest(); // This will now iterate through members if actual_sync_root is a workspace
 
     let temp_dir_for_docs = sw.temp_dir()?;
-    state.documents.store_sway_files_from_temp(temp_dir_for_docs).await?;
-    tracing::info!("Initial document population complete for SyncWorkspace root: {:?}", actual_sync_root);
+    state
+        .documents
+        .store_sway_files_from_temp(temp_dir_for_docs)
+        .await?;
+    tracing::info!(
+        "Initial document population complete for SyncWorkspace root: {:?}",
+        actual_sync_root
+    );
 
     Ok(sw)
 }

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -37,6 +37,7 @@ pub async fn handle_did_open_text_document(
                 optimized_build: false,
                 gc_options: state.config.read().garbage_collection.clone(),
                 file_versions: BTreeMap::new(),
+                sync: Some(state.sync_workspace.get().unwrap().clone()),
             }));
         state.is_compiling.store(true, Ordering::SeqCst);
         state.wait_for_parsing().await;
@@ -78,6 +79,7 @@ fn send_new_compilation_request(
             optimized_build,
             gc_options: state.config.read().garbage_collection.clone(),
             file_versions,
+            sync: Some(state.sync_workspace.get().unwrap().clone()),
         }));
 }
 
@@ -163,7 +165,7 @@ pub(crate) async fn handle_did_change_watched_files(
         match event.typ {
             FileChangeType::CHANGED => {
                 if event.uri.to_string().contains("Forc.toml") {
-                    session.sync.sync_manifest();
+                    //session.sync.sync_manifest();
                     // TODO: Recompile the project | see https://github.com/FuelLabs/sway/issues/7103
                 }
             }

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -22,7 +22,7 @@ pub async fn handle_did_open_text_document(
 ) -> Result<(), LanguageServerError> {
     let file_uri = &params.text_document.uri;
     // Initialize the SyncWorkspace if it doesn't exist.
-    let _ = state.get_or_init_global_sync_workspace(&file_uri).await?;
+    let _ = state.get_or_init_global_sync_workspace(file_uri).await?;
 
     // Get or create a session for the original file URI.
     let (uri, session) = state

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -120,7 +120,7 @@ pub async fn handle_goto_definition(
         Ok((uri, session)) => {
             let sync = state.sync_workspace.get().unwrap();
             let position = params.text_document_position_params.position;
-            Ok(session.token_definition_response(&uri, position, &sync))
+            Ok(session.token_definition_response(&uri, position, sync))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());
@@ -170,7 +170,7 @@ pub async fn handle_hover(
                 &uri,
                 position,
                 state.config.read().client.clone(),
-                &sync,
+                sync,
             ))
         }
         Err(err) => {
@@ -190,7 +190,7 @@ pub async fn handle_prepare_rename(
     {
         Ok((uri, session)) => {
             let sync = state.sync_workspace.get().unwrap();
-            match capabilities::rename::prepare_rename(session, &uri, params.position, &sync) {
+            match capabilities::rename::prepare_rename(session, &uri, params.position, sync) {
                 Ok(res) => Ok(Some(res)),
                 Err(err) => {
                     tracing::error!("{}", err.to_string());
@@ -217,7 +217,7 @@ pub async fn handle_rename(
             let new_name = params.new_name;
             let position = params.text_document_position.position;
             let sync = state.sync_workspace.get().unwrap();
-            match capabilities::rename::rename(session, new_name, &uri, position, &sync) {
+            match capabilities::rename::rename(session, new_name, &uri, position, sync) {
                 Ok(res) => Ok(Some(res)),
                 Err(err) => {
                     tracing::error!("{}", err.to_string());
@@ -266,7 +266,7 @@ pub async fn handle_references(
         Ok((uri, session)) => {
             let position = params.text_document_position.position;
             let sync = state.sync_workspace.get().unwrap();
-            Ok(session.token_references(&uri, position, &sync))
+            Ok(session.token_references(&uri, position, sync))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -84,9 +84,9 @@ pub async fn handle_goto_definition(
         .await
     {
         Ok((uri, session)) => {
-            let sync = state.sync_workspace.get().unwrap();
+            let sync = state.sync_workspace();
             let position = params.text_document_position_params.position;
-            Ok(session.token_definition_response(&uri, position, sync))
+            Ok(session.token_definition_response(&uri, position, &sync))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());
@@ -129,14 +129,14 @@ pub async fn handle_hover(
     {
         Ok((uri, session)) => {
             let position = params.text_document_position_params.position;
-            let sync = state.sync_workspace.get().unwrap();
+            let sync = state.sync_workspace();
             Ok(capabilities::hover::hover_data(
                 session,
                 &state.keyword_docs,
                 &uri,
                 position,
                 state.config.read().client.clone(),
-                sync,
+                &sync,
             ))
         }
         Err(err) => {
@@ -155,8 +155,8 @@ pub async fn handle_prepare_rename(
         .await
     {
         Ok((uri, session)) => {
-            let sync = state.sync_workspace.get().unwrap();
-            match capabilities::rename::prepare_rename(session, &uri, params.position, sync) {
+            let sync = state.sync_workspace();
+            match capabilities::rename::prepare_rename(session, &uri, params.position, &sync) {
                 Ok(res) => Ok(Some(res)),
                 Err(err) => {
                     tracing::error!("{}", err.to_string());
@@ -182,8 +182,8 @@ pub async fn handle_rename(
         Ok((uri, session)) => {
             let new_name = params.new_name;
             let position = params.text_document_position.position;
-            let sync = state.sync_workspace.get().unwrap();
-            match capabilities::rename::rename(session, new_name, &uri, position, sync) {
+            let sync = state.sync_workspace();
+            match capabilities::rename::rename(session, new_name, &uri, position, &sync) {
                 Ok(res) => Ok(Some(res)),
                 Err(err) => {
                     tracing::error!("{}", err.to_string());
@@ -231,8 +231,8 @@ pub async fn handle_references(
     {
         Ok((uri, session)) => {
             let position = params.text_document_position.position;
-            let sync = state.sync_workspace.get().unwrap();
-            Ok(session.token_references(&uri, position, sync))
+            let sync = state.sync_workspace();
+            Ok(session.token_references(&uri, position, &sync))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -394,6 +394,7 @@ pub async fn handle_inlay_hints(
         .await
     {
         Ok((uri, session)) => {
+            eprintln!("inlay hints: Uri: {:?}", uri);
             let config = &state.config.read().inlay_hints;
             Ok(capabilities::inlay_hints::inlay_hints(
                 session,

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -2,14 +2,8 @@
 //! Protocol. This module specifically handles requests.
 
 use crate::{
-    capabilities,
-    core::{session::build_plan, sync::SyncWorkspace},
-    error::{DocumentError, LanguageServerError},
-    lsp_ext,
-    server_state::ServerState,
-    utils::debug,
+    capabilities, core::session::build_plan, lsp_ext, server_state::ServerState, utils::debug,
 };
-use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
 use forc_tracing::{tracing_subscriber, FmtSpan, TracingWriter};
 use lsp_types::{
     CodeLens, CompletionResponse, DocumentFormattingParams, DocumentSymbolResponse,
@@ -21,7 +15,6 @@ use std::{
     fs::File,
     io::Write,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 use sway_types::{Ident, Spanned};
 use sway_utils::PerformanceData;

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -394,7 +394,6 @@ pub async fn handle_inlay_hints(
         .await
     {
         Ok((uri, session)) => {
-            eprintln!("inlay hints: Uri: {:?}", uri);
             let config = &state.config.read().inlay_hints;
             Ok(capabilities::inlay_hints::inlay_hints(
                 session,

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -12,10 +12,10 @@ use crate::{
 use forc_tracing::{tracing_subscriber, FmtSpan, TracingWriter};
 use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
 use lsp_types::{
-    CodeLens, CompletionResponse, DocumentFormattingParams, DocumentSymbolResponse,
-    InlayHint, InlayHintParams, PrepareRenameResponse, RenameParams,
-    SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
-    SemanticTokensResult, TextDocumentIdentifier, Url, WorkspaceEdit,
+    CodeLens, CompletionResponse, DocumentFormattingParams, DocumentSymbolResponse, InlayHint,
+    InlayHintParams, PrepareRenameResponse, RenameParams, SemanticTokensParams,
+    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult,
+    TextDocumentIdentifier, Url, WorkspaceEdit,
 };
 use std::{
     fs::File,

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -48,54 +48,12 @@ pub fn handle_initialize(
             .init();
     }
     tracing::info!("Initializing the Sway Language Server");
-    if let Some(uri) = &params.root_uri {
-        tracing::info!("Client reported rootUri: {}", uri);
-    }
 
     Ok(InitializeResult {
         server_info: None,
         capabilities: crate::server_capabilities(),
         ..InitializeResult::default()
     })
-
-    // // Determine the workspace root path.
-    // let workspace_root = params
-    //     .root_uri
-    //     .as_ref()
-    //     .and_then(|uri| uri.to_file_path().ok())
-    //     .ok_or(LanguageServerError::ClientNotInitialized)?;
-
-    // // Regardless of whether initial_path_from_client is a file or directory,
-    // // use ManifestFile::from_dir to find the true project/workspace root.
-    // // ManifestFile::from_dir will search upwards from initial_path_from_client (or its parent if it's a file)
-    // // to find a Forc.toml.
-    // let search_path_for_manifest = if workspace_root.is_file() {
-    //     workspace_root.parent().unwrap_or(&workspace_root)
-    // } else {
-    //     &workspace_root
-    // };
-
-    // let manifest_file = ManifestFile::from_dir(search_path_for_manifest)
-    // .map_err(|_e| DocumentError::ManifestFileNotFound {
-    //     dir: workspace_root.to_string_lossy().to_string(),
-    // })?;
-
-    // let actual_workspace_root = manifest_file.dir().to_path_buf(); // This will be sway/examples/
-    // tracing::info!("Actual workspace root determined by ManifestFile::from_dir: {:?}", actual_workspace_root);
-
-    // // Create and initialize the global SyncWorkspace.
-    // let sw = Arc::new(SyncWorkspace::new());
-    // sw.create_temp_dir_from_workspace(&actual_workspace_root)?;
-    // sw.clone_manifest_dir_to_temp()?;
-    // sw.sync_manifest();
-
-    // // Initialize the OnceLock for sync_workspace
-    // state
-    //     .sync_workspace
-    //     .set(sw)
-    //     .map_err(|_| LanguageServerError::SyncWorkspaceAlreadyInitialized)?;
-
-    // Ok(())
 }
 
 pub async fn handle_document_symbol(

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -9,8 +9,8 @@ use crate::{
     server_state::ServerState,
     utils::debug,
 };
-use forc_tracing::{tracing_subscriber, FmtSpan, TracingWriter};
 use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
+use forc_tracing::{tracing_subscriber, FmtSpan, TracingWriter};
 use lsp_types::{
     CodeLens, CompletionResponse, DocumentFormattingParams, DocumentSymbolResponse, InlayHint,
     InlayHintParams, PrepareRenameResponse, RenameParams, SemanticTokensParams,

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -12,7 +12,10 @@ use crate::{
 use forc_pkg::manifest::{GenericManifestFile, ManifestFile};
 use forc_tracing::{tracing_subscriber, FmtSpan, TracingWriter};
 use lsp_types::{
-    CodeLens, CompletionResponse, DocumentFormattingParams, DocumentSymbolResponse, InitializeResult, InlayHint, InlayHintParams, PrepareRenameResponse, RenameParams, SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, TextDocumentIdentifier, Url, WorkspaceEdit
+    CodeLens, CompletionResponse, DocumentFormattingParams, DocumentSymbolResponse,
+    InitializeResult, InlayHint, InlayHintParams, PrepareRenameResponse, RenameParams,
+    SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+    SemanticTokensResult, TextDocumentIdentifier, Url, WorkspaceEdit,
 };
 use std::{
     fs::File,

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -79,13 +79,13 @@ pub fn handle_initialize(
     let sw = Arc::new(SyncWorkspace::new());
     sw.create_temp_dir_from_workspace(&actual_workspace_root)?;
     sw.clone_manifest_dir_to_temp()?;
-    sw.sync_manifest(); // Assuming this doesn't return a critical error or we log within it.
+    sw.sync_manifest();
 
     // Initialize the OnceLock for sync_workspace
     state
         .sync_workspace
         .set(sw)
-        .map_err(|_| LanguageServerError::FailedToParse)?; // Or a more specific error "SyncWorkspaceAlreadyInitialized"
+        .map_err(|_| LanguageServerError::SyncWorkspaceAlreadyInitialized)?;
 
     Ok(())
 }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -15,9 +15,7 @@ mod traverse;
 pub mod utils;
 
 use lsp_types::{
-    CodeActionProviderCapability, CodeLensOptions, CompletionOptions, ExecuteCommandOptions,
-    HoverProviderCapability, OneOf, RenameOptions, SemanticTokensLegend, SemanticTokensOptions,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
+    CodeActionProviderCapability, CodeLensOptions, CompletionOptions, ExecuteCommandOptions, HoverProviderCapability, OneOf, RenameOptions, SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions, WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities
 };
 use server_state::ServerState;
 use tower_lsp::{LspService, Server};
@@ -77,6 +75,13 @@ pub fn server_capabilities() -> ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
+        workspace: Some(WorkspaceServerCapabilities {
+            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                supported: Some(true),
+                change_notifications: Some(OneOf::Left(true)),
+            }),
+            ..Default::default()
+        }),
         ..ServerCapabilities::default()
     }
 }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -15,7 +15,10 @@ mod traverse;
 pub mod utils;
 
 use lsp_types::{
-    CodeActionProviderCapability, CodeLensOptions, CompletionOptions, ExecuteCommandOptions, HoverProviderCapability, OneOf, RenameOptions, SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions, WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities
+    CodeActionProviderCapability, CodeLensOptions, CompletionOptions, ExecuteCommandOptions,
+    HoverProviderCapability, OneOf, RenameOptions, SemanticTokensLegend, SemanticTokensOptions,
+    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
+    WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
 };
 use server_state::ServerState;
 use tower_lsp::{LspService, Server};

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -39,19 +39,16 @@ impl LanguageServer for ServerState {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        eprintln!("INITIALIZED");
         // Register a file system watcher for Forc.toml files with the client.
         if let Err(err) = self.register_forc_toml_watcher().await {
             tracing::error!("Failed to register Forc.toml file watcher: {}", err);
         }
-        eprintln!("registered forc toml watcher");
+        // Populate documents from temp dir
         if let Some(sw) = self.sync_workspace.get() {
             if let Ok(temp_dir) = sw.temp_dir() {
-                eprintln!("temp dir: {:?}", temp_dir);
                 let _ = self.documents.store_sway_files_from_temp(temp_dir).await;
             }
         }
-        eprintln!("synced documents");
         tracing::info!("Sway Language Server Initialized");
     }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -34,7 +34,9 @@ impl LanguageServer for ServerState {
         // Populate documents from temp dir
         if let Some(sw) = self.sync_workspace.get() {
             if let Ok(temp_dir) = sw.temp_dir() {
-                let _ = self.documents.store_sway_files_from_temp(temp_dir).await;
+                if let Err(err) = self.documents.store_sway_files_from_temp(temp_dir).await {
+                    tracing::warn!("Failed to populate documents from temp dir: {}", err);
+                }
             }
         }
         tracing::info!("Sway Language Server Initialized");

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -23,19 +23,7 @@ use tower_lsp::{jsonrpc::Result, LanguageServer};
 #[tower_lsp::async_trait]
 impl LanguageServer for ServerState {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        match request::handle_initialize(self, &params) {
-            Ok(_) => Ok(InitializeResult {
-                server_info: None,
-                capabilities: crate::server_capabilities(),
-                ..InitializeResult::default()
-            }),
-            Err(err) => {
-                tracing::error!("Server initialization failed: {}", err.to_string());
-                let mut json_err = tower_lsp::jsonrpc::Error::internal_error();
-                json_err.message = err.to_string().into();
-                Err(json_err)
-            }
-        }
+        request::handle_initialize(self, &params)
     }
 
     async fn initialized(&self, _: InitializedParams) {

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -524,6 +524,20 @@ impl ServerState {
 
         Ok(sw)
     }
+
+    /// Returns a cloned `Arc` of the `SyncWorkspace`.
+    ///
+    /// Panics if `sync_workspace` has not been initialized by a prior call to
+    /// `get_or_init_global_sync_workspace`. This scenario is not expected in normal operation.
+    pub fn sync_workspace(&self) -> Arc<SyncWorkspace> {
+        // `sync_workspace` is initialized once during the first call to `get_or_init_global_sync_workspace`.
+        // After initialization, it's always expected to be `Some`.
+        // Using `expect` here simplifies the code, as the `None` case should not occur in normal operation.
+        self.sync_workspace
+            .get()
+            .expect("SyncWorkspace not initialized")
+            .clone()
+    }
 }
 
 /// A Least Recently Used (LRU) cache for storing and managing `Session` objects.

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -417,7 +417,7 @@ impl ServerState {
         if let Some(session) = self.sessions.get(&manifest_dir) {
             return Ok(session);
         }
-        
+
         // If no session can be found, then we need to call init and insert a new session into the map
         let session = Arc::new(Session::new());
         self.sessions

--- a/sway-lsp/tests/fixtures/diagnostics/dead_code/Forc.toml
+++ b/sway-lsp/tests/fixtures/diagnostics/dead_code/Forc.toml
@@ -5,7 +5,5 @@ license = "Apache-2.0"
 name = "dead_code"
 
 [dependencies]
-# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.66.5" }
-# TODO: Pin back to latest version once std and core merge is in
-std = { path = "../../../../sway-lib-std" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.68.4" }
 

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
@@ -6,7 +6,5 @@ entry = "main.sw"
 implicit-std = false
 
 [dependencies]
-# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
-# TODO: Pin back to latest version once std and core merge is in
-std = { path = "../../../../sway-lib-std" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.68.4" }
 

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -796,6 +796,7 @@ pub fn create_did_change_params(
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn range_from_start_and_end_line(start_line: u32, end_line: u32) -> Range {
     Range {
         start: Position {

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -52,7 +52,7 @@ pub(crate) fn client_capabilities() -> ClientCapabilities {
 
 pub(crate) async fn initialize_request(
     service: &mut LspService<ServerState>,
-    entry_point: &PathBuf,
+    entry_point: &Path,
 ) -> Request {
     let search_dir = entry_point.parent().unwrap_or_else(|| Path::new(""));
     let project_root_path_for_uri: PathBuf = match ManifestFile::from_dir(search_dir) {

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -4,11 +4,14 @@
 
 use crate::{GotoDefinition, HoverDocumentation, Rename};
 use assert_json_diff::assert_json_eq;
-use forc_pkg::manifest::ManifestFile;
 use forc_pkg::manifest::GenericManifestFile;
+use forc_pkg::manifest::ManifestFile;
 use regex::Regex;
 use serde_json::json;
-use std::{borrow::Cow, path::{Path, PathBuf}};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 use sway_lsp::{
     handlers::request,
     lsp_ext::{ShowAstParams, VisualizeParams},
@@ -47,12 +50,17 @@ pub(crate) fn client_capabilities() -> ClientCapabilities {
     }
 }
 
-pub(crate) async fn initialize_request(service: &mut LspService<ServerState>, entry_point: &PathBuf) -> Request {
+pub(crate) async fn initialize_request(
+    service: &mut LspService<ServerState>,
+    entry_point: &PathBuf,
+) -> Request {
     let search_dir = entry_point.parent().unwrap_or(&entry_point);
     let manifest_file = ManifestFile::from_dir(search_dir).unwrap();
     let project_root_path = manifest_file.dir();
-    let root_uri = Url::from_directory_path(project_root_path)
-        .expect(&format!("Failed to create directory URL from project root: {:?}", project_root_path));
+    let root_uri = Url::from_directory_path(project_root_path).expect(&format!(
+        "Failed to create directory URL from project root: {:?}",
+        project_root_path
+    ));
 
     // Construct the InitializeParams using the defined client_capabilities
     let params = json!({
@@ -68,7 +76,11 @@ pub(crate) async fn initialize_request(service: &mut LspService<ServerState>, en
     let expected_initialize_result = json!({ "capabilities": sway_lsp::server_capabilities() });
     let expected_response = Response::from_ok(1.into(), expected_initialize_result);
 
-    assert!(response.is_ok(), "Initialize request failed: {:?}", response.err());
+    assert!(
+        response.is_ok(),
+        "Initialize request failed: {:?}",
+        response.err()
+    );
     assert_json_eq!(expected_response, response.ok().unwrap());
 
     initialize_request

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -781,25 +781,38 @@ pub fn create_did_change_params(
     }
 }
 
-pub(crate) async fn inlay_hints_request(server: &ServerState, uri: &Url) -> Option<Vec<InlayHint>> {
+pub(crate) fn range_from_start_and_end_line(start_line: u32, end_line: u32) -> Range {
+    Range {
+        start: Position { line: start_line, character: 0 },
+        end: Position { line: end_line, character: 0 },
+    }
+}
+
+pub(crate) async fn get_inlay_hints_for_range(
+    server: &ServerState,
+    uri: Url,
+    range: Range,
+) -> Vec<InlayHint> {
     let params = InlayHintParams {
-        text_document: TextDocumentIdentifier { uri: uri.clone() },
-        range: Range {
-            start: Position {
-                line: 25,
-                character: 0,
-            },
-            end: Position {
-                line: 26,
-                character: 1,
-            },
-        },
+        text_document: TextDocumentIdentifier { uri },
+        range,
         work_done_progress_params: Default::default(),
     };
-    let res = request::handle_inlay_hints(server, params)
+    request::handle_inlay_hints(server, params)
         .await
         .unwrap()
-        .unwrap();
+        .unwrap()
+}
+
+pub(crate) async fn inlay_hints_request(server: &ServerState, uri: &Url) -> Option<Vec<InlayHint>> {
+    let range = Range {
+        start: Position {
+            line: 25,
+            character: 0,
+        },
+        end: Position { line: 26, character: 1 },
+    };
+    let res = get_inlay_hints_for_range(server, uri.clone(), range).await;
     let expected = vec![
         InlayHint {
             position: Position {

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -192,7 +192,7 @@ fn did_open_all_members_in_examples() {
                 let uri = if service.inner().sync_workspace.get().is_none() {
                     init_and_open(&mut service, dir.join("src/main.sw")).await
                 } else {
-                    open(&mut service.inner(), dir.join("src/main.sw")).await
+                    open(service.inner(), dir.join("src/main.sw")).await
                 };
 
                 // Make sure that program was parsed and the token map is populated
@@ -206,7 +206,7 @@ fn did_open_all_members_in_examples() {
 
                 // Make sure that semantic tokens are successfully returned for the file
                 let semantic_tokens = lsp::get_semantic_tokens_full(service.inner(), &uri).await;
-                assert!(semantic_tokens.data.len() > 0);
+                assert!(!semantic_tokens.data.is_empty());
             }
         }
         shutdown_and_exit(&mut service).await;

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -181,7 +181,7 @@ fn did_open_all_members_in_examples() {
                 .unwrap();
 
             // Open all workspace members and assert that we are able to return semantic tokens for each workspace member.
-            for (name, package_manifest) in &member_manifests {
+            for (_name, package_manifest) in &member_manifests {
                 let dir = package_manifest.path().parent().unwrap();
 
                 // If the workspace is not initialized, we need to initialize it

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -2233,257 +2233,257 @@ fn test_url_to_session_existing_session() {
     });
 }
 
-// //------------------- GARBAGE COLLECTION TESTS -------------------//
+//------------------- GARBAGE COLLECTION TESTS -------------------//
 
-// async fn garbage_collection_runner(path: PathBuf) {
-//     setup_panic_hook();
-//     let (mut service, _) = LspService::new(ServerState::new);
-//     let uri = init_and_open(&mut service, path).await;
-//     let times = 20;
+async fn garbage_collection_runner(path: PathBuf) {
+    setup_panic_hook();
+    let (mut service, _) = LspService::new(ServerState::new);
+    let uri = init_and_open(&mut service, path).await;
+    let times = 20;
 
-//     // Initialize cursor position
-//     let mut cursor_line = 1;
+    // Initialize cursor position
+    let mut cursor_line = 1;
 
-//     for version in 1..times {
-//         //eprintln!("version: {}", version);
-//         let params = lsp::simulate_keypress(&uri, version, &mut cursor_line);
-//         let _ = lsp::did_change_request(&mut service, &uri, version, Some(params)).await;
-//         if version == 0 {
-//             service.inner().wait_for_parsing().await;
-//         }
-//         // wait for a random amount of time to simulate typing
-//         random_delay().await;
-//     }
-//     shutdown_and_exit(&mut service).await;
-// }
+    for version in 1..times {
+        //eprintln!("version: {}", version);
+        let params = lsp::simulate_keypress(&uri, version, &mut cursor_line);
+        let _ = lsp::did_change_request(&mut service, &uri, version, Some(params)).await;
+        if version == 0 {
+            service.inner().wait_for_parsing().await;
+        }
+        // wait for a random amount of time to simulate typing
+        random_delay().await;
+    }
+    shutdown_and_exit(&mut service).await;
+}
 
-// /// Contains representable individual projects suitable for GC tests,
-// /// as well as projects in which GC was failing, and that are not
-// /// included in [garbage_collection_all_language_tests].
-// #[test]
-// fn garbage_collection_tests() -> Result<(), String> {
-//     let mut tests = vec![
-//         // TODO: Enable this test once https://github.com/FuelLabs/sway/issues/6687 is fixed.
-//         // (
-//         //     "option_eq".into(),
-//         //     sway_workspace_dir()
-//         //         .join(e2e_stdlib_dir())
-//         //         .join("option_eq")
-//         //         .join("src/main.sw"),
-//         // ),
-//         (
-//             "arrays".into(),
-//             sway_workspace_dir()
-//                 .join("examples/arrays")
-//                 .join("src/main.sw"),
-//         ),
-//         (
-//             "minimal_script".into(),
-//             sway_workspace_dir()
-//                 .join("sway-lsp/tests/fixtures/garbage_collection/minimal_script")
-//                 .join("src/main.sw"),
-//         ),
-//         (
-//             "paths".into(),
-//             test_fixtures_dir().join("tokens/paths/src/main.sw"),
-//         ),
-//         (
-//             "storage_contract".into(),
-//             sway_workspace_dir()
-//                 .join("sway-lsp/tests/fixtures/garbage_collection/storage_contract")
-//                 .join("src/main.sw"),
-//         ),
-//     ];
+/// Contains representable individual projects suitable for GC tests,
+/// as well as projects in which GC was failing, and that are not
+/// included in [garbage_collection_all_language_tests].
+#[test]
+fn garbage_collection_tests() -> Result<(), String> {
+    let mut tests = vec![
+        // TODO: Enable this test once https://github.com/FuelLabs/sway/issues/6687 is fixed.
+        // (
+        //     "option_eq".into(),
+        //     sway_workspace_dir()
+        //         .join(e2e_stdlib_dir())
+        //         .join("option_eq")
+        //         .join("src/main.sw"),
+        // ),
+        (
+            "arrays".into(),
+            sway_workspace_dir()
+                .join("examples/arrays")
+                .join("src/main.sw"),
+        ),
+        (
+            "minimal_script".into(),
+            sway_workspace_dir()
+                .join("sway-lsp/tests/fixtures/garbage_collection/minimal_script")
+                .join("src/main.sw"),
+        ),
+        (
+            "paths".into(),
+            test_fixtures_dir().join("tokens/paths/src/main.sw"),
+        ),
+        (
+            "storage_contract".into(),
+            sway_workspace_dir()
+                .join("sway-lsp/tests/fixtures/garbage_collection/storage_contract")
+                .join("src/main.sw"),
+        ),
+    ];
 
-//     tests.sort();
+    tests.sort();
 
-//     run_garbage_collection_tests(&tests, None)
-// }
+    run_garbage_collection_tests(&tests, None)
+}
 
-// #[test]
-// fn garbage_collection_all_language_tests() -> Result<(), String> {
-//     run_garbage_collection_tests_from_projects_dir(e2e_language_dir())
-// }
+#[test]
+fn garbage_collection_all_language_tests() -> Result<(), String> {
+    run_garbage_collection_tests_from_projects_dir(e2e_language_dir())
+}
 
-// #[test]
-// #[ignore = "Additional stress test for GC. Run it locally when working on code that affects GC."]
-// fn garbage_collection_all_should_pass_tests() -> Result<(), String> {
-//     run_garbage_collection_tests_from_projects_dir(e2e_should_pass_dir())
-// }
+#[test]
+#[ignore = "Additional stress test for GC. Run it locally when working on code that affects GC."]
+fn garbage_collection_all_should_pass_tests() -> Result<(), String> {
+    run_garbage_collection_tests_from_projects_dir(e2e_should_pass_dir())
+}
 
-// #[test]
-// #[ignore = "Additional stress test for GC. Run it locally when working on code that affects GC."]
-// fn garbage_collection_all_should_fail_tests() -> Result<(), String> {
-//     run_garbage_collection_tests_from_projects_dir(e2e_should_fail_dir())
-// }
+#[test]
+#[ignore = "Additional stress test for GC. Run it locally when working on code that affects GC."]
+fn garbage_collection_all_should_fail_tests() -> Result<(), String> {
+    run_garbage_collection_tests_from_projects_dir(e2e_should_fail_dir())
+}
 
-// #[test]
-// #[ignore = "Additional stress test for GC. Run it locally when working on code that affects GC."]
-// fn garbage_collection_all_stdlib_tests() -> Result<(), String> {
-//     run_garbage_collection_tests_from_projects_dir(e2e_stdlib_dir())
-// }
+#[test]
+#[ignore = "Additional stress test for GC. Run it locally when working on code that affects GC."]
+fn garbage_collection_all_stdlib_tests() -> Result<(), String> {
+    run_garbage_collection_tests_from_projects_dir(e2e_stdlib_dir())
+}
 
-// /// Parallel test runner for garbage collection tests across Sway projects defined by `tests`.
-// /// Each test in `tests` consists of a project name and the path to the file that will
-// /// be changed during the test (keystroke simulation will be in that file).
-// ///
-// /// # Overview
-// /// This test suite takes a unique approach to handling test isolation and error reporting:
-// ///
-// /// 1. Process Isolation: Each test is run in its own process to ensure complete isolation
-// ///    between test runs. This allows us to catch all failures rather than stopping at
-// ///    the first panic or error.
-// ///
-// /// 2. Parallel Execution: Uses rayon to run tests concurrently, significantly reducing
-// ///    total test time from several minutes to under a minute.
-// ///
-// /// 3. Full Coverage: Unlike traditional test approaches that stop at the first failure,
-// ///    this runner continues through all tests, providing a complete picture of which
-// ///    examples need garbage collection fixes.
-// ///
-// /// # Implementation Details
-// /// - Uses [std::process::Command] to spawn each test in isolation
-// /// - Collects results through a thread-safe [Mutex]
-// /// - Provides detailed error reporting for failed tests
-// /// - Categorizes different types of failures (exit codes vs signals)
-// fn run_garbage_collection_tests(
-//     tests: &[(String, PathBuf)],
-//     base_dir: Option<String>,
-// ) -> Result<(), String> {
-//     println!("\n=== Starting Garbage Collection Tests ===\n");
+/// Parallel test runner for garbage collection tests across Sway projects defined by `tests`.
+/// Each test in `tests` consists of a project name and the path to the file that will
+/// be changed during the test (keystroke simulation will be in that file).
+///
+/// # Overview
+/// This test suite takes a unique approach to handling test isolation and error reporting:
+///
+/// 1. Process Isolation: Each test is run in its own process to ensure complete isolation
+///    between test runs. This allows us to catch all failures rather than stopping at
+///    the first panic or error.
+///
+/// 2. Parallel Execution: Uses rayon to run tests concurrently, significantly reducing
+///    total test time from several minutes to under a minute.
+///
+/// 3. Full Coverage: Unlike traditional test approaches that stop at the first failure,
+///    this runner continues through all tests, providing a complete picture of which
+///    examples need garbage collection fixes.
+///
+/// # Implementation Details
+/// - Uses [std::process::Command] to spawn each test in isolation
+/// - Collects results through a thread-safe [Mutex]
+/// - Provides detailed error reporting for failed tests
+/// - Categorizes different types of failures (exit codes vs signals)
+fn run_garbage_collection_tests(
+    tests: &[(String, PathBuf)],
+    base_dir: Option<String>,
+) -> Result<(), String> {
+    println!("\n=== Starting Garbage Collection Tests ===\n");
 
-//     match base_dir {
-//         Some(base_dir) => {
-//             println!("▶ Testing {} project(s) in '{base_dir}'\n", tests.len());
-//         }
-//         None => {
-//             println!("▶ Testing {} project(s):", tests.len());
-//             let max_project_name_len = tests
-//                 .iter()
-//                 .map(|(project_name, _)| project_name.len())
-//                 .max()
-//                 .unwrap_or_default();
-//             tests.iter().for_each(|(project_name, test_file)| {
-//                 println!(
-//                     "- {project_name:<max_project_name_len$} {}",
-//                     test_file.display()
-//                 );
-//             });
-//             println!();
-//         }
-//     }
+    match base_dir {
+        Some(base_dir) => {
+            println!("▶ Testing {} project(s) in '{base_dir}'\n", tests.len());
+        }
+        None => {
+            println!("▶ Testing {} project(s):", tests.len());
+            let max_project_name_len = tests
+                .iter()
+                .map(|(project_name, _)| project_name.len())
+                .max()
+                .unwrap_or_default();
+            tests.iter().for_each(|(project_name, test_file)| {
+                println!(
+                    "- {project_name:<max_project_name_len$} {}",
+                    test_file.display()
+                );
+            });
+            println!();
+        }
+    }
 
-//     let results = Mutex::new(Vec::new());
+    let results = Mutex::new(Vec::new());
 
-//     println!("▶ Testing started\n");
-//     tests.par_iter().for_each(|(project_name, test_file)| {
-//         let test_file = test_file.to_string_lossy().to_string();
-//         let status = Command::new(std::env::current_exe().unwrap())
-//             .args([
-//                 "--test",
-//                 "test_single_garbage_collection_project",
-//                 "--exact",
-//                 "--nocapture",
-//                 "--ignored",
-//             ])
-//             .env("TEST_FILE", test_file.clone())
-//             .stdout(Stdio::null())
-//             .status()
-//             .unwrap();
+    println!("▶ Testing started\n");
+    tests.par_iter().for_each(|(project_name, test_file)| {
+        let test_file = test_file.to_string_lossy().to_string();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--test",
+                "test_single_garbage_collection_project",
+                "--exact",
+                "--nocapture",
+                "--ignored",
+            ])
+            .env("TEST_FILE", test_file.clone())
+            .stdout(Stdio::null())
+            .status()
+            .unwrap();
 
-//         let test_result = if status.success() {
-//             println!("  ✅ Passed: {}", project_name);
-//             (project_name, test_file, true, None)
-//         } else {
-//             println!("  ❌ Failed: {} ({})", project_name, status);
-//             (
-//                 project_name,
-//                 test_file,
-//                 false,
-//                 Some(format!("Exit code: {}", status)),
-//             )
-//         };
+        let test_result = if status.success() {
+            println!("  ✅ Passed: {}", project_name);
+            (project_name, test_file, true, None)
+        } else {
+            println!("  ❌ Failed: {} ({})", project_name, status);
+            (
+                project_name,
+                test_file,
+                false,
+                Some(format!("Exit code: {}", status)),
+            )
+        };
 
-//         results.lock().unwrap().push(test_result);
-//     });
-//     println!("\n▶ Testing finished");
+        results.lock().unwrap().push(test_result);
+    });
+    println!("\n▶ Testing finished");
 
-//     let results = results.into_inner().unwrap();
+    let results = results.into_inner().unwrap();
 
-//     println!("\n=== Garbage Collection Test Results ===\n");
+    println!("\n=== Garbage Collection Test Results ===\n");
 
-//     let total = results.len();
-//     let passed = results.iter().filter(|r| r.2).count();
-//     let failed = total - passed;
+    let total = results.len();
+    let passed = results.iter().filter(|r| r.2).count();
+    let failed = total - passed;
 
-//     println!("Total tests: {}", total);
-//     println!("✅ Passed:   {}", passed);
-//     println!("❌ Failed:   {}", failed);
-//     println!();
+    println!("Total tests: {}", total);
+    println!("✅ Passed:   {}", passed);
+    println!("❌ Failed:   {}", failed);
+    println!();
 
-//     if failed > 0 {
-//         println!("Failed projects:");
-//         for (project_name, test_file, _, error) in results.iter().filter(|r| !r.2) {
-//             println!("- Project: {project_name}");
-//             println!("  Path:    {test_file}");
-//             println!("  Error:   {}", error.as_ref().unwrap());
-//         }
+    if failed > 0 {
+        println!("Failed projects:");
+        for (project_name, test_file, _, error) in results.iter().filter(|r| !r.2) {
+            println!("- Project: {project_name}");
+            println!("  Path:    {test_file}");
+            println!("  Error:   {}", error.as_ref().unwrap());
+        }
 
-//         println!();
+        println!();
 
-//         Err(format!(
-//             "{} project(s) failed garbage collection testing",
-//             failed
-//         ))
-//     } else {
-//         Ok(())
-//     }
-// }
+        Err(format!(
+            "{} project(s) failed garbage collection testing",
+            failed
+        ))
+    } else {
+        Ok(())
+    }
+}
 
-// /// Test runner for garbage collection tests across all Sway projects found in the `projects_dir`.
-// /// Tests run in parallel and include only the projects that have `src/main.sw` file.
-// fn run_garbage_collection_tests_from_projects_dir(projects_dir: PathBuf) -> Result<(), String> {
-//     let base_dir = sway_workspace_dir().join(projects_dir);
-//     let mut tests: Vec<_> = std::fs::read_dir(base_dir.clone())
-//         .unwrap()
-//         .filter_map(|e| e.ok())
-//         .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
-//         .map(|dir_entry| {
-//             let project_dir = dir_entry.path();
-//             let project_name = project_dir
-//                 .file_name()
-//                 .unwrap()
-//                 .to_string_lossy()
-//                 .to_string();
-//             let main_file = project_dir.join("src/main.sw");
-//             (project_name, main_file)
-//         })
-//         .filter(|(_, main_file)| main_file.exists())
-//         .collect();
+/// Test runner for garbage collection tests across all Sway projects found in the `projects_dir`.
+/// Tests run in parallel and include only the projects that have `src/main.sw` file.
+fn run_garbage_collection_tests_from_projects_dir(projects_dir: PathBuf) -> Result<(), String> {
+    let base_dir = sway_workspace_dir().join(projects_dir);
+    let mut tests: Vec<_> = std::fs::read_dir(base_dir.clone())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .map(|dir_entry| {
+            let project_dir = dir_entry.path();
+            let project_name = project_dir
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+            let main_file = project_dir.join("src/main.sw");
+            (project_name, main_file)
+        })
+        .filter(|(_, main_file)| main_file.exists())
+        .collect();
 
-//     tests.sort();
+    tests.sort();
 
-//     run_garbage_collection_tests(&tests, Some(base_dir.to_string_lossy().to_string()))
-// }
+    run_garbage_collection_tests(&tests, Some(base_dir.to_string_lossy().to_string()))
+}
 
-// /// Individual test runner executed in a separate process for each test.
-// ///
-// /// This function is called by the main test runner through a new process invocation
-// /// for each test file. The file path is passed via the TEST_FILE environment
-// /// variable to maintain process isolation.
-// ///
-// /// # Process Isolation
-// /// Running each test in its own process ensures that:
-// /// 1. Tests are completely isolated from each other
-// /// 2. Panics in one test don't affect others
-// /// 3. Resource cleanup happens automatically on process exit
-// #[tokio::test]
-// #[ignore = "This test is meant to be run only indirectly through the tests that run GC in parallel."]
-// async fn test_single_garbage_collection_project() {
-//     if let Ok(test_file) = std::env::var("TEST_FILE") {
-//         let path = PathBuf::from(test_file);
-//         garbage_collection_runner(path).await;
-//     } else {
-//         panic!("TEST_FILE environment variable not set");
-//     }
-// }
+/// Individual test runner executed in a separate process for each test.
+///
+/// This function is called by the main test runner through a new process invocation
+/// for each test file. The file path is passed via the TEST_FILE environment
+/// variable to maintain process isolation.
+///
+/// # Process Isolation
+/// Running each test in its own process ensures that:
+/// 1. Tests are completely isolated from each other
+/// 2. Panics in one test don't affect others
+/// 3. Resource cleanup happens automatically on process exit
+#[tokio::test]
+#[ignore = "This test is meant to be run only indirectly through the tests that run GC in parallel."]
+async fn test_single_garbage_collection_project() {
+    if let Ok(test_file) = std::env::var("TEST_FILE") {
+        let path = PathBuf::from(test_file);
+        garbage_collection_runner(path).await;
+    } else {
+        panic!("TEST_FILE environment variable not set");
+    }
+}

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -142,7 +142,7 @@ fn initialize() {
             initialization_options: None,
             ..Default::default()
         };
-        let _ = request::handle_initialize(&service.inner(), &params);
+        let _ = request::handle_initialize(service.inner(), &params);
     });
 }
 
@@ -156,6 +156,8 @@ fn did_open() {
     });
 }
 
+// Opens all members in the examples workspace and assert that we are able to return semantic tokens for each workspace member.
+// This test is expected to run for a while although should be much faster once https://github.com/FuelLabs/sway/pull/7139 is merged.
 #[test]
 fn did_open_all_members_in_examples() {
     run_async!({
@@ -181,7 +183,8 @@ fn did_open_all_members_in_examples() {
                 .unwrap();
 
             // Open all workspace members and assert that we are able to return semantic tokens for each workspace member.
-            for (_name, package_manifest) in &member_manifests {
+            for (name, package_manifest) in &member_manifests {
+                eprintln!("compiling {:?}", name);
                 let dir = package_manifest.path().parent().unwrap();
 
                 // If the workspace is not initialized, we need to initialize it
@@ -202,7 +205,7 @@ fn did_open_all_members_in_examples() {
                 assert!(num_tokens_for_file > 0);
 
                 // Make sure that semantic tokens are successfully returned for the file
-                let semantic_tokens = lsp::get_semantic_tokens_full(&service.inner(), &uri).await;
+                let semantic_tokens = lsp::get_semantic_tokens_full(service.inner(), &uri).await;
                 assert!(semantic_tokens.data.len() > 0);
             }
         }
@@ -409,7 +412,7 @@ fn show_ast() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
         let uri = init_and_open(&mut service, e2e_test_dir().join("src/main.sw")).await;
-        lsp::show_ast_request(&service.inner(), &uri, "typed", None).await;
+        lsp::show_ast_request(service.inner(), &uri, "typed", None).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -420,7 +423,7 @@ fn visualize() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
         let uri = init_and_open(&mut service, e2e_test_dir().join("src/main.sw")).await;
-        lsp::visualize_request(&service.inner(), &uri, "build_plan").await;
+        lsp::visualize_request(service.inner(), &uri, "build_plan").await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -441,7 +444,7 @@ fn go_to_definition() {
             def_end_char: 11,
             def_path: uri.as_str(),
         };
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -465,14 +468,14 @@ fn go_to_definition_for_fields() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // Option
-        lsp::definition_check(&service.inner(), &opt_go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 5, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 9, 9).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 9, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 13, 12).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 13, 19).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 13, 34).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 13, 47).await;
+        lsp::definition_check(service.inner(), &opt_go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 5, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 9, 9).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 9, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 13, 12).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 13, 19).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 13, 34).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 13, 47).await;
 
         let opt_go_to = GotoDefinition {
             req_uri: &uri,
@@ -484,7 +487,7 @@ fn go_to_definition_for_fields() {
             def_path: "sway-lsp/tests/fixtures/tokens/fields/src/foo.sw",
         };
         // foo
-        lsp::definition_check(&service.inner(), &opt_go_to).await;
+        lsp::definition_check(service.inner(), &opt_go_to).await;
 
         let opt_go_to = GotoDefinition {
             req_uri: &uri,
@@ -496,7 +499,7 @@ fn go_to_definition_for_fields() {
             def_path: "sway-lsp/tests/fixtures/tokens/fields/src/foo.sw",
         };
         // Foo
-        lsp::definition_check(&service.inner(), &opt_go_to).await;
+        lsp::definition_check(service.inner(), &opt_go_to).await;
 
         shutdown_and_exit(&mut service).await;
     });
@@ -522,15 +525,15 @@ fn go_to_definition_inside_turbofish() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // option.sw
-        lsp::definition_check(&service.inner(), &opt_go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 16, 17).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 17, 29).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 18, 19).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 20, 13).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 21, 19).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 22, 29).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 23, 18).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut opt_go_to, 24, 26).await;
+        lsp::definition_check(service.inner(), &opt_go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 16, 17).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 17, 29).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 18, 19).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 20, 13).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 21, 19).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 22, 29).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 23, 18).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut opt_go_to, 24, 26).await;
 
         let mut res_go_to = GotoDefinition {
             req_uri: &uri,
@@ -542,11 +545,11 @@ fn go_to_definition_inside_turbofish() {
             def_path: "sway-lib-std/src/result.sw",
         };
         // result.sw
-        lsp::definition_check(&service.inner(), &res_go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut res_go_to, 21, 25).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut res_go_to, 22, 36).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut res_go_to, 23, 27).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut res_go_to, 24, 33).await;
+        lsp::definition_check(service.inner(), &res_go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut res_go_to, 21, 25).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut res_go_to, 22, 36).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut res_go_to, 23, 27).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut res_go_to, 24, 33).await;
 
         shutdown_and_exit(&mut service).await;
     });
@@ -572,13 +575,13 @@ fn go_to_definition_for_matches() {
             def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
         };
         // EXAMPLE_CONST
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 19, 18).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 22, 18).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 19, 18).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 22, 18).await;
         // TODO: Enable the below check once this issue is fixed: https://github.com/FuelLabs/sway/issues/5221
-        // lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 22, 30);
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 23, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 38).await;
+        // lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 22, 30);
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 23, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 38).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -590,7 +593,7 @@ fn go_to_definition_for_matches() {
             def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
         };
         // a => a + 1
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -602,13 +605,13 @@ fn go_to_definition_for_matches() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // Option
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 33).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 26, 11).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 27, 11).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 27, 22).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 11).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 22).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 33).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 26, 11).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 27, 11).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 27, 22).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 11).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 22).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -620,10 +623,10 @@ fn go_to_definition_for_matches() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // Some
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 27, 17).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 17).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 30).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 27, 17).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 17).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 30).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -635,8 +638,8 @@ fn go_to_definition_for_matches() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // None
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 27, 30).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 27, 30).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -648,7 +651,7 @@ fn go_to_definition_for_matches() {
             def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
         };
         // ExampleStruct
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -660,7 +663,7 @@ fn go_to_definition_for_matches() {
             def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
         };
         // ExampleStruct.variable
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         shutdown_and_exit(&mut service).await;
     });
@@ -686,9 +689,9 @@ fn go_to_definition_for_modules() {
             def_path: "sway-lsp/tests/fixtures/tokens/modules/src/test_mod.sw",
         };
         // mod test_mod;
-        lsp::definition_check(&service.inner(), &opt_go_to).await;
+        lsp::definition_check(service.inner(), &opt_go_to).await;
         let uri = open(
-            &service.inner(),
+            service.inner(),
             test_fixtures_dir().join("tokens/modules/src/test_mod.sw"),
         )
         .await;
@@ -703,7 +706,7 @@ fn go_to_definition_for_modules() {
             def_path: "sway-lsp/tests/fixtures/tokens/modules/src/test_mod/deep_mod.sw",
         };
         // mod deep_mod;
-        lsp::definition_check(&service.inner(), &opt_go_to).await;
+        lsp::definition_check(service.inner(), &opt_go_to).await;
 
         shutdown_and_exit(&mut service).await;
     });
@@ -729,11 +732,11 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/lib.sw",
         };
         // std
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 12, 14).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 16, 5).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 22, 13).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 7, 5).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 12, 14).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 16, 5).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 22, 13).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 7, 5).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -745,7 +748,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // option
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -757,8 +760,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // Option
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 14).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 14).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -770,7 +773,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/vm.sw",
         };
         // vm
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -782,7 +785,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/vm/evm.sw",
         };
         // evm
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -794,7 +797,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
         };
         // evm_address
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -806,7 +809,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
         };
         // EvmAddress
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -818,9 +821,9 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
         };
         // test_mod
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 20, 7).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 5, 5).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 20, 7).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 5, 5).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -832,7 +835,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
         };
         // test_fun
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -844,14 +847,14 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod.sw",
         };
         // deep_mod
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 6, 6).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 26, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 27, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 30, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 31, 16).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 6, 6).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 26, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 27, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 30, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 31, 16).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -863,14 +866,14 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // deeper_mod
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 6, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 28).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 26, 28).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 27, 28).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 28).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 30, 28).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 31, 28).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 6, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 28).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 26, 28).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 27, 28).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 28).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 30, 28).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 31, 28).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -882,10 +885,10 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // DeepEnum
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 26, 38).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 27, 38).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 38).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 26, 38).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 27, 38).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 38).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -897,8 +900,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // DeepStruct
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 31, 37).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 31, 37).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -910,8 +913,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // DeepEnum::Variant
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 26, 48).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 26, 48).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -923,8 +926,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // DeepEnum::Number
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 48).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 48).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -936,8 +939,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // deep_fun
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 6, 28).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 6, 28).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -949,7 +952,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/assert.sw",
         };
         // assert
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -961,7 +964,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod.sw",
         };
         // std
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -973,7 +976,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // primitives
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -985,7 +988,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/primitives.sw",
         };
         // primitives
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -997,7 +1000,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
         };
         // A def
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1009,8 +1012,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
         };
         // A impl
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 20, 14).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 20, 14).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1022,8 +1025,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
         };
         // fun
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 20, 18).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 20, 18).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1035,9 +1038,9 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/constants.sw",
         };
         // constants
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 7, 11).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 7, 23).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 7, 11).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 7, 23).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1049,8 +1052,8 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/constants.sw",
         };
         // ZERO_B256
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 7, 31).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 7, 31).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1062,7 +1065,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/primitives.sw",
         };
         // u64::min()
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1074,7 +1077,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lib-std/src/primitives.sw",
         };
         // b256::min()
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1086,7 +1089,7 @@ fn go_to_definition_for_paths() {
             def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // dfun
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         shutdown_and_exit(&mut service).await;
     });
@@ -1112,13 +1115,13 @@ fn go_to_definition_for_traits() {
             def_path: "sway-lsp/tests/fixtures/tokens/traits/src/traits.sw",
         };
 
-        lsp::definition_check(&service.inner(), &trait_go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut trait_go_to, 7, 10).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut trait_go_to, 10, 6).await;
+        lsp::definition_check(service.inner(), &trait_go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut trait_go_to, 7, 10).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut trait_go_to, 10, 6).await;
         trait_go_to.req_line = 7;
         trait_go_to.req_char = 20;
         trait_go_to.def_line = 3;
-        lsp::definition_check(&service.inner(), &trait_go_to).await;
+        lsp::definition_check(service.inner(), &trait_go_to).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1143,74 +1146,74 @@ fn go_to_definition_for_variables() {
             def_path: uri.as_str(),
         };
         // Variable expressions
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         // Function arguments
         go_to.def_line = 20;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 35).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 35).await;
 
         // Struct fields
         go_to.def_line = 19;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 28, 45).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 28, 45).await;
 
         // Enum fields
         go_to.def_line = 19;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 31, 39).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 31, 39).await;
 
         // Tuple elements
         go_to.def_line = 21;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 34, 20).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 34, 20).await;
 
         // Array elements
         go_to.def_line = 22;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 37, 20).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 37, 20).await;
 
         // Scoped declarations
         go_to.def_line = 41;
         go_to.def_start_char = 12;
         go_to.def_end_char = 21;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 42, 13).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 42, 13).await;
 
         // If let scopes
         go_to.def_line = 47;
         go_to.def_start_char = 38;
         go_to.def_end_char = 39;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 47, 47).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 47, 47).await;
 
         // Shadowing
         go_to.def_line = 47;
         go_to.def_start_char = 8;
         go_to.def_end_char = 17;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 50, 29).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 50, 29).await;
 
         // Variable type ascriptions
         go_to.def_line = 6;
         go_to.def_start_char = 5;
         go_to.def_end_char = 16;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 53, 21).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 53, 21).await;
 
         // Complex type ascriptions
         go_to.def_line = 65;
         go_to.def_start_char = 9;
         go_to.def_end_char = 15;
         go_to.def_path = "sway-lib-std/src/result.sw";
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 56, 22).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 31).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 60).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 56, 22).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 31).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 60).await;
         go_to.def_line = 85;
         go_to.def_path = "sway-lib-std/src/option.sw";
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 56, 28).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 39).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 68).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 56, 28).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 39).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 68).await;
 
         // ContractCaller
         go_to.def_line = 15;
         go_to.def_start_char = 4;
         go_to.def_end_char = 11;
         go_to.def_path = uri.as_str();
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 60, 34).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 60, 50).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 61, 50).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 60, 34).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 60, 50).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 61, 50).await;
 
         shutdown_and_exit(&mut service).await;
     });
@@ -1236,14 +1239,14 @@ fn go_to_definition_for_consts() {
             def_end_char: 21,
             def_path: "sway-lib-std/src/contract_id.sw",
         };
-        lsp::definition_check(&service.inner(), &contract_go_to).await;
+        lsp::definition_check(service.inner(), &contract_go_to).await;
 
         // value: `from`
         contract_go_to.req_char = 34;
         contract_go_to.def_line = 63;
         contract_go_to.def_start_char = 7;
         contract_go_to.def_end_char = 11;
-        lsp::definition_check(&service.inner(), &contract_go_to).await;
+        lsp::definition_check(service.inner(), &contract_go_to).await;
 
         // Constants defined in the same module
         let mut go_to = GotoDefinition {
@@ -1255,10 +1258,10 @@ fn go_to_definition_for_consts() {
             def_end_char: 16,
             def_path: uri.as_str(),
         };
-        lsp::definition_check(&service.inner(), &contract_go_to).await;
+        lsp::definition_check(service.inner(), &contract_go_to).await;
 
         go_to.def_line = 9;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 21, 29).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 21, 29).await;
 
         // Constants defined in a different module
         go_to = GotoDefinition {
@@ -1270,27 +1273,27 @@ fn go_to_definition_for_consts() {
             def_end_char: 20,
             def_path: "consts/src/more_consts.sw",
         };
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         go_to.def_line = 13;
         go_to.def_start_char = 10;
         go_to.def_end_char = 18;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 31).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 31).await;
 
         // Constants with type ascriptions
         go_to.def_line = 6;
         go_to.def_start_char = 5;
         go_to.def_end_char = 9;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 10, 17).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 10, 17).await;
 
         // Complex type ascriptions
         go_to.def_line = 85;
         go_to.def_start_char = 9;
         go_to.def_end_char = 15;
         go_to.def_path = "sway-lib-std/src/option.sw";
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 17).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 24).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 11, 38).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 17).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 24).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 11, 38).await;
     });
 }
 
@@ -1314,35 +1317,35 @@ fn go_to_definition_for_functions() {
             def_path: uri.as_str(),
         };
         // Return type
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
         go_to.def_line = 23;
         go_to.def_start_char = 9;
         go_to.def_end_char = 15;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 33, 42).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 33, 42).await;
         go_to.def_line = 28;
         go_to.def_start_char = 9;
         go_to.def_end_char = 18;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 33, 55).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 33, 55).await;
 
         // Function parameters
         go_to.def_line = 2;
         go_to.def_start_char = 7;
         go_to.def_end_char = 12;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 13, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 13, 16).await;
         go_to.def_line = 23;
         go_to.def_start_char = 9;
         go_to.def_end_char = 15;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 33, 18).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 33, 18).await;
         go_to.def_line = 28;
         go_to.def_start_char = 9;
         go_to.def_end_char = 18;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 33, 28).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 33, 28).await;
 
         // Functions expression
         go_to.def_line = 8;
         go_to.def_start_char = 3;
         go_to.def_end_char = 6;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 19, 13).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 19, 13).await;
     });
 }
 
@@ -1367,15 +1370,15 @@ fn go_to_definition_for_structs() {
             def_path: uri.as_str(),
         };
         // Type Params
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
         go_to.def_line = 3;
         go_to.def_start_char = 5;
         go_to.def_end_char = 9;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 12, 8).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 13, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 14, 9).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 15, 16).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 15, 23).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 12, 8).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 13, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 14, 9).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 15, 16).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 15, 23).await;
         go_to = GotoDefinition {
             req_uri: &uri,
             req_line: 16,
@@ -1386,7 +1389,7 @@ fn go_to_definition_for_structs() {
             def_path: "sway-lib-std/src/option.sw",
         };
         // Type Params
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         // Call Path
         go_to = GotoDefinition {
@@ -1398,7 +1401,7 @@ fn go_to_definition_for_structs() {
             def_end_char: 13,
             def_path: uri.as_str(),
         };
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
     });
 }
 
@@ -1422,10 +1425,10 @@ fn go_to_definition_for_impls() {
             def_path: uri.as_str(),
         };
         // TestStruct
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 7, 33).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 8, 17).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 8, 27).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 7, 33).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 8, 17).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 8, 27).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1437,7 +1440,7 @@ fn go_to_definition_for_impls() {
             def_path: uri.as_str(),
         };
         // TestTrait
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
     });
 }
 
@@ -1461,8 +1464,8 @@ fn go_to_definition_for_where_clause() {
             def_path: uri.as_str(),
         };
         // Trait1
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 7, 8).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 7, 8).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1474,7 +1477,7 @@ fn go_to_definition_for_where_clause() {
             def_path: uri.as_str(),
         };
         // Trait2
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1486,7 +1489,7 @@ fn go_to_definition_for_where_clause() {
             def_path: uri.as_str(),
         };
         // A
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1498,7 +1501,7 @@ fn go_to_definition_for_where_clause() {
             def_path: uri.as_str(),
         };
         // B
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
     });
 }
 
@@ -1522,28 +1525,28 @@ fn go_to_definition_for_enums() {
             def_path: uri.as_str(),
         };
         // Type Params
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
         go_to.def_line = 8;
         go_to.def_start_char = 5;
         go_to.def_end_char = 10;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 17, 15).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 18, 20).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 17, 15).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 18, 20).await;
 
         // Variants
         go_to.def_line = 9;
         go_to.def_start_char = 4;
         go_to.def_end_char = 7;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 24, 21).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 24, 21).await;
         go_to.def_line = 20;
         go_to.def_start_char = 4;
         go_to.def_end_char = 10;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 31).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 31).await;
 
         // Call Path
         go_to.def_line = 15;
         go_to.def_start_char = 9;
         go_to.def_end_char = 15;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 23).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 23).await;
     });
 }
 
@@ -1567,14 +1570,14 @@ fn go_to_definition_for_abi() {
             def_path: uri.as_str(),
         };
         // Return type
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         // Abi name
         go_to.def_line = 5;
         go_to.def_start_char = 4;
         go_to.def_end_char = 14;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 9, 11).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 16, 15).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 9, 11).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 16, 15).await;
     });
 }
 
@@ -1598,9 +1601,9 @@ fn go_to_definition_for_storage() {
             def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
         };
         // storage
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 8).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 26, 8).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 8).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 26, 8).await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1612,9 +1615,9 @@ fn go_to_definition_for_storage() {
             def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
         };
         // storage.var1
-        lsp::definition_check(&service.inner(), &go_to).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 25, 17).await;
-        lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 26, 17).await;
+        lsp::definition_check(service.inner(), &go_to).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 25, 17).await;
+        lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 26, 17).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1626,7 +1629,7 @@ fn go_to_definition_for_storage() {
             def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
         };
         // storage.var1.x
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1638,7 +1641,7 @@ fn go_to_definition_for_storage() {
             def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
         };
         // storage.var1.y
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1650,7 +1653,7 @@ fn go_to_definition_for_storage() {
             def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
         };
         // storage.var1.z
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -1662,7 +1665,7 @@ fn go_to_definition_for_storage() {
             def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
         };
         // storage.var1.z.x
-        lsp::definition_check(&service.inner(), &go_to).await;
+        lsp::definition_check(service.inner(), &go_to).await;
 
         shutdown_and_exit(&mut service).await;
     });
@@ -1687,10 +1690,10 @@ fn hover_docs_for_consts() {
             documentation: vec![" documentation for CONSTANT_1"],
         };
 
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_char = 49;
         hover.documentation = vec![" CONSTANT_2 has a value of 200"];
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1712,7 +1715,7 @@ fn hover_docs_for_functions_vscode() {
         req_char: 14,
         documentation: vec!["```sway\npub fn bar(p: Point) -> Point\n```\n---\n A function declaration with struct as a function parameter\n\n---\nGo to [Point](command:sway.goToLocation?%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A5%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Ftokens%2Ffunctions%2Fsrc%2Fmain.sw%22%7D%5D \"functions::Point\")"],
     };
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1734,16 +1737,16 @@ fn hover_docs_for_structs() {
             req_char: 10,
             documentation: vec![data_documentation],
         };
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_line = 13;
         hover.req_char = 15;
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_line = 14;
         hover.req_char = 10;
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_line = 15;
         hover.req_char = 16;
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
 
         hover = HoverDocumentation {
             req_uri: &uri,
@@ -1751,7 +1754,7 @@ fn hover_docs_for_structs() {
             req_char: 8,
             documentation: vec!["```sway\nstruct MyStruct\n```\n---\n My struct type"],
         };
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1772,15 +1775,15 @@ fn hover_docs_for_enums() {
             req_char: 19,
             documentation: vec!["```sway\nstruct TestStruct\n```\n---\n Test Struct Docs"],
         };
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_line = 18;
         hover.req_char = 20;
         hover.documentation = vec!["```sway\nenum Color\n```\n---\n Color enum with RGB variants"];
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_line = 25;
         hover.req_char = 29;
         hover.documentation = vec![" Docs for variants"];
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1801,7 +1804,7 @@ fn hover_docs_for_abis() {
             req_char: 14,
             documentation: vec!["```sway\nabi MyContract\n```\n---\n Docs for MyContract"],
         };
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1822,7 +1825,7 @@ fn hover_docs_for_variables() {
             req_char: 14,
             documentation: vec!["```sway\nlet variable8: ContractCaller<TestAbi>\n```\n---"],
         };
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1839,7 +1842,7 @@ fn hover_docs_with_code_examples() {
             req_char: 24,
             documentation: vec!["```sway\nstruct Data\n```\n---\n Struct holding:\n\n 1. A `value` of type `NumberOrString`\n 2. An `address` of type `u64`"],
         };
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1862,7 +1865,7 @@ fn hover_docs_for_self_keywords_vscode() {
             documentation: vec!["\n```sway\nself\n```\n\n---\n\n The receiver of a method, or the current module.\n\n `self` is used in two situations: referencing the current module and marking\n the receiver of a method.\n\n In paths, `self` can be used to refer to the current module, either in a\n [`use`] statement or in a path to access an element:\n\n ```sway\n use std::contract_id::{self, ContractId};\n ```\n\n Is functionally the same as:\n\n ```sway\n use std::contract_id;\n use std::contract_id::ContractId;\n ```\n\n `self` as the current receiver for a method allows to omit the parameter\n type most of the time. With the exception of this particularity, `self` is\n used much like any other parameter:\n\n ```sway\n struct Foo(u32);\n\n impl Foo {\n     // No `self`.\n     fn new() -> Self {\n         Self(0)\n     }\n\n     // Borrowing `self`.\n     fn value(&self) -> u32 {\n         self.0\n     }\n\n     // Updating `self` mutably.\n     fn clear(ref mut self) {\n         self.0 = 0\n     }\n }\n ```"],
         };
 
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_char = 24;
         hover.documentation = vec![
             "```sway\nstruct MyStruct\n```\n---\n\n---\n[3 implementations]",
@@ -1871,7 +1874,7 @@ fn hover_docs_for_self_keywords_vscode() {
             "sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.%25253Cautogenerated%25253E.sw%22%7D%5D%7D%5D",
             "\"Go to implementations\")"
         ];
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1893,7 +1896,7 @@ fn hover_docs_for_self_keywords() {
             documentation: vec!["\n```sway\nself\n```\n\n---\n\n The receiver of a method, or the current module.\n\n `self` is used in two situations: referencing the current module and marking\n the receiver of a method.\n\n In paths, `self` can be used to refer to the current module, either in a\n [`use`] statement or in a path to access an element:\n\n ```sway\n use std::contract_id::{self, ContractId};\n ```\n\n Is functionally the same as:\n\n ```sway\n use std::contract_id;\n use std::contract_id::ContractId;\n ```\n\n `self` as the current receiver for a method allows to omit the parameter\n type most of the time. With the exception of this particularity, `self` is\n used much like any other parameter:\n\n ```sway\n struct Foo(u32);\n\n impl Foo {\n     // No `self`.\n     fn new() -> Self {\n         Self(0)\n     }\n\n     // Borrowing `self`.\n     fn value(&self) -> u32 {\n         self.0\n     }\n\n     // Updating `self` mutably.\n     fn clear(ref mut self) {\n         self.0 = 0\n     }\n }\n ```"],
         };
 
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1915,11 +1918,11 @@ fn hover_docs_for_boolean_keywords() {
         documentation: vec!["\n```sway\nfalse\n```\n\n---\n\n A value of type [`bool`] representing logical **false**.\n\n `false` is the logical opposite of [`true`].\n\n See the documentation for [`true`] for more information."],
     };
 
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         hover.req_line = 25;
         hover.req_char = 31;
         hover.documentation = vec!["\n```sway\ntrue\n```\n\n---\n\n A value of type [`bool`] representing logical **true**.\n\n Logically `true` is not equal to [`false`].\n\n ## Control structures that check for **true**\n\n Several of Sway's control structures will check for a `bool` condition evaluating to **true**.\n\n   * The condition in an [`if`] expression must be of type `bool`.\n     Whenever that condition evaluates to **true**, the `if` expression takes\n     on the value of the first block. If however, the condition evaluates\n     to `false`, the expression takes on value of the `else` block if there is one.\n\n   * [`while`] is another control flow construct expecting a `bool`-typed condition.\n     As long as the condition evaluates to **true**, the `while` loop will continually\n     evaluate its associated block.\n\n   * [`match`] arms can have guard clauses on them."];
-        lsp::hover_request(&service.inner(), &hover).await;
+        lsp::hover_request(service.inner(), &hover).await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -1941,8 +1944,8 @@ fn rename() {
             req_char: 19,
             new_name: "pnt", // from "point"
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let _ = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let _ = lsp::rename_request(service.inner(), &rename).await;
 
         // Enum
         let rename = Rename {
@@ -1951,8 +1954,8 @@ fn rename() {
             req_char: 17,
             new_name: "MyEnum", // from "Color"
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let _ = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let _ = lsp::rename_request(service.inner(), &rename).await;
 
         // Enum Variant
         let rename = Rename {
@@ -1961,8 +1964,8 @@ fn rename() {
             req_char: 20,
             new_name: "Pink", // from "Red"
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let _ = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let _ = lsp::rename_request(service.inner(), &rename).await;
 
         // raw identifier syntax
         let rename = Rename {
@@ -1971,8 +1974,8 @@ fn rename() {
             req_char: 16,
             new_name: "new_var_name", // from r#struct
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let _ = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let _ = lsp::rename_request(service.inner(), &rename).await;
 
         // Function name defined in external module
         let rename = Rename {
@@ -1981,8 +1984,8 @@ fn rename() {
             req_char: 25,
             new_name: "better_func_name", // from test_fun
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let _ = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let _ = lsp::rename_request(service.inner(), &rename).await;
 
         // Function method in ABI declaration
         let rename = Rename {
@@ -1991,8 +1994,8 @@ fn rename() {
             req_char: 16,
             new_name: "name_func_name", // from test_function
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let _ = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let _ = lsp::rename_request(service.inner(), &rename).await;
 
         // Function method in ABI implementation
         let rename = Rename {
@@ -2001,8 +2004,8 @@ fn rename() {
             req_char: 16,
             new_name: "name_func_name", // from test_function
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let _ = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let _ = lsp::rename_request(service.inner(), &rename).await;
 
         // Type alias used in function call
         let rename = Rename {
@@ -2011,8 +2014,8 @@ fn rename() {
             req_char: 8,
             new_name: "Alias11", // from Alias1
         };
-        let _ = lsp::prepare_rename_request(&service.inner(), &rename).await;
-        let result = lsp::rename_request(&service.inner(), &rename).await;
+        let _ = lsp::prepare_rename_request(service.inner(), &rename).await;
+        let result = lsp::rename_request(service.inner(), &rename).await;
         assert_eq!(result.changes.unwrap().values().next().unwrap().len(), 3);
 
         // Fail to rename keyword
@@ -2023,7 +2026,7 @@ fn rename() {
             new_name: "StruCt", // from struct
         };
         assert_eq!(
-            lsp::prepare_rename_request(&service.inner(), &rename).await,
+            lsp::prepare_rename_request(service.inner(), &rename).await,
             None
         );
 
@@ -2035,7 +2038,7 @@ fn rename() {
             new_name: "new_mod_name", // from std
         };
         assert_eq!(
-            lsp::prepare_rename_request(&service.inner(), &rename).await,
+            lsp::prepare_rename_request(service.inner(), &rename).await,
             None
         );
 
@@ -2047,7 +2050,7 @@ fn rename() {
             new_name: "NEW_TYPE_NAME", // from ZERO_B256
         };
         assert_eq!(
-            lsp::prepare_rename_request(&service.inner(), &rename).await,
+            lsp::prepare_rename_request(service.inner(), &rename).await,
             None
         );
         shutdown_and_exit(&mut service).await;
@@ -2247,9 +2250,9 @@ async fn write_all_example_asts() {
 
             let uri = init_and_open(&mut service, manifest_dir.join("src/main.sw")).await;
             let example_dir = Some(Url::from_file_path(example_dir).unwrap());
-            lsp::show_ast_request(&service.inner(), &uri, "lexed", example_dir.clone()).await;
-            lsp::show_ast_request(&service.inner(), &uri, "parsed", example_dir.clone()).await;
-            lsp::show_ast_request(&service.inner(), &uri, "typed", example_dir).await;
+            lsp::show_ast_request(service.inner(), &uri, "lexed", example_dir.clone()).await;
+            lsp::show_ast_request(service.inner(), &uri, "parsed", example_dir.clone()).await;
+            lsp::show_ast_request(service.inner(), &uri, "typed", example_dir).await;
         }
     }
     shutdown_and_exit(&mut service).await;

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -163,7 +163,7 @@ fn did_open_all_members_in_examples() {
         let examples_workspace_dir = sway_workspace_dir().join("examples");
         let _test_programs_workspace_dir = sway_workspace_dir().join(in_language_test_dir());
         let _sdk_harness_workspace_dir = sway_workspace_dir().join(sdk_harness_test_projects_dir());
-        
+
         // TODO: Support multiple workspaces: https://github.com/FuelLabs/sway/issues/7177
         let workspace_dirs = vec![
             &examples_workspace_dir,
@@ -171,41 +171,10 @@ fn did_open_all_members_in_examples() {
             //&sdk_harness_workspace_dir,
         ];
 
-        // Open up the arrays example in the examples workspace
-        //let arrays_dir = examples_workspace_dir.join("arrays");
-        //let address_inline_tests_dir = test_programs_workspace_dir.join("test_programs/address_inline_tests");
-        //let call_frames_dir = sdk_harness_workspace_dir.join("test_projects/call_frames");
-
-        // This example opens and passes here but if you open it in the editor its obviously not working. Improve this test tomorrow!
-        //let uri = init_and_open(&mut service, arrays_dir.join("src/main.sw")).await;
-        //service.inner().wait_for_parsing().await;
-
-        // // Assert that we found the correct workspace manifest file
-        // let workspace_manifest_path = service
-        //     .inner()
-        //     .sync_workspace
-        //     .get()
-        //     .unwrap()
-        //     .workspace_manifest_path()
-        //     .unwrap();
-        // assert!(workspace_manifest_path.ends_with("sway/examples/Forc.toml"));
-        // eprintln!("workspace manifest: {:?}", workspace_manifest_path);
-
-        // let range = lsp::range_from_start_and_end_line(0, 34);
-        // let inlay_hints = lsp::get_inlay_hints_for_range(&service.inner(), &uri, range).await;
-        // assert!(inlay_hints.len() > 0);
-
-        // let document_symbols = lsp::get_nested_document_symbols(&service.inner(), &uri).await;
-        // assert!(document_symbols.len() > 0);
-
-        // let semantic_tokens = lsp::get_semantic_tokens_full(&service.inner(), &uri).await;
-        // assert!(semantic_tokens.data.len() > 0);
-
         //----------------------------------
         for workspace_dir in workspace_dirs {
             // we need to init and open if this is the first time we are opening a workspace
             // TODO: https://github.com/FuelLabs/sway/issues/7177
-            eprintln!("---- opening workspace: {:?}", workspace_dir);
             let member_manifests = ManifestFile::from_dir(workspace_dir)
                 .unwrap()
                 .member_manifests()
@@ -213,7 +182,6 @@ fn did_open_all_members_in_examples() {
 
             // Open all workspace members and assert that we are able to return semantic tokens for each workspace member.
             for (name, package_manifest) in &member_manifests {
-                eprintln!("opening workspace member: {:?}", name);
                 let dir = package_manifest.path().parent().unwrap();
 
                 // If the workspace is not initialized, we need to initialize it
@@ -238,7 +206,6 @@ fn did_open_all_members_in_examples() {
                 assert!(semantic_tokens.data.len() > 0);
             }
         }
-
         shutdown_and_exit(&mut service).await;
     });
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -64,7 +64,7 @@ async fn open(server: &ServerState, entry_point: PathBuf) -> Url {
 
 async fn init_and_open(service: &mut LspService<ServerState>, entry_point: PathBuf) -> Url {
     let _ = lsp::initialize_request(service, &entry_point).await;
-    let _ =lsp::initialized_notification(service).await;
+    let _ = lsp::initialized_notification(service).await;
     let (uri, sway_program) = load_sway_example(entry_point);
     lsp::did_open_notification(service, &uri, &sway_program).await;
     uri
@@ -198,9 +198,15 @@ fn sync_with_updates_to_manifest_in_workspace() {
             .unwrap();
         let build_plan = session
             .build_plan_cache
-            .get_or_update(&service.inner().sync_workspace.get().unwrap().manifest_path(), || {
-                sway_lsp::core::session::build_plan(&uri)
-            })
+            .get_or_update(
+                &service
+                    .inner()
+                    .sync_workspace
+                    .get()
+                    .unwrap()
+                    .manifest_path(),
+                || sway_lsp::core::session::build_plan(&uri),
+            )
             .unwrap();
         assert_eq!(build_plan.compilation_order().len(), 3);
 
@@ -334,7 +340,11 @@ fn did_change_stress_test_random_wait() {
 fn compilation_succeeds_when_triggered_from_module() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/modules/src/test_mod.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/modules/src/test_mod.sw"),
+        )
+        .await;
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -385,7 +395,8 @@ fn go_to_definition() {
 fn go_to_definition_for_fields() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service,
+        let uri = init_and_open(
+            &mut service,
             test_fixtures_dir().join("tokens/fields/src/main.sw"),
         )
         .await;
@@ -440,7 +451,11 @@ fn go_to_definition_for_fields() {
 fn go_to_definition_inside_turbofish() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/turbofish/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/turbofish/src/main.sw"),
+        )
+        .await;
 
         let mut opt_go_to = GotoDefinition {
             req_uri: &uri,
@@ -486,7 +501,11 @@ fn go_to_definition_inside_turbofish() {
 fn go_to_definition_for_matches() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/matches/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/matches/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -596,7 +615,11 @@ fn go_to_definition_for_matches() {
 fn go_to_definition_for_modules() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/modules/src/lib.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/modules/src/lib.sw"),
+        )
+        .await;
 
         let opt_go_to = GotoDefinition {
             req_uri: &uri,
@@ -609,7 +632,11 @@ fn go_to_definition_for_modules() {
         };
         // mod test_mod;
         lsp::definition_check(&service.inner(), &opt_go_to).await;
-        let uri = open(&service.inner(), test_fixtures_dir().join("tokens/modules/src/test_mod.sw")).await;
+        let uri = open(
+            &service.inner(),
+            test_fixtures_dir().join("tokens/modules/src/test_mod.sw"),
+        )
+        .await;
 
         let opt_go_to = GotoDefinition {
             req_uri: &uri,
@@ -631,7 +658,11 @@ fn go_to_definition_for_modules() {
 fn go_to_definition_for_paths() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/paths/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/paths/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1010,7 +1041,11 @@ fn go_to_definition_for_paths() {
 fn go_to_definition_for_traits() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/traits/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/traits/src/main.sw"),
+        )
+        .await;
 
         let mut trait_go_to = GotoDefinition {
             req_uri: &uri,
@@ -1037,7 +1072,11 @@ fn go_to_definition_for_traits() {
 fn go_to_definition_for_variables() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/variables/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/variables/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1126,7 +1165,11 @@ fn go_to_definition_for_variables() {
 fn go_to_definition_for_consts() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/consts/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/consts/src/main.sw"),
+        )
+        .await;
 
         // value: TyExpression: `ContractId`
         let mut contract_go_to = GotoDefinition {
@@ -1200,7 +1243,11 @@ fn go_to_definition_for_consts() {
 fn go_to_definition_for_functions() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/functions/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/functions/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1249,7 +1296,11 @@ fn go_to_definition_for_functions() {
 fn go_to_definition_for_structs() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/structs/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/structs/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1300,7 +1351,11 @@ fn go_to_definition_for_structs() {
 fn go_to_definition_for_impls() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/impls/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/impls/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1335,7 +1390,11 @@ fn go_to_definition_for_impls() {
 fn go_to_definition_for_where_clause() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/where_clause/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/where_clause/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1392,7 +1451,11 @@ fn go_to_definition_for_where_clause() {
 fn go_to_definition_for_enums() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/enums/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/enums/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1433,7 +1496,11 @@ fn go_to_definition_for_enums() {
 fn go_to_definition_for_abi() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/abi/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/abi/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1460,7 +1527,11 @@ fn go_to_definition_for_abi() {
 fn go_to_definition_for_storage() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/storage/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/storage/src/main.sw"),
+        )
+        .await;
 
         let mut go_to = GotoDefinition {
             req_uri: &uri,
@@ -1548,7 +1619,11 @@ fn go_to_definition_for_storage() {
 fn hover_docs_for_consts() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/consts/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/consts/src/main.sw"),
+        )
+        .await;
 
         let mut hover = HoverDocumentation {
             req_uri: &uri,
@@ -1570,7 +1645,11 @@ fn hover_docs_for_functions_vscode() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
         service.inner().config.write().client = LspClient::VsCode;
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/functions/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/functions/src/main.sw"),
+        )
+        .await;
 
         let hover = HoverDocumentation {
         req_uri: &uri,
@@ -1587,7 +1666,11 @@ fn hover_docs_for_functions_vscode() {
 fn hover_docs_for_structs() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/structs/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/structs/src/main.sw"),
+        )
+        .await;
         let data_documentation = "```sway\nenum Data\n```\n---\n My data enum";
 
         let mut hover = HoverDocumentation {
@@ -1622,7 +1705,11 @@ fn hover_docs_for_structs() {
 fn hover_docs_for_enums() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/enums/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/enums/src/main.sw"),
+        )
+        .await;
 
         let mut hover = HoverDocumentation {
             req_uri: &uri,
@@ -1647,7 +1734,11 @@ fn hover_docs_for_enums() {
 fn hover_docs_for_abis() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/abi/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/abi/src/main.sw"),
+        )
+        .await;
 
         let hover = HoverDocumentation {
             req_uri: &uri,
@@ -1664,7 +1755,11 @@ fn hover_docs_for_abis() {
 fn hover_docs_for_variables() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/variables/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/variables/src/main.sw"),
+        )
+        .await;
 
         let hover = HoverDocumentation {
             req_uri: &uri,
@@ -1699,7 +1794,11 @@ fn hover_docs_for_self_keywords_vscode() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
         service.inner().config.write().client = LspClient::VsCode;
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("completion/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("completion/src/main.sw"),
+        )
+        .await;
 
         let mut hover = HoverDocumentation {
             req_uri: &uri,
@@ -1726,7 +1825,11 @@ fn hover_docs_for_self_keywords_vscode() {
 fn hover_docs_for_self_keywords() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("completion/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("completion/src/main.sw"),
+        )
+        .await;
 
         let hover = HoverDocumentation {
             req_uri: &uri,
@@ -1744,7 +1847,11 @@ fn hover_docs_for_self_keywords() {
 fn hover_docs_for_boolean_keywords() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("tokens/storage/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("tokens/storage/src/main.sw"),
+        )
+        .await;
 
         let mut hover = HoverDocumentation {
         req_uri: &uri,
@@ -1766,7 +1873,11 @@ fn hover_docs_for_boolean_keywords() {
 fn rename() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let uri = init_and_open(&mut service, test_fixtures_dir().join("renaming/src/main.sw")).await;
+        let uri = init_and_open(
+            &mut service,
+            test_fixtures_dir().join("renaming/src/main.sw"),
+        )
+        .await;
 
         // Struct expression variable
         let rename = Rename {
@@ -1856,7 +1967,10 @@ fn rename() {
             req_char: 2,
             new_name: "StruCt", // from struct
         };
-        assert_eq!(lsp::prepare_rename_request(&service.inner(), &rename).await, None);
+        assert_eq!(
+            lsp::prepare_rename_request(&service.inner(), &rename).await,
+            None
+        );
 
         // Fail to rename module
         let rename = Rename {
@@ -1865,7 +1979,10 @@ fn rename() {
             req_char: 13,
             new_name: "new_mod_name", // from std
         };
-        assert_eq!(lsp::prepare_rename_request(&service.inner(), &rename).await, None);
+        assert_eq!(
+            lsp::prepare_rename_request(&service.inner(), &rename).await,
+            None
+        );
 
         // Fail to rename a type defined in a module outside of the users workspace
         let rename = Rename {
@@ -1874,7 +1991,10 @@ fn rename() {
             req_char: 33,
             new_name: "NEW_TYPE_NAME", // from ZERO_B256
         };
-        assert_eq!(lsp::prepare_rename_request(&service.inner(), &rename).await, None);
+        assert_eq!(
+            lsp::prepare_rename_request(&service.inner(), &rename).await,
+            None
+        );
         shutdown_and_exit(&mut service).await;
     });
 }
@@ -2043,7 +2163,6 @@ async fn write_all_example_asts() {
     let _ = lsp::initialize_request(&mut service, &ast_folder).await;
     lsp::initialized_notification(&mut service).await;
 
-    
     let _ = fs::create_dir(&ast_folder);
     let e2e_dir = sway_workspace_dir().join(e2e_language_dir());
     let mut entries = fs::read_dir(&e2e_dir)

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -118,7 +118,7 @@ macro_rules! test_lsp_capability {
         let uri = init_and_open(&mut service, $entry_point).await;
 
         // Call the specific LSP capability function that was passed in.
-        let _ = $capability(&mut service.inner(), &uri).await;
+        let _ = $capability(&service.inner(), &uri).await;
         shutdown_and_exit(&mut service).await;
     }};
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -142,6 +142,7 @@ fn initialize() {
             ..Default::default()
         };
         let _ = request::handle_initialize(&service.inner(), &params);
+        shutdown_and_exit(&mut service).await;
     });
 }
 
@@ -150,6 +151,20 @@ fn did_open() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
         let _ = init_and_open(&mut service, e2e_test_dir().join("src/main.sw")).await;
+        service.inner().wait_for_parsing().await;
+        shutdown_and_exit(&mut service).await;
+    });
+}
+
+// Josh we need to focus on getting the examples workspace working nicely tomorrow! 
+#[test]
+fn did_open_all_members_in_examples() {
+    run_async!({
+        let (mut service, _) = LspService::new(ServerState::new);
+        let arrays_dir = sway_workspace_dir().join("examples/arrays");
+
+        // THis example opens and passes here but if you open it in the editor its obviously not working. Improve this test tomorrow!
+        let _ = init_and_open(&mut service, arrays_dir.join("src/main.sw")).await;
         service.inner().wait_for_parsing().await;
         shutdown_and_exit(&mut service).await;
     });

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -156,28 +156,29 @@ fn did_open() {
     });
 }
 
-// Josh we need to focus on getting the examples workspace working nicely tomorrow!
 #[test]
 fn did_open_all_members_in_examples() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
         let examples_workspace_dir = sway_workspace_dir().join("examples");
-        let test_programs_workspace_dir = sway_workspace_dir().join(in_language_test_dir());
-        let sdk_harness_workspace_dir = sway_workspace_dir().join(sdk_harness_test_projects_dir());
+        let _test_programs_workspace_dir = sway_workspace_dir().join(in_language_test_dir());
+        let _sdk_harness_workspace_dir = sway_workspace_dir().join(sdk_harness_test_projects_dir());
+        
+        // TODO: Support multiple workspaces: https://github.com/FuelLabs/sway/issues/7177
         let workspace_dirs = vec![
             &examples_workspace_dir,
-            &test_programs_workspace_dir,
-            &sdk_harness_workspace_dir,
+            //&test_programs_workspace_dir,
+            //&sdk_harness_workspace_dir,
         ];
 
         // Open up the arrays example in the examples workspace
-        let arrays_dir = examples_workspace_dir.join("arrays");
-        let address_inline_tests_dir = test_programs_workspace_dir.join("test_programs/address_inline_tests");
-        let call_frames_dir = sdk_harness_workspace_dir.join("test_projects/call_frames");
+        //let arrays_dir = examples_workspace_dir.join("arrays");
+        //let address_inline_tests_dir = test_programs_workspace_dir.join("test_programs/address_inline_tests");
+        //let call_frames_dir = sdk_harness_workspace_dir.join("test_projects/call_frames");
 
         // This example opens and passes here but if you open it in the editor its obviously not working. Improve this test tomorrow!
-        let uri = init_and_open(&mut service, call_frames_dir.join("src/main.sw")).await;
-        service.inner().wait_for_parsing().await;
+        //let uri = init_and_open(&mut service, arrays_dir.join("src/main.sw")).await;
+        //service.inner().wait_for_parsing().await;
 
         // // Assert that we found the correct workspace manifest file
         // let workspace_manifest_path = service
@@ -203,7 +204,7 @@ fn did_open_all_members_in_examples() {
         //----------------------------------
         for workspace_dir in workspace_dirs {
             // we need to init and open if this is the first time we are opening a workspace
-            // TODO: fix this
+            // TODO: https://github.com/FuelLabs/sway/issues/7177
             eprintln!("---- opening workspace: {:?}", workspace_dir);
             let member_manifests = ManifestFile::from_dir(workspace_dir)
                 .unwrap()
@@ -214,7 +215,14 @@ fn did_open_all_members_in_examples() {
             for (name, package_manifest) in &member_manifests {
                 eprintln!("opening workspace member: {:?}", name);
                 let dir = package_manifest.path().parent().unwrap();
-                let uri = open(&mut service.inner(), dir.join("src/main.sw")).await;
+
+                // If the workspace is not initialized, we need to initialize it
+                // Otherwise, we can just open the file
+                let uri = if service.inner().sync_workspace.get().is_none() {
+                    init_and_open(&mut service, dir.join("src/main.sw")).await
+                } else {
+                    open(&mut service.inner(), dir.join("src/main.sw")).await
+                };
 
                 // Make sure that program was parsed and the token map is populated
                 let (tmp_uri, session) = service
@@ -225,6 +233,7 @@ fn did_open_all_members_in_examples() {
                 let num_tokens_for_file = session.token_map().tokens_for_file(&tmp_uri).count();
                 assert!(num_tokens_for_file > 0);
 
+                // Make sure that semantic tokens are successfully returned for the file
                 let semantic_tokens = lsp::get_semantic_tokens_full(&service.inner(), &uri).await;
                 assert!(semantic_tokens.data.len() > 0);
             }

--- a/sway-lsp/tests/utils/src/lib.rs
+++ b/sway-lsp/tests/utils/src/lib.rs
@@ -24,6 +24,14 @@ pub fn sway_workspace_dir() -> PathBuf {
     env::current_dir().unwrap().parent().unwrap().to_path_buf()
 }
 
+pub fn in_language_test_dir() -> PathBuf {
+    PathBuf::from("test/src/in_language_tests")
+}
+
+pub fn sdk_harness_test_projects_dir() -> PathBuf {
+    PathBuf::from("test/src/sdk-harness")
+}
+
 pub fn e2e_language_dir() -> PathBuf {
     PathBuf::from("test/src/e2e_vm_tests/test_programs/should_pass/language")
 }


### PR DESCRIPTION
## Description
* Moves `SyncWorkspace` ownership from individual `Session` instances to a single, global instance within `ServerState`.
* `SyncWorkspace` is now initialized once when the LSP server starts, creating a single temporary workspace clone.

Also removes the `resync` function. This was causing the server and the IDE to fall out of sync with each other. For example, if you have 2 panels open and then save a file in one of the tabs but have unsaved changes in the other tab then those changes would not be reflected in the temp memory folder. This meant everything would be out of sync. We already are syncing everything on each keystroke per file so this fn was not necessary in the first place.

This PR is a precursor to https://github.com/FuelLabs/sway/pull/7139
part of https://github.com/FuelLabs/sway/issues/7111

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
