### PR TITLE
const generics for standalone fns

### DIFF
--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -70,6 +70,10 @@ impl CompiledFunctionCache {
         decl.hash(&mut hasher, engines);
         let fn_key = hasher.finish();
 
+        if decl.name.as_str().contains("return_n") {
+            dbg!(fn_key, decl);
+        }
+
         let (fn_key, item) = (Some(fn_key), self.recreated_fns.get(&fn_key).copied());
         let new_callee = match item {
             Some(func) => func,

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -70,10 +70,6 @@ impl CompiledFunctionCache {
         decl.hash(&mut hasher, engines);
         let fn_key = hasher.finish();
 
-        if decl.name.as_str().contains("return_n") {
-            dbg!(fn_key, decl);
-        }
-
         let (fn_key, item) = (Some(fn_key), self.recreated_fns.get(&fn_key).copied());
         let new_callee = match item {
             Some(func) => func,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -530,6 +530,7 @@ impl<'eng> FnCompiler<'eng> {
                     )
                 } else {
                     let function_decl = self.engines.de().get_function(fn_ref);
+
                     self.compile_fn_call(
                         context,
                         md_mgr,

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -713,7 +713,7 @@ impl DebugWithEngines for TyFunctionSig {
                 self.type_parameters
                     .iter()
                     .map(|p| match p {
-                        TyFunctionSigTypeParameter::Type(t) => format!("{}", engines.help_out(t)),
+                        TyFunctionSigTypeParameter::Type(t) => format!("{:?}", engines.help_out(t)),
                         TyFunctionSigTypeParameter::Const(expr) =>
                             format!("{:?}", engines.help_out(expr)),
                     })

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -96,7 +96,6 @@ pub(crate) fn instantiate_function_application(
                 function_decl.name.as_str(),
                 &call_path_binding.span(),
             )?;
-
             function_decl.replace_decls(&decl_mapping, handler, &mut ctx)?;
         }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -300,11 +300,7 @@ pub(crate) fn struct_instantiation(
         .scoped(handler, None, |scoped_ctx| {
             // Insert struct type parameter into namespace.
             // This is required so check_type_parameter_bounds can resolve generic trait type parameters.
-            for p in struct_decl
-                .generic_parameters
-                .iter()
-                .filter_map(|x| x.as_type_parameter())
-            {
+            for p in struct_decl.generic_parameters.iter() {
                 p.insert_into_namespace_self(handler, scoped_ctx.by_ref())?;
             }
 

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -561,7 +561,7 @@ pub fn item_fn_to_function_declaration(
     let kind = override_kind.unwrap_or(kind);
     let implementing_type = context.implementing_type.clone();
 
-    let generic_parameters = generic_params_opt_to_type_parameters_with_parent(
+    let mut generic_parameters = generic_params_opt_to_type_parameters_with_parent(
         context,
         handler,
         engines,
@@ -570,6 +570,19 @@ pub fn item_fn_to_function_declaration(
         item_fn.fn_signature.where_clause_opt.clone(),
         parent_where_clause_opt,
     )?;
+
+    for p in generic_parameters.iter_mut() {
+        match p {
+            TypeParameter::Type(_) => {}
+            TypeParameter::Const(p) => {
+                p.id = Some(engines.pe().insert(ConstGenericDeclaration {
+                    name: p.name.clone(),
+                    ty: p.ty,
+                    span: p.span.clone(),
+                }));
+            }
+        }
+    }
 
     let fn_decl = FunctionDeclaration {
         purity: attributes.purity(),

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -319,6 +319,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
         let fn_ref = unknown_decl.to_fn_ref(handler, ctx.engines())?;
         // Get a new copy from the declaration engine.
         let mut new_copy = (*decl_engine.get_function(fn_ref.id())).clone();
+
         match self.type_arguments {
             // Monomorphize the copy, in place.
             TypeArgs::Regular(_) => {
@@ -352,6 +353,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
                 decl_engine.get_parsed_decl_id(fn_ref.id()).as_ref(),
             )
             .with_parent(ctx.engines.de(), fn_ref.id().into());
+
         Ok((new_fn_ref, None, None))
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -1,12 +1,14 @@
 use crate::{
     abi_generation::abi_str::AbiStrContext,
-    decl_engine::{parsed_id::ParsedDeclId, DeclMapping, InterfaceItemMap, ItemMap},
+    decl_engine::{
+        parsed_id::ParsedDeclId, DeclEngineInsert as _, DeclMapping, InterfaceItemMap, ItemMap,
+    },
     engine_threading::*,
     has_changes,
     language::{
         parsed::ConstGenericDeclaration,
-        ty::{self, TyExpression},
-        CallPath,
+        ty::{self, ConstGenericDecl, TyConstGenericDecl, TyExpression},
+        CallPath, CallPathType,
     },
     namespace::TraitMap,
     semantic_analysis::{GenericShadowingMode, TypeCheckContext},
@@ -29,6 +31,136 @@ use sway_types::{ident::Ident, span::Span, BaseIdent, Named, Spanned};
 pub enum TypeParameter {
     Type(GenericTypeParameter),
     Const(ConstGenericParameter),
+}
+
+impl TypeParameter {
+    pub(crate) fn insert_into_namespace_constraints(
+        &self,
+        handler: &Handler,
+        mut ctx: TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
+        // Insert the trait constraints into the namespace.
+        match self {
+            TypeParameter::Type(p) => {
+                for trait_constraint in &p.trait_constraints {
+                    TraitConstraint::insert_into_namespace(
+                        handler,
+                        ctx.by_ref(),
+                        p.type_id,
+                        trait_constraint,
+                    )?;
+                }
+            }
+            TypeParameter::Const(_) => {}
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn insert_into_namespace_self(
+        &self,
+        handler: &Handler,
+        mut ctx: TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
+        let (is_from_parent, name, type_id, ty_decl) = match self {
+            TypeParameter::Type(GenericTypeParameter {
+                is_from_parent,
+                name,
+                type_id,
+                ..
+            }) => (
+                is_from_parent,
+                name,
+                *type_id,
+                ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
+                    name: name.clone(),
+                    type_id: *type_id,
+                }),
+            ),
+            TypeParameter::Const(ConstGenericParameter {
+                is_from_parent,
+                name,
+                id,
+                span,
+                ty,
+                ..
+            }) => {
+                let decl_ref = ctx.engines.de().insert(
+                    TyConstGenericDecl {
+                        call_path: CallPath {
+                            prefixes: vec![],
+                            suffix: name.clone(),
+                            callpath_type: CallPathType::Ambiguous,
+                        },
+                        span: span.clone(),
+                        return_type: *ty,
+                        value: None,
+                    },
+                    id.as_ref(),
+                );
+                (
+                    is_from_parent,
+                    name,
+                    ctx.engines.te().id_of_u64(),
+                    ty::TyDecl::ConstGenericDecl(ConstGenericDecl {
+                        decl_id: *decl_ref.id(),
+                    }),
+                )
+            }
+        };
+
+        if *is_from_parent {
+            ctx = ctx.with_generic_shadowing_mode(GenericShadowingMode::Allow);
+
+            let (resolve_declaration, _) =
+                ctx.namespace()
+                    .current_module()
+                    .resolve_symbol(handler, ctx.engines(), name)?;
+
+            match resolve_declaration.expect_typed_ref() {
+                ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
+                    type_id: parent_type_id,
+                    ..
+                }) => {
+                    if let TypeInfo::UnknownGeneric {
+                        name,
+                        trait_constraints,
+                        parent,
+                        is_from_type_parameter,
+                    } = &*ctx.engines().te().get(type_id)
+                    {
+                        if parent.is_some() {
+                            return Ok(());
+                        }
+
+                        ctx.engines.te().replace(
+                            ctx.engines(),
+                            type_id,
+                            TypeInfo::UnknownGeneric {
+                                name: name.clone(),
+                                trait_constraints: trait_constraints.clone(),
+                                parent: Some(*parent_type_id),
+                                is_from_type_parameter: *is_from_type_parameter,
+                            },
+                        );
+                    }
+                }
+                ty::TyDecl::ConstGenericDecl(_) => {}
+                _ => {
+                    handler.emit_err(CompileError::Internal(
+                        "Unexpected TyDeclaration for TypeParameter.",
+                        name.span(),
+                    ));
+                }
+            }
+        }
+
+        // Insert the type parameter into the namespace as a dummy type
+        // declaration.
+        ctx.insert_symbol(handler, name.clone(), ty_decl).ok();
+
+        Ok(())
+    }
 }
 
 impl Named for TypeParameter {
@@ -377,35 +509,35 @@ impl GenericTypeParameter {
 
         handler.scope(|handler| {
             for p in generic_params {
-                match p {
+                let p = match p {
                     TypeParameter::Type(p) => {
-                        let p = TypeParameter::Type(
-                            match GenericTypeParameter::type_check(handler, ctx.by_ref(), p) {
-                                Ok(res) => res,
-                                Err(_) => continue,
-                            },
-                        );
-                        new_generic_params.push(p)
+                        match GenericTypeParameter::type_check(handler, ctx.by_ref(), p) {
+                            Ok(res) => res,
+                            Err(_) => continue,
+                        }
                     }
-                    TypeParameter::Const(p) => {
-                        let p = TypeParameter::Const(p.clone());
-                        new_generic_params.push(p);
-                    }
-                }
+                    TypeParameter::Const(p) => TypeParameter::Const(p.clone()),
+                };
+                p.insert_into_namespace_self(handler, ctx.by_ref())?;
+                new_generic_params.push(p)
             }
 
             // Type check trait constraints only after type checking all type parameters.
             // This is required because a trait constraint may use other type parameters.
             // Ex: `struct Struct2<A, B> where A : MyAdd<B>`
-            for type_parameter in new_generic_params
-                .iter_mut()
-                .filter_map(|x| x.as_type_parameter_mut())
-            {
-                GenericTypeParameter::type_check_trait_constraints(
-                    handler,
-                    ctx.by_ref(),
-                    type_parameter,
-                )?;
+            for type_parameter in new_generic_params.iter_mut() {
+                match type_parameter {
+                    TypeParameter::Type(type_parameter) => {
+                        GenericTypeParameter::type_check_trait_constraints(
+                            handler,
+                            ctx.by_ref(),
+                            type_parameter,
+                        )?;
+                    }
+                    TypeParameter::Const(_) => {}
+                }
+
+                type_parameter.insert_into_namespace_constraints(handler, ctx.by_ref())?;
             }
 
             Ok(new_generic_params)
@@ -451,9 +583,9 @@ impl GenericTypeParameter {
     /// inserts into into the current namespace.
     fn type_check(
         handler: &Handler,
-        mut ctx: TypeCheckContext,
+        ctx: TypeCheckContext,
         type_parameter: GenericTypeParameter,
-    ) -> Result<Self, ErrorEmitted> {
+    ) -> Result<TypeParameter, ErrorEmitted> {
         let type_engine = ctx.engines.te();
 
         let GenericTypeParameter {
@@ -501,8 +633,7 @@ impl GenericTypeParameter {
         };
 
         // Insert the type parameter into the namespace
-        type_parameter.insert_into_namespace_self(handler, ctx.by_ref())?;
-
+        let type_parameter = TypeParameter::Type(type_parameter);
         Ok(type_parameter)
     }
 
@@ -553,97 +684,6 @@ impl GenericTypeParameter {
         );
 
         type_parameter.trait_constraints = trait_constraints_with_supertraits;
-
-        // Insert the trait constraints into the namespace.
-        type_parameter.insert_into_namespace_constraints(handler, ctx.by_ref())?;
-
-        Ok(())
-    }
-
-    pub(crate) fn insert_into_namespace_constraints(
-        &self,
-        handler: &Handler,
-        mut ctx: TypeCheckContext,
-    ) -> Result<(), ErrorEmitted> {
-        // Insert the trait constraints into the namespace.
-        for trait_constraint in &self.trait_constraints {
-            TraitConstraint::insert_into_namespace(
-                handler,
-                ctx.by_ref(),
-                self.type_id,
-                trait_constraint,
-            )?;
-        }
-
-        Ok(())
-    }
-
-    pub(crate) fn insert_into_namespace_self(
-        &self,
-        handler: &Handler,
-        mut ctx: TypeCheckContext,
-    ) -> Result<(), ErrorEmitted> {
-        let Self {
-            is_from_parent,
-            name,
-            type_id,
-            ..
-        } = self;
-
-        if *is_from_parent {
-            ctx = ctx.with_generic_shadowing_mode(GenericShadowingMode::Allow);
-
-            let (sy, _) =
-                ctx.namespace()
-                    .current_module()
-                    .resolve_symbol(handler, ctx.engines(), name)?;
-
-            match sy.expect_typed_ref() {
-                ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
-                    type_id: parent_type_id,
-                    ..
-                }) => {
-                    if let TypeInfo::UnknownGeneric {
-                        name,
-                        trait_constraints,
-                        parent,
-                        is_from_type_parameter,
-                    } = &*ctx.engines().te().get(*type_id)
-                    {
-                        if parent.is_some() {
-                            return Ok(());
-                        }
-
-                        ctx.engines.te().replace(
-                            ctx.engines(),
-                            *type_id,
-                            TypeInfo::UnknownGeneric {
-                                name: name.clone(),
-                                trait_constraints: trait_constraints.clone(),
-                                parent: Some(*parent_type_id),
-                                is_from_type_parameter: *is_from_type_parameter,
-                            },
-                        );
-                    }
-                }
-                _ => {
-                    handler.emit_err(CompileError::Internal(
-                        "Unexpected TyDeclaration for TypeParameter.",
-                        self.name.span(),
-                    ));
-                }
-            }
-        }
-
-        // Insert the type parameter into the namespace as a dummy type
-        // declaration.
-        let type_parameter_decl =
-            ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
-                name: name.clone(),
-                type_id: *type_id,
-            });
-        ctx.insert_symbol(handler, name.clone(), type_parameter_decl)
-            .ok();
 
         Ok(())
     }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -2533,7 +2533,7 @@ fn run_garbage_collection_tests_from_projects_dir(projects_dir: PathBuf) -> Resu
                 .to_string();
             let main_file = project_dir.join("src/main.sw");
 
-             // check if this test must be ignored
+            // check if this test must be ignored
             let contents = std::fs::read_to_string(&main_file)
                 .map(|x| x.contains("ignore garbage_collection_all_language_tests"));
             if let Ok(true) = contents {

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -2524,7 +2524,7 @@ fn run_garbage_collection_tests_from_projects_dir(projects_dir: PathBuf) -> Resu
         .unwrap()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
-        .map(|dir_entry| {
+        .filter_map(|dir_entry| {
             let project_dir = dir_entry.path();
             let project_name = project_dir
                 .file_name()
@@ -2532,7 +2532,15 @@ fn run_garbage_collection_tests_from_projects_dir(projects_dir: PathBuf) -> Resu
                 .to_string_lossy()
                 .to_string();
             let main_file = project_dir.join("src/main.sw");
-            (project_name, main_file)
+
+             // check if this test must be ignored
+            let contents = std::fs::read_to_string(&main_file)
+                .map(|x| x.contains("ignore garbage_collection_all_language_tests"));
+            if let Ok(true) = contents {
+                None
+            } else {
+                Some((project_name, main_file))
+            }
         })
         .filter(|(_, main_file)| main_file.exists())
         .collect();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/json_abi_oracle.json
@@ -8,10 +8,6 @@
       "concreteTypeId": "4936d108619f9cd75cdeea2f3fe11241b06d22b856d4b61fa3ae412370b10a6a",
       "metadataTypeId": 0,
       "type": "[u64; 2]"
-    },
-    {
-      "concreteTypeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-      "type": "u64"
     }
   ],
   "configurables": [],
@@ -29,27 +25,22 @@
       "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
     }
   ],
-  "loggedTypes": [
-    {
-      "concreteTypeId": "4936d108619f9cd75cdeea2f3fe11241b06d22b856d4b61fa3ae412370b10a6a",
-      "logId": "5275633847438908631"
-    },
-    {
-      "concreteTypeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-      "logId": "1515152261580153489"
-    }
-  ],
+  "loggedTypes": [],
   "messagesTypes": [],
   "metadataTypes": [
     {
       "components": [
         {
           "name": "__array_element",
-          "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0"
+          "typeId": 1
         }
       ],
       "metadataTypeId": 0,
       "type": "[_; 2]"
+    },
+    {
+      "metadataTypeId": 1,
+      "type": "u64"
     }
   ],
   "programType": "script",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/snapshot.toml
@@ -1,0 +1,4 @@
+cmds = [
+    "forc build --path {root} --release",
+    "forc test --path {root} --experimental const_generics --test-threads 1 --logs --revert-codes",
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
@@ -21,6 +21,11 @@ impl<T, const N: u64> S<T, N> {
     }
 }
 
+#[inline(never)]
+fn return_n<const NNN: u64>() -> u64 {
+    NNN
+}
+
 fn main(a: [u64; 2]) {
     __log(a);
 
@@ -32,4 +37,8 @@ fn main(a: [u64; 2]) {
 
     let s: S<u64, 3> = S { };
     __log(s.len_xxx());
+
+    __dbg(return_n::<3>());
+    assert(return_n::<4>() == 4);
+    __dbg(return_n::<5>());
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
@@ -1,3 +1,4 @@
+// ignore garbage_collection_all_language_tests - needs a experimental feature
 script;
 
 struct C {}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
@@ -38,7 +38,6 @@ fn main(a: [u64; 2]) {
     let s: S<u64, 3> = S { };
     __log(s.len_xxx());
 
-    __dbg(return_n::<3>());
-    assert(return_n::<4>() == 4);
-    __dbg(return_n::<5>());
+    let _ = __dbg(return_n::<3>());
+    let _ = __dbg(return_n::<5>());
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
@@ -28,7 +28,7 @@ fn return_n<const NNN: u64>() -> u64 {
 }
 
 fn main(a: [u64; 2]) {
-    __log(a);
+    let _ = __dbg(a);
 
     let a = [C {}].my_len();
     assert(a == 1);
@@ -37,8 +37,13 @@ fn main(a: [u64; 2]) {
     assert(b == 2);
 
     let s: S<u64, 3> = S { };
-    __log(s.len_xxx());
+    let _ = __dbg(s.len_xxx());
 
     let _ = __dbg(return_n::<3>());
     let _ = __dbg(return_n::<5>());
+}
+
+#[test]
+fn run_main() {
+    main([1, 2]);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
@@ -1,0 +1,80 @@
+---
+source: test/src/snapshot/mod.rs
+---
+> forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --release
+exit status: 1
+output:
+    Building test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics
+   Compiling library std (sway-lib-std)
+   Compiling script const_generics (test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics)
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:10:15
+   |
+ 8 | }
+ 9 | 
+10 | impl<T, const N: u64> A for [T; N] {
+   |               ^ This needs "const_generics" to be enabled, but it is currently disabled. For more details go to https://github.com/FuelLabs/sway/issues/6860.
+11 |     fn my_len(self) -> u64 {
+12 |         N
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:16:19
+   |
+14 | }
+15 | 
+16 | struct S<T, const N: u64> {
+   |                   ^ This needs "const_generics" to be enabled, but it is currently disabled. For more details go to https://github.com/FuelLabs/sway/issues/6860.
+17 | }
+18 | 
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:19:15
+   |
+17 | }
+18 | 
+19 | impl<T, const N: u64> S<T, N> {
+   |               ^ This needs "const_generics" to be enabled, but it is currently disabled. For more details go to https://github.com/FuelLabs/sway/issues/6860.
+20 |     pub fn len_xxx(self) -> u64 {
+21 |         N
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:26:19
+   |
+24 | 
+25 | #[inline(never)]
+26 | fn return_n<const NNN: u64>() -> u64 {
+   |                   ^^^ This needs "const_generics" to be enabled, but it is currently disabled. For more details go to https://github.com/FuelLabs/sway/issues/6860.
+27 |     NNN
+28 | }
+   |
+____
+
+  Aborting due to 4 errors.
+error: Failed to compile const_generics
+
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --experimental const_generics --test-threads 1 --logs --revert-codes
+exit status: 0
+output:
+    Building test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics
+   Compiling library std (sway-lib-std)
+   Compiling script const_generics (test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics)
+    Finished debug [unoptimized + fuel] target(s) [2.856 KB] in ???
+     Running 1 test, filtered 0 tests
+
+tested -- const_generics
+
+      test run_main ... ok (???, 4184 gas)
+[src/main.sw:31:13] a = [1, 2]
+[src/main.sw:40:13] s.len_xxx() = 3
+[src/main.sw:42:13] return_n::<3>() = 3
+[src/main.sw:43:13] return_n::<5>() = 5
+
+test result: OK. 1 passed; 0 failed; finished in ???
+
+    Finished in ???


### PR DESCRIPTION
## Description

This PR is part of https://github.com/FuelLabs/sway/issues/6860 and allows standalone functions to have "const generics" like the code below:

```sway
fn return_n<const NNN: u64>() -> u64 {
    NNN
}
```

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
