### PR TITLE
ci: release sway std after publishing forc binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -912,7 +912,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
   publish-sway-lib-std:
-    needs: publish
+    needs: [publish, build-and-release-forc-binaries]
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
@@ -946,7 +946,7 @@ jobs:
 
   build-publish-release-image:
     # Build & Publish Docker Image Per Sway Release
-    needs: [publish, publish-sway-lib-std]
+    needs: [publish]
     runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       contents: read
@@ -1003,7 +1003,7 @@ jobs:
     name: Build and upload forc binaries to release
     runs-on: ${{ matrix.job.os }}
     if: github.event_name == 'release' && github.event.action == 'published'
-    needs: [publish, publish-sway-lib-std]
+    needs: [publish]
     strategy:
       matrix:
         job:


### PR DESCRIPTION
## Description

The forc.pub server, invoked from `forc-publish` tries to use the same version of forc to build the project as the `forc-publish` version. This means we should wait until the new forc binary is published before invoking `forc-publish`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
