### PR TITLE
fix: ensure forc-node ignition fetches ignition chain config

### DIFF
--- a/forc-plugins/forc-node/src/consts.rs
+++ b/forc-plugins/forc-node/src/consts.rs
@@ -1,5 +1,5 @@
 /// Minimum fuel-core version supported.
-pub const MIN_FUEL_CORE_VERSION: &str = "0.40.0";
+pub const MIN_FUEL_CORE_VERSION: &str = "0.43.0";
 
 pub const TESTNET_SERVICE_NAME: &str = "fuel-sepolia-testnet-node";
 pub const TESTNET_SYNC_HEADER_BATCH_SIZE: u32 = 100;

--- a/forc-plugins/forc-node/src/ignition/op.rs
+++ b/forc-plugins/forc-node/src/ignition/op.rs
@@ -19,7 +19,7 @@ use std::{
 /// Configures the node with testnet configuration to connect the node to latest testnet.
 /// Returns `None` if this is a dry_run and no child process created for fuel-core.
 pub(crate) async fn run(cmd: IgnitionCmd, dry_run: bool) -> anyhow::Result<Option<Child>> {
-    check_and_update_chain_config(ChainConfig::Testnet).await?;
+    check_and_update_chain_config(ChainConfig::Ignition).await?;
     let keypair = if let (Some(peer_id), Some(secret)) = (
         &cmd.connection_settings.peer_id,
         &cmd.connection_settings.secret,


### PR DESCRIPTION
## Description
closes #7193.

There was a simple bug in the mainnet setup we were still fetching testnet configuration. Which caused some syncing issues.