### PR TITLE
fix: Prevent panic in semantic highlighting for unknown token types

### DIFF
--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -47,6 +47,8 @@ pub fn semantic_tokens(tokens_sorted: &[&RefMulti<TokenIdent, Token>]) -> Semant
     for entry in tokens_sorted {
         let (ident, token) = entry.pair();
         let ty = semantic_token_type(&token.kind);
+        eprintln!("name: {:?}", ident.name);
+        eprintln!("ty: {:?}", ty);
         let token_index = type_index(&ty);
         // TODO - improve with modifiers
         let modifier_bitset = 0;
@@ -151,6 +153,7 @@ pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
     SemanticTokenType::new("selfKeyword"),
     SemanticTokenType::new("selfTypeKeyword"),
     SemanticTokenType::new("typeAlias"),
+    SemanticTokenType::new("traitType"),
 ];
 
 pub(crate) const SUPPORTED_MODIFIERS: &[SemanticTokenModifier] = &[
@@ -195,5 +198,12 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
 }
 
 fn type_index(ty: &SemanticTokenType) -> u32 {
-    SUPPORTED_TYPES.iter().position(|it| it == ty).unwrap() as u32
+    eprintln!("ty: {:?}", ty);
+    SUPPORTED_TYPES
+        .iter()
+        .position(|it| {
+            eprintln!("it: {:?} | ty: {:?}", it, ty);
+            it == ty
+        })
+        .unwrap() as u32
 }

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -47,12 +47,13 @@ pub fn semantic_tokens(tokens_sorted: &[&RefMulti<TokenIdent, Token>]) -> Semant
     for entry in tokens_sorted {
         let (ident, token) = entry.pair();
         let ty = semantic_token_type(&token.kind);
-        eprintln!("name: {:?}", ident.name);
-        eprintln!("ty: {:?}", ty);
-        let token_index = type_index(&ty);
-        // TODO - improve with modifiers
-        let modifier_bitset = 0;
-        builder.push(ident.range, token_index, modifier_bitset);
+        if let Some(token_index) = type_index(&ty) {
+            // TODO - improve with modifiers
+            let modifier_bitset = 0;
+            builder.push(ident.range, token_index, modifier_bitset);
+        } else {
+            tracing::error!("Unsupported token type: {:?} for token: {:#?}", ty, token);
+        }
     }
     builder.build()
 }
@@ -197,13 +198,9 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
     }
 }
 
-fn type_index(ty: &SemanticTokenType) -> u32 {
-    eprintln!("ty: {:?}", ty);
+fn type_index(ty: &SemanticTokenType) -> Option<u32> {
     SUPPORTED_TYPES
         .iter()
-        .position(|it| {
-            eprintln!("it: {:?} | ty: {:?}", it, ty);
-            it == ty
-        })
-        .unwrap() as u32
+        .position(|it| it == ty)
+        .map(|x| x as u32)
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -150,7 +150,7 @@ fn initialize() {
 fn did_open() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let _ = init_and_open(&mut service, e2e_test_dir().join("src/iterator.sw")).await;
+        let _ = init_and_open(&mut service, e2e_test_dir().join("src/main.sw")).await;
         service.inner().wait_for_parsing().await;
         shutdown_and_exit(&mut service).await;
     });

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -150,8 +150,32 @@ fn initialize() {
 fn did_open() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let _ = init_and_open(&mut service, e2e_test_dir().join("src/main.sw")).await;
+        let _ = init_and_open(&mut service, std_lib_dir().join("src/iterator.sw")).await;
         service.inner().wait_for_parsing().await;
+        shutdown_and_exit(&mut service).await;
+    });
+}
+
+#[test]
+fn did_open_all_std_lib_files() {
+    run_async!({
+        let (mut service, _) = LspService::new(ServerState::new);
+        let files = sway_utils::helpers::get_sway_files(std_lib_dir().join("src"));
+        for file in files {
+            eprintln!("opening file: {:?}", file.as_path());
+
+            // If the workspace is not initialized, we need to initialize it
+            // Otherwise, we can just open the file
+            let uri = if service.inner().sync_workspace.get().is_none() {
+                init_and_open(&mut service, file.to_path_buf()).await
+            } else {
+                open(service.inner(), file.to_path_buf()).await
+            };
+
+            // Make sure that semantic tokens are successfully returned for the file
+            let semantic_tokens = lsp::get_semantic_tokens_full(service.inner(), &uri).await;
+            assert!(!semantic_tokens.data.is_empty());
+        }
         shutdown_and_exit(&mut service).await;
     });
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -150,7 +150,7 @@ fn initialize() {
 fn did_open() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let _ = init_and_open(&mut service, std_lib_dir().join("src/iterator.sw")).await;
+        let _ = init_and_open(&mut service, e2e_test_dir().join("src/iterator.sw")).await;
         service.inner().wait_for_parsing().await;
         shutdown_and_exit(&mut service).await;
     });

--- a/sway-lsp/tests/utils/src/lib.rs
+++ b/sway-lsp/tests/utils/src/lib.rs
@@ -58,6 +58,10 @@ pub fn e2e_test_dir() -> PathBuf {
         .join("struct_field_access")
 }
 
+pub fn std_lib_dir() -> PathBuf {
+    sway_workspace_dir().join("sway-lib-std")
+}
+
 pub fn runnables_test_dir() -> PathBuf {
     test_fixtures_dir().join("runnables")
 }


### PR DESCRIPTION
## Description
Previously, the language server would panic if it encountered a `SymbolKind` that mapped to a `SemanticTokenType` not present in the `SUPPORTED_TYPES` array. This was due to an `unwrap()` call in the `type_index` function.

This PR addresses the issue by:
Adding `SemanticTokenType::new("traitType")` to the `SUPPORTED_TYPES` array, which was the specific missing type causing a crash when opening `sway-lib-std/src/iterator.sw`.

Modifying `type_index` to return `Option<u32>` instead of `u32`, removing the `unwrap()`.

closes #7188

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
