### PR TITLE
Const generics for "string array" and `len` methods

### DIFF
--- a/forc-plugins/forc-doc/src/render/item/type_anchor.rs
+++ b/forc-plugins/forc-doc/src/render/item/type_anchor.rs
@@ -103,7 +103,7 @@ pub(crate) fn render_type_anchor(
             : name.as_str();
         }),
         TypeInfo::StringArray(len) => Ok(box_html! {
-            : len.span().as_str();
+            : len.expr().span().as_str();
         }),
         TypeInfo::UnsignedInteger(int_bits) => {
             use sway_types::integer_bits::IntegerBits;

--- a/sway-core/src/abi_generation/abi_str.rs
+++ b/sway-core/src/abi_generation/abi_str.rs
@@ -94,7 +94,7 @@ impl TypeInfo {
             Placeholder(_) => "_".to_string(),
             TypeParam(param) => format!("typeparam({})", param.name()),
             StringSlice => "str".into(),
-            StringArray(length) => format!("str[{}]", length.val()),
+            StringArray(length) => format!("str[{:?}]", engines.help_out(length.expr())),
             UnsignedInteger(x) => match x {
                 IntegerBits::Eight => "u8",
                 IntegerBits::Sixteen => "u16",

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -153,9 +153,10 @@ pub fn abi_param_type(type_info: &TypeInfo, engines: &Engines) -> ethabi::ParamT
     let type_engine = engines.te();
     let decl_engine = engines.de();
     match type_info {
-        StringArray(length) => {
-            ethabi::ParamType::FixedArray(Box::new(ethabi::ParamType::String), length.expr().as_literal_val().unwrap())
-        }
+        StringArray(length) => ethabi::ParamType::FixedArray(
+            Box::new(ethabi::ParamType::String),
+            length.expr().as_literal_val().unwrap(),
+        ),
         UnsignedInteger(x) => match x {
             IntegerBits::Eight => ethabi::ParamType::Uint(8),
             IntegerBits::Sixteen => ethabi::ParamType::Uint(16),

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -71,7 +71,7 @@ pub fn abi_str(type_info: &TypeInfo, engines: &Engines) -> String {
         Placeholder(_) => "_".to_string(),
         TypeParam(param) => format!("typeparam({})", param.name()),
         StringSlice => "str".into(),
-        StringArray(x) => format!("str[{}]", x.val()),
+        StringArray(length) => format!("str[{:?}]", engines.help_out(length.expr())),
         UnsignedInteger(x) => match x {
             IntegerBits::Eight => "uint8",
             IntegerBits::Sixteen => "uint16",
@@ -153,8 +153,8 @@ pub fn abi_param_type(type_info: &TypeInfo, engines: &Engines) -> ethabi::ParamT
     let type_engine = engines.te();
     let decl_engine = engines.de();
     match type_info {
-        StringArray(x) => {
-            ethabi::ParamType::FixedArray(Box::new(ethabi::ParamType::String), x.val())
+        StringArray(length) => {
+            ethabi::ParamType::FixedArray(Box::new(ethabi::ParamType::String), length.expr().as_literal_val().unwrap())
         }
         UnsignedInteger(x) => match x {
             IntegerBits::Eight => ethabi::ParamType::Uint(8),

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -103,7 +103,7 @@ fn convert_resolved_type_info(
         TypeInfo::Boolean => Type::get_bool(context),
         TypeInfo::B256 => Type::get_b256(context),
         TypeInfo::StringSlice => Type::get_slice(context),
-        TypeInfo::StringArray(length) => Type::new_string_array(context, length.val() as u64),
+        TypeInfo::StringArray(length) if length.expr().as_literal_val().is_some() => Type::new_string_array(context, length.expr().as_literal_val().unwrap() as u64),
         TypeInfo::Struct(decl_ref) => super::types::get_struct_for_types(
             type_engine,
             decl_engine,
@@ -193,5 +193,6 @@ fn convert_resolved_type_info(
         TypeInfo::ErrorRecovery(_) => reject_type!("Error recovery"),
         TypeInfo::TraitType { .. } => reject_type!("TraitType"),
         TypeInfo::Array(..) => reject_type!("Array with non literal length"),
+        TypeInfo::StringArray(..) => reject_type!("String Array with non literal length"),
     })
 }

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -103,7 +103,9 @@ fn convert_resolved_type_info(
         TypeInfo::Boolean => Type::get_bool(context),
         TypeInfo::B256 => Type::get_b256(context),
         TypeInfo::StringSlice => Type::get_slice(context),
-        TypeInfo::StringArray(length) if length.expr().as_literal_val().is_some() => Type::new_string_array(context, length.expr().as_literal_val().unwrap() as u64),
+        TypeInfo::StringArray(length) if length.expr().as_literal_val().is_some() => {
+            Type::new_string_array(context, length.expr().as_literal_val().unwrap() as u64)
+        }
         TypeInfo::Struct(decl_ref) => super::types::get_struct_for_types(
             type_engine,
             decl_engine,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -2049,17 +2049,10 @@ impl<'a> FnCompiler<'a> {
                             len,
                             Type::get_uint8(context),
                         );
-                        self.current_block.append(context).mem_copy_bytes(
-                            addr,
-                            item_ptr,
-                            string_len,
-                        );
-                        increase_len(
-                            &mut self.current_block,
-                            context,
-                            len,
-                            string_len,
-                        )
+                        self.current_block
+                            .append(context)
+                            .mem_copy_bytes(addr, item_ptr, string_len);
+                        increase_len(&mut self.current_block, context, len, string_len)
                     }
                     TypeInfo::StringSlice | TypeInfo::RawUntypedSlice => {
                         let uint64 = Type::get_uint64(context);

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -1927,8 +1927,9 @@ impl<'a> FnCompiler<'a> {
                         let needed_size = to_constant(self, context, 32);
                         grow_if_needed(self, context, ptr, cap, len, needed_size)
                     }
-                    TypeInfo::StringArray(string_len) => {
-                        let needed_size = to_constant(self, context, string_len.val() as u64);
+                    TypeInfo::StringArray(length) => {
+                        let value = length.expr().as_literal_val().unwrap() as u64;
+                        let needed_size = to_constant(self, context, value);
                         grow_if_needed(self, context, ptr, cap, len, needed_size)
                     }
                     TypeInfo::StringSlice | TypeInfo::RawUntypedSlice => {
@@ -2037,7 +2038,8 @@ impl<'a> FnCompiler<'a> {
                             .mem_copy_bytes(addr, item_ptr, 32);
                         increase_len(&mut self.current_block, context, len, 32)
                     }
-                    TypeInfo::StringArray(string_len) => {
+                    TypeInfo::StringArray(length) => {
+                        let string_len = length.expr().as_literal_val().unwrap() as u64;
                         // Save to local and return ptr to local
                         let item_ptr = save_to_local_return_ptr(self, context, item)?;
                         let addr = calc_addr_as_ptr(
@@ -2050,13 +2052,13 @@ impl<'a> FnCompiler<'a> {
                         self.current_block.append(context).mem_copy_bytes(
                             addr,
                             item_ptr,
-                            string_len.val() as u64,
+                            string_len,
                         );
                         increase_len(
                             &mut self.current_block,
                             context,
                             len,
-                            string_len.val() as u64,
+                            string_len,
                         )
                     }
                     TypeInfo::StringSlice | TypeInfo::RawUntypedSlice => {

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -190,7 +190,8 @@ impl DeclRefFunction {
     pub fn get_method_safe_to_unify(&self, engines: &Engines, type_id: TypeId) -> Self {
         let decl_engine = engines.de();
 
-        let mut method = (*decl_engine.get_function(self)).clone();
+        let original = &*decl_engine.get_function(self);
+        let mut method = original.clone();
 
         if let Some(method_implementing_for_typeid) = method.implementing_for_typeid {
             let mut type_id_type_subst_map = TypeSubstMap::new();
@@ -241,6 +242,11 @@ impl DeclRefFunction {
                         type_id_type_subst_map.insert(p.type_id, type_id);
                     }
                 }
+            }
+
+            for p in method.parameters.iter_mut() {
+                let t = engines.te().get(p.type_argument.type_id());
+                *p.type_argument.type_id_mut() = engines.te().insert(engines, TypeInfo::clone(&t), None);
             }
 
             let mut method_type_subst_map = TypeSubstMap::new();

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -244,10 +244,11 @@ impl DeclRefFunction {
                 }
             }
 
-            for p in method.parameters.iter_mut() {
-                let t = engines.te().get(p.type_argument.type_id());
-                *p.type_argument.type_id_mut() =
-                    engines.te().insert(engines, TypeInfo::clone(&t), None);
+            // Duplicate arguments to avoid changing TypeId inside TraitMap
+            for parameter in method.parameters.iter_mut() {
+                *parameter.type_argument.type_id_mut() = engines
+                    .te()
+                    .duplicate(engines, parameter.type_argument.type_id())
             }
 
             let mut method_type_subst_map = TypeSubstMap::new();

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -246,7 +246,8 @@ impl DeclRefFunction {
 
             for p in method.parameters.iter_mut() {
                 let t = engines.te().get(p.type_argument.type_id());
-                *p.type_argument.type_id_mut() = engines.te().insert(engines, TypeInfo::clone(&t), None);
+                *p.type_argument.type_id_mut() =
+                    engines.te().insert(engines, TypeInfo::clone(&t), None);
             }
 
             let mut method_type_subst_map = TypeSubstMap::new();

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -206,7 +206,7 @@ fn type_check_transmute(
             .by_ref()
             .with_help_text("")
             .with_type_annotation(arg_type);
-        ty::TyExpression::type_check(handler, ctx, &arguments[0]).unwrap()
+        ty::TyExpression::type_check(handler, ctx, &arguments[0])?
     };
 
     engines.te().unify(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -144,17 +144,9 @@ pub(crate) fn type_check_method_application(
             }
             (
                 TypeInfo::StringArray(Length(ConstGenericExpr::Literal { .. })),
-                TypeInfo::StringArray(Length(ConstGenericExpr::Literal { val, .. })),
+                TypeInfo::StringArray(Length(ConstGenericExpr::Literal { .. })),
             ) => {
-                //TODO
-                const_generics.insert(
-                    "N".to_string(),
-                    TyExpression {
-                        expression: ty::TyExpressionVariant::Literal(Literal::U64(*val as u64)),
-                        return_type: engines.te().id_of_u64(),
-                        span: Span::dummy(),
-                    },
-                );
+                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860");
             }
             (
                 TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -128,19 +128,48 @@ pub(crate) fn type_check_method_application(
         let b = engines
             .te()
             .get(args_opt_buf[0].0.as_ref().unwrap().return_type);
-        if let (
-            TypeInfo::Array(_, Length(ConstGenericExpr::AmbiguousVariableExpression { ident })),
-            TypeInfo::Array(_, Length(ConstGenericExpr::Literal { val, .. })),
-        ) = (&*a, &*b)
-        {
-            const_generics.insert(
-                ident.as_str().to_string(),
-                TyExpression {
-                    expression: ty::TyExpressionVariant::Literal(Literal::U64(*val as u64)),
-                    return_type: engines.te().id_of_u64(),
-                    span: Span::dummy(),
-                },
-            );
+        match (&*a, &*b) {
+            (
+                TypeInfo::Array(_, Length(ConstGenericExpr::AmbiguousVariableExpression { ident })),
+                TypeInfo::Array(_, Length(ConstGenericExpr::Literal { val, .. })),
+            ) => {
+                const_generics.insert(
+                    ident.as_str().to_string(),
+                    TyExpression {
+                        expression: ty::TyExpressionVariant::Literal(Literal::U64(*val as u64)),
+                        return_type: engines.te().id_of_u64(),
+                        span: Span::dummy(),
+                    },
+                );
+            }
+            (
+                TypeInfo::StringArray(Length(ConstGenericExpr::Literal { .. })),
+                TypeInfo::StringArray(Length(ConstGenericExpr::Literal { val, .. })),
+            ) => {
+                //TODO
+                const_generics.insert(
+                    "N".to_string(),
+                    TyExpression {
+                        expression: ty::TyExpressionVariant::Literal(Literal::U64(*val as u64)),
+                        return_type: engines.te().id_of_u64(),
+                        span: Span::dummy(),
+                    },
+                );
+            }
+            (
+                TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression { ident })),
+                TypeInfo::StringArray(Length(ConstGenericExpr::Literal { val, .. })),
+            ) => {
+                const_generics.insert(
+                    ident.as_str().to_string(),
+                    TyExpression {
+                        expression: ty::TyExpressionVariant::Literal(Literal::U64(*val as u64)),
+                        return_type: engines.te().id_of_u64(),
+                        span: Span::dummy(),
+                    },
+                );
+            }
+            _ => {},
         }
     }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -157,7 +157,9 @@ pub(crate) fn type_check_method_application(
                 );
             }
             (
-                TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression { ident })),
+                TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression {
+                    ident,
+                })),
                 TypeInfo::StringArray(Length(ConstGenericExpr::Literal { val, .. })),
             ) => {
                 const_generics.insert(
@@ -169,7 +171,7 @@ pub(crate) fn type_check_method_application(
                     },
                 );
             }
-            _ => {},
+            _ => {}
         }
     }
 

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -174,7 +174,7 @@ pub(crate) enum TypeRootFilter {
     Never,
     Placeholder,
     StringSlice,
-    StringArray(usize),
+    StringArray,
     U8,
     U16,
     U32,
@@ -878,6 +878,7 @@ impl TraitMap {
                 true,
                 |entry| {
                     if unify_check.check(type_id, entry.key.type_id) {
+                        
                         let trait_items = Self::filter_dummy_methods(
                             &entry.value.trait_items,
                             type_id,
@@ -1559,7 +1560,7 @@ impl TraitMap {
             UnknownGeneric { .. } | Placeholder(_) => TypeRootFilter::Placeholder,
             TypeParam(_param) => unreachable!(),
             StringSlice => TypeRootFilter::StringSlice,
-            StringArray(x) => TypeRootFilter::StringArray(x.val()),
+            StringArray(_) => TypeRootFilter::StringArray,
             UnsignedInteger(x) => match x {
                 IntegerBits::Eight => TypeRootFilter::U8,
                 IntegerBits::Sixteen => TypeRootFilter::U16,

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -878,7 +878,6 @@ impl TraitMap {
                 true,
                 |entry| {
                     if unify_check.check(type_id, entry.key.type_id) {
-                        
                         let trait_items = Self::filter_dummy_methods(
                             &entry.value.trait_items,
                             type_id,

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -880,9 +880,7 @@ impl<'a> TypeCheckContext<'a> {
                         .parameters
                         .iter()
                         .zip(arguments_types.iter().skip(args_len_diff))
-                        .all(|(p, a)| {
-                            coercion_check.check(*a, p.type_argument.type_id())
-                        })
+                        .all(|(p, a)| coercion_check.check(*a, p.type_argument.type_id()))
                     && (matches!(&*type_engine.get(annotation_type), TypeInfo::Unknown)
                         || matches!(
                             &*type_engine.get(method.return_type.type_id()),

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -880,7 +880,9 @@ impl<'a> TypeCheckContext<'a> {
                         .parameters
                         .iter()
                         .zip(arguments_types.iter().skip(args_len_diff))
-                        .all(|(p, a)| coercion_check.check(*a, p.type_argument.type_id()))
+                        .all(|(p, a)| {
+                            coercion_check.check(*a, p.type_argument.type_id())
+                        })
                     && (matches!(&*type_engine.get(annotation_type), TypeInfo::Unknown)
                         || matches!(
                             &*type_engine.get(method.return_type.type_id()),

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast_elements::{length::NumericLength, type_parameter::ConstGenericParameter},
+    ast_elements::type_parameter::ConstGenericParameter,
     attr_decls_to_attributes,
     compiler_generated::{
         generate_destructured_struct_var_name, generate_matched_value_var_name,
@@ -1637,11 +1637,12 @@ fn ty_to_type_info(
             )
         }
         Ty::StringSlice(..) => TypeInfo::StringSlice,
-        Ty::StringArray { length, .. } => TypeInfo::StringArray(expr_to_numeric_length(
+        Ty::StringArray { length, .. } => TypeInfo::StringArray(Length(expr_to_const_generic_expr(
             context,
+            engines,
             handler,
-            *length.into_inner(),
-        )?),
+            length.get(),
+        )?)),
         Ty::Infer { .. } => TypeInfo::Unknown,
         Ty::Ptr { ty, .. } => {
             let type_argument = ty_to_type_argument(context, handler, engines, *ty.into_inner())?;
@@ -3187,16 +3188,6 @@ fn expr_to_const_generic_expr(
             }
         }
     }
-}
-
-fn expr_to_numeric_length(
-    context: &mut Context,
-    handler: &Handler,
-    expr: Expr,
-) -> Result<NumericLength, ErrorEmitted> {
-    let span = expr.span();
-    let val = expr_to_usize(context, handler, expr)?;
-    Ok(NumericLength { val, span })
 }
 
 fn expr_to_usize(

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -1637,12 +1637,9 @@ fn ty_to_type_info(
             )
         }
         Ty::StringSlice(..) => TypeInfo::StringSlice,
-        Ty::StringArray { length, .. } => TypeInfo::StringArray(Length(expr_to_const_generic_expr(
-            context,
-            engines,
-            handler,
-            length.get(),
-        )?)),
+        Ty::StringArray { length, .. } => TypeInfo::StringArray(Length(
+            expr_to_const_generic_expr(context, engines, handler, length.get())?,
+        )),
         Ty::Infer { .. } => TypeInfo::Unknown,
         Ty::Ptr { ty, .. } => {
             let type_argument = ty_to_type_argument(context, handler, engines, *ty.into_inner())?;

--- a/sway-core/src/type_system/ast_elements/length.rs
+++ b/sway-core/src/type_system/ast_elements/length.rs
@@ -1,5 +1,4 @@
 use super::type_parameter::ConstGenericExpr;
-use sway_types::{span::Span, Spanned};
 
 /// Describes a fixed length for types that need it, e.g., [crate::TypeInfo::Array].
 ///
@@ -19,27 +18,5 @@ pub struct Length(pub ConstGenericExpr);
 impl Length {
     pub fn expr(&self) -> &ConstGenericExpr {
         &self.0
-    }
-}
-
-#[derive(Debug, Clone, Hash)]
-pub struct NumericLength {
-    pub val: usize,
-    pub span: Span,
-}
-
-impl NumericLength {
-    pub fn val(&self) -> usize {
-        self.val
-    }
-
-    pub fn is_annotated(&self) -> bool {
-        !self.span().is_dummy()
-    }
-}
-
-impl Spanned for NumericLength {
-    fn span(&self) -> Span {
-        self.span.clone()
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -1052,7 +1052,9 @@ pub struct ConstGenericParameter {
 
 impl HashWithEngines for ConstGenericParameter {
     fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
-        let ConstGenericParameter { name, ty, id, expr, .. } = self;
+        let ConstGenericParameter {
+            name, ty, id, expr, ..
+        } = self;
         let type_engine = engines.te();
         type_engine.get(*ty).hash(state, engines);
         name.hash(state);

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -1052,7 +1052,7 @@ pub struct ConstGenericParameter {
 
 impl HashWithEngines for ConstGenericParameter {
     fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
-        let ConstGenericParameter { name, ty, id, .. } = self;
+        let ConstGenericParameter { name, ty, id, expr, .. } = self;
         let type_engine = engines.te();
         type_engine.get(*ty).hash(state, engines);
         name.hash(state);
@@ -1060,6 +1060,14 @@ impl HashWithEngines for ConstGenericParameter {
             let decl = engines.pe().get(id);
             decl.name.hash(state);
             decl.ty.hash(state);
+        }
+        match &expr {
+            Some(expr) => {
+                expr.hash(state);
+            }
+            None => {
+                self.name.hash(state);
+            }
         }
     }
 }

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -969,7 +969,9 @@ impl TypeEngine {
             | TypeInfo::Placeholder(_)
             | TypeInfo::UnknownGeneric { .. }
             | TypeInfo::Array(.., Length(ConstGenericExpr::AmbiguousVariableExpression { .. }))
-            | TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression { .. }))
+            | TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression {
+                ..
+            }))
             | TypeInfo::Struct(_)
             | TypeInfo::Enum(_) => true,
             TypeInfo::ContractCaller { abi_name, address } => {

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -862,6 +862,14 @@ impl TypeEngine {
         self.insert_or_replace_type_source_info(engines, ty, source_id, is_shareable_type, None)
     }
 
+    // Get, clone, insert and return new TypeId.
+    // Keep the same source_id
+    pub fn duplicate(&self, engines: &Engines, id: TypeId) -> TypeId {
+        let type_source_info = self.slab.get(id.index());
+        let duplicate = TypeInfo::clone(&type_source_info.type_info);
+        self.insert(engines, duplicate, type_source_info.source_id.as_ref())
+    }
+
     /// This method performs two actions, depending on the `replace_at_type_id`.
     ///
     /// If the `replace_at_type_id` is `Some`, this indicates that we want to unconditionally replace the [TypeSourceInfo]

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -26,10 +26,7 @@ use sway_types::{
     integer_bits::IntegerBits, span::Span, Ident, Named, ProgramId, SourceId, Spanned,
 };
 
-use super::{
-    ast_elements::type_parameter::ConstGenericExpr,
-    unify::unifier::UnifyKind,
-};
+use super::{ast_elements::type_parameter::ConstGenericExpr, unify::unifier::UnifyKind};
 
 /// To be able to garbage-collect [TypeInfo]s from the [TypeEngine]
 /// we need to track which types need to be GCed when a particular
@@ -611,10 +608,7 @@ impl TypeEngine {
         engines: &Engines,
         length: usize,
     ) -> TypeId {
-        self.insert_string_array(
-            engines,
-            Length(ConstGenericExpr::literal(length, None)),
-        )
+        self.insert_string_array(engines, Length(ConstGenericExpr::literal(length, None)))
     }
 
     /// Inserts a new [TypeInfo::ContractCaller] into the [TypeEngine] and returns its [TypeId].

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -1,12 +1,16 @@
 use crate::{
-    decl_engine::{parsed_id::ParsedDeclId, DeclEngine, DeclEngineGet, DeclId}, engine_threading::{
+    decl_engine::{parsed_id::ParsedDeclId, DeclEngine, DeclEngineGet, DeclId},
+    engine_threading::{
         DebugWithEngines, DisplayWithEngines, Engines, EqWithEngines, HashWithEngines,
         OrdWithEngines, OrdWithEnginesContext, PartialEqWithEngines, PartialEqWithEnginesContext,
-    }, language::{
+    },
+    language::{
         parsed::{EnumDeclaration, StructDeclaration},
         ty::{self, TyEnumDecl, TyStructDecl},
         CallPath, CallPathType, QualifiedCallPath,
-    }, type_system::priv_prelude::*, Ident
+    },
+    type_system::priv_prelude::*,
+    Ident,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -21,9 +25,7 @@ use sway_error::{
 };
 use sway_types::{integer_bits::IntegerBits, span::Span, Named};
 
-use super::ast_elements::{
-    type_argument::GenericTypeArgument, type_parameter::ConstGenericExpr,
-};
+use super::ast_elements::{type_argument::GenericTypeArgument, type_parameter::ConstGenericExpr};
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum AbiName {
@@ -451,13 +453,13 @@ impl OrdWithEngines for TypeInfo {
                 .then_with(|| l_type_args.as_deref().cmp(&r_type_args.as_deref(), ctx)),
             (Self::StringArray(l), Self::StringArray(r)) => {
                 if let Some(ord) = l.expr().partial_cmp(r.expr()) {
-                        ord
-                    } else {
-                        l.expr()
-                            .discriminant_value()
-                            .cmp(&r.expr().discriminant_value())
-                    }
-            },
+                    ord
+                } else {
+                    l.expr()
+                        .discriminant_value()
+                        .cmp(&r.expr().discriminant_value())
+                }
+            }
             (Self::UnsignedInteger(l), Self::UnsignedInteger(r)) => l.cmp(r),
             (Self::Enum(l_decl_id), Self::Enum(r_decl_id)) => {
                 let l_decl = decl_engine.get_enum(l_decl_id);
@@ -575,7 +577,7 @@ impl DisplayWithEngines for TypeInfo {
                     }
                 };
                 format!("str[{}]", length)
-            },
+            }
             UnsignedInteger(x) => match x {
                 IntegerBits::Eight => "u8",
                 IntegerBits::Sixteen => "u16",
@@ -708,11 +710,8 @@ impl DebugWithEngines for TypeInfo {
             TypeParam(param) => format!("typeparam({})", param.name()),
             StringSlice => "str".into(),
             StringArray(length) => {
-                format!(
-                    "str[{:?}]",
-                    engines.help_out(length.expr()),
-                )
-            },
+                format!("str[{:?}]", engines.help_out(length.expr()),)
+            }
             UnsignedInteger(x) => match x {
                 IntegerBits::Eight => "u8",
                 IntegerBits::Sixteen => "u16",
@@ -967,7 +966,7 @@ impl TypeInfo {
                     .as_literal_val()
                     .expect("unexpected non literal length");
                 format!("str[{}]", len)
-            },
+            }
             UnsignedInteger(bits) => {
                 use IntegerBits::{Eight, Sixteen, SixtyFour, ThirtyTwo, V256};
                 match bits {
@@ -1684,12 +1683,10 @@ impl TypeInfo {
                 }
             }
 
-            TypeInfo::StringArray(len) => {
-                match len.expr() {
-                    ConstGenericExpr::Literal { val, .. } => AbiEncodeSizeHint::Exact(*val),
-                    ConstGenericExpr::AmbiguousVariableExpression { .. } => {
-                        AbiEncodeSizeHint::PotentiallyInfinite
-                    }
+            TypeInfo::StringArray(len) => match len.expr() {
+                ConstGenericExpr::Literal { val, .. } => AbiEncodeSizeHint::Exact(*val),
+                ConstGenericExpr::AmbiguousVariableExpression { .. } => {
+                    AbiEncodeSizeHint::PotentiallyInfinite
                 }
             },
 
@@ -1758,11 +1755,8 @@ impl TypeInfo {
             TypeParam(param) => format!("typeparam({})", param.name()),
             StringSlice => "str".into(),
             StringArray(length) => {
-                format!(
-                    "str[{:?}]",
-                    engines.help_out(length.expr())
-                )
-            },
+                format!("str[{:?}]", engines.help_out(length.expr()))
+            }
             UnsignedInteger(x) => match x {
                 IntegerBits::Eight => "u8",
                 IntegerBits::Sixteen => "u16",

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -397,7 +397,7 @@ impl<'a> Unifier<'a> {
             (
                 ConstGenericExpr::AmbiguousVariableExpression { .. },
                 ConstGenericExpr::Literal { .. },
-            ) => todo!(),
+            ) => todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860"),
             (
                 ConstGenericExpr::AmbiguousVariableExpression { ident: r_ident },
                 ConstGenericExpr::AmbiguousVariableExpression { ident: e_ident },

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -254,6 +254,24 @@ impl<'a> UnifyCheck<'a> {
         self.check_inner(left, right)
     }
 
+    fn check_length(&self, l1: &Length, r1: &Length) -> bool {
+        match (&l1.expr(), &r1.expr()) {
+            (
+                ConstGenericExpr::Literal { val: l, .. },
+                ConstGenericExpr::Literal { val: r, .. },
+            ) => l == r,
+            (
+                ConstGenericExpr::AmbiguousVariableExpression { ident: l },
+                ConstGenericExpr::AmbiguousVariableExpression { ident: r },
+            ) => l == r,
+            (
+                ConstGenericExpr::Literal { .. },
+                ConstGenericExpr::AmbiguousVariableExpression { .. },
+            ) => true,
+            _ => false,
+        }
+    }
+
     fn check_inner(&self, left: TypeId, right: TypeId) -> bool {
         use TypeInfo::{
             Alias, Array, ContractCaller, Custom, Enum, ErrorRecovery, Never, Numeric, Placeholder,
@@ -287,21 +305,7 @@ impl<'a> UnifyCheck<'a> {
                 return if !elem_types_unify {
                     false
                 } else {
-                    match (&l1.expr(), &r1.expr()) {
-                        (
-                            ConstGenericExpr::Literal { val: l, .. },
-                            ConstGenericExpr::Literal { val: r, .. },
-                        ) => l == r,
-                        (
-                            ConstGenericExpr::AmbiguousVariableExpression { ident: l },
-                            ConstGenericExpr::AmbiguousVariableExpression { ident: r },
-                        ) => l == r,
-                        (
-                            ConstGenericExpr::Literal { .. },
-                            ConstGenericExpr::AmbiguousVariableExpression { .. },
-                        ) => true,
-                        _ => false,
-                    }
+                    self.check_length(l1, r1)
                 };
             }
 
@@ -483,7 +487,7 @@ impl<'a> UnifyCheck<'a> {
                     (UnsignedInteger(_), Numeric) => true,
 
                     (StringSlice, StringSlice) => true,
-                    (StringArray(l), StringArray(r)) => l.val() == r.val(),
+                    (StringArray(l), StringArray(r)) => self.check_length(l, r),
 
                     // For contract callers, they can be coerced if they have the same
                     // name and at least one has an address of `None`
@@ -512,6 +516,7 @@ impl<'a> UnifyCheck<'a> {
             }
             ConstraintSubset | NonGenericConstraintSubset => {
                 match (&*left_info, &*right_info) {
+                    (StringArray(l), StringArray(r)) => self.check_length(l, r),
                     (
                         UnknownGeneric {
                             name: _,
@@ -552,7 +557,7 @@ impl<'a> UnifyCheck<'a> {
                 (TypeInfo::B256, TypeInfo::B256) => true,
                 (TypeInfo::ErrorRecovery(_), TypeInfo::ErrorRecovery(_)) => true,
                 (TypeInfo::StringSlice, TypeInfo::StringSlice) => true,
-                (TypeInfo::StringArray(l), TypeInfo::StringArray(r)) => l.val() == r.val(),
+                (TypeInfo::StringArray(l), TypeInfo::StringArray(r)) => self.check_length(l, r),
                 (TypeInfo::UnsignedInteger(l), TypeInfo::UnsignedInteger(r)) => l == r,
                 (TypeInfo::RawUntypedPtr, TypeInfo::RawUntypedPtr) => true,
                 (TypeInfo::RawUntypedSlice, TypeInfo::RawUntypedSlice) => true,

--- a/sway-lib-std/generate.sh
+++ b/sway-lib-std/generate.sh
@@ -238,7 +238,7 @@ remove_generated_code "STRARRAY_DEBUG" "debug.sw"
 START=1
 END=64
 for ((i=END;i>=START;i--)); do
-    CODE="impl Debug for str[$i] { fn fmt(self, ref mut f: Formatter) { use ::str::*; from_str_array(self).fmt(f); } }"
+    CODE="#[cfg(experimental_const_generics = false)]\nimpl Debug for str[$i] { fn fmt(self, ref mut f: Formatter) { use ::str::*; from_str_array(self).fmt(f); } }"
     sed -i "s/\/\/ BEGIN STRARRAY_DEBUG/\/\/ BEGIN STRARRAY_DEBUG\n$CODE/g" ./src/debug.sw
 done
 

--- a/sway-lib-std/src/debug.sw
+++ b/sway-lib-std/src/debug.sw
@@ -2756,8 +2756,7 @@ where
 
 
 #[cfg(experimental_const_generics = true)]
-impl<const N: u64> Debug for str[N]
-{
+impl<const N: u64> Debug for str[N] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);

--- a/sway-lib-std/src/debug.sw
+++ b/sway-lib-std/src/debug.sw
@@ -1382,6 +1382,7 @@ where
 }
 // END ARRAY_DEBUG
 
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[0] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
@@ -1390,384 +1391,448 @@ impl Debug for str[0] {
 }
 
 // BEGIN STRARRAY_DEBUG
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[1] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[2] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[3] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[4] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[5] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[6] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[7] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[8] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[9] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[10] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[11] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[12] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[13] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[14] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[15] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[16] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[17] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[18] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[19] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[20] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[21] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[22] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[23] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[24] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[25] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[26] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[27] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[28] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[29] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[30] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[31] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[32] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[33] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[34] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[35] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[36] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[37] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[38] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[39] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[40] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[41] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[42] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[43] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[44] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[45] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[46] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[47] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[48] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[49] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[50] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[51] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[52] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[53] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[54] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[55] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[56] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[57] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[58] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[59] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[60] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[61] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[62] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[63] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
         from_str_array(self).fmt(f);
     }
 }
+#[cfg(experimental_const_generics = false)]
 impl Debug for str[64] {
     fn fmt(self, ref mut f: Formatter) {
         use ::str::*;
@@ -2688,3 +2753,13 @@ where
     }
 }
 // END TUPLES_DEBUG
+
+
+#[cfg(experimental_const_generics = true)]
+impl<const N: u64> Debug for str[N]
+{
+    fn fmt(self, ref mut f: Formatter) {
+        use ::str::*;
+        from_str_array(self).fmt(f);
+    }
+}

--- a/sway-lib-std/src/primitives.sw
+++ b/sway-lib-std/src/primitives.sw
@@ -449,3 +449,17 @@ impl b256 {
         0x0000000000000000000000000000000000000000000000000000000000000000
     }
 }
+
+#[cfg(experimental_const_generics = true)]
+impl<T, const N: u64> [T; N] {
+    pub fn len(self) -> u64 {
+        N
+    }
+}
+
+#[cfg(experimental_const_generics = true)]
+impl<const N: u64> str[N] {
+    pub fn len(self) -> u64 {
+        N
+    }
+}

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -1151,7 +1151,7 @@ fn collect_type_info_token(ctx: &ParseContext, type_info: &TypeInfo, type_span: 
     let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), type_info, type_span);
     match type_info {
         TypeInfo::StringArray(length) => {
-            let ident = Ident::new(length.span());
+            let ident = Ident::new(length.expr().span());
             ctx.tokens.insert(
                 ctx.ident(&ident),
                 Token::from_parsed(ParsedAstToken::Ident(ident.clone()), symbol_kind),

--- a/sway-parse/src/item/item_impl.rs
+++ b/sway-parse/src/item/item_impl.rs
@@ -34,7 +34,7 @@ impl Parse for ItemImpl {
     fn parse(parser: &mut Parser) -> ParseResult<ItemImpl> {
         let impl_token = parser.parse()?;
         let generic_params_opt = parser.guarded_parse::<OpenAngleBracketToken, GenericParams>()?;
-        let ty = parser.parse()?;
+        let ty = parser.parse::<Ty>()?;
         let (trait_opt, ty) = match parser.take() {
             Some(for_token) => match ty {
                 Ty::Path(path_type) => (Some((path_type, for_token)), parser.parse()?),

--- a/sway-parse/src/ty/mod.rs
+++ b/sway-parse/src/ty/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Parse, ParseBracket, ParseResult, ParseToEnd, Parser, ParserConsumed};
 use sway_ast::brackets::{Parens, SquareBrackets};
-use sway_ast::keywords::{DoubleColonToken, OpenAngleBracketToken, PtrToken, SliceToken};
+use sway_ast::keywords::{DoubleColonToken, OpenAngleBracketToken, PtrToken, SliceToken, StrToken};
 use sway_ast::ty::{Ty, TyArrayDescriptor, TyTupleDescriptor};
 use sway_ast::{Expr, Literal};
 use sway_error::parser_error::ParseErrorKind;
@@ -49,7 +49,9 @@ impl Parse for Ty {
             }
         }
 
-        if let Some(str_token) = parser.take() {
+        // string array like str[1] or str[N]
+        // or string slice like str
+        if let Some(str_token) = parser.take::<StrToken>() {
             let length = SquareBrackets::try_parse_all_inner(parser, |mut parser| {
                 parser.emit_error(ParseErrorKind::UnexpectedTokenAfterStrLength)
             })?;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
@@ -91,7 +91,10 @@ fn main(a: [u64; 2]) {
     assert(b == 3);
     //__dbg(e);
 
+    // standalone fns
+    assert(return_n::<3>() == 3);
     let _ = __dbg(return_n::<3>());
+    assert(return_n::<5>() == 5);
     let _ = __dbg(return_n::<5>());
 
     // string arrays

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw
@@ -66,9 +66,13 @@ fn main(a: [u64; 2]) {
 
     let a = [C {}].my_len();
     assert(a == 1);
+    let _ = __dbg([C {}].len());
+    assert([C {}].len() == 1);
 
     let b = [C {}, C{}].my_len();
     assert(b == 2);
+    let _ = __dbg([C {}, C{}].len());
+    assert([C {}, C{}].len() == 2);
 
     let s: S<u64, 3> = S { };
     let _ = __dbg(s.len_xxx());
@@ -89,6 +93,15 @@ fn main(a: [u64; 2]) {
 
     let _ = __dbg(return_n::<3>());
     let _ = __dbg(return_n::<5>());
+
+    // string arrays
+    let a: str[3] = __to_str_array("ABC");
+    assert(a.len() == 3);
+    let _ = __dbg(a.len());
+
+    let a: str[5] = __to_str_array("ABCDE");
+    assert(a.len() == 5);
+    let _ = __dbg(a.len());
 }
 
 #[test]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
@@ -1,5 +1,6 @@
 ---
 source: test/src/snapshot/mod.rs
+snapshot_kind: text
 ---
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --release
 exit status: 1
@@ -8,7 +9,6 @@ output:
    Compiling library std (sway-lib-std)
    Compiling script const_generics (test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics)
 warning
-<<<<<<< HEAD
   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:50:5
    |
 48 | enum TwoVariants<T, const N: u64> {
@@ -17,29 +17,31 @@ warning
    |     ----- Enum variant Array is never constructed.
 51 | }
 52 | 
-=======
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:50:9
-   |
-48 | 
-49 |     // string arrays
-50 |     let a: str[3] = __to_str_array("ABC");
-   |         - This declaration is never used.
-51 |     assert(a.len() == 3);
-52 |     let _ = __dbg(a.len());
    |
 ____
 
 warning
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:54:9
-   |
-52 |     let _ = __dbg(a.len());
-53 | 
-54 |     let a: str[5] = __to_str_array("ABCDE");
-   |         - This declaration is never used.
-55 |     assert(a.len() == 5);
-56 |     let _ = __dbg(a.len());
->>>>>>> cosnt generics for string array and len methods
-   |
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:98:9
+    |
+ 96 | 
+ 97 |     // string arrays
+ 98 |     let a: str[3] = __to_str_array("ABC");
+    |         - This declaration is never used.
+ 99 |     assert(a.len() == 3);
+100 |     let _ = __dbg(a.len());
+    |
+____
+
+warning
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:102:9
+    |
+100 |     let _ = __dbg(a.len());
+101 | 
+102 |     let a: str[5] = __to_str_array("ABCDE");
+    |         - This declaration is never used.
+103 |     assert(a.len() == 5);
+104 |     let _ = __dbg(a.len());
+    |
 ____
 
 error
@@ -138,155 +140,151 @@ error
    |
 ____
 
-<<<<<<< HEAD
-  Aborting due to 8 errors.
-=======
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:35:26
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:69:26
    |
-33 |     let a = [C {}].my_len();
-34 |     assert(a == 1);
-35 |     let _ = __dbg([C {}].len());
+67 |     let a = [C {}].my_len();
+68 |     assert(a == 1);
+69 |     let _ = __dbg([C {}].len());
    |                          ^^^ No method "len([C; 1])" found for type "[C; 1]".
-36 |     assert([C {}].len() == 1);
-37 | 
+70 |     assert([C {}].len() == 1);
+71 | 
    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:36:19
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:70:19
    |
-34 |     assert(a == 1);
-35 |     let _ = __dbg([C {}].len());
-36 |     assert([C {}].len() == 1);
+68 |     assert(a == 1);
+69 |     let _ = __dbg([C {}].len());
+70 |     assert([C {}].len() == 1);
    |                   ^^^ No method "len([C; 1])" found for type "[C; 1]".
-37 | 
-38 |     let b = [C {}, C{}].my_len();
+71 | 
+72 |     let b = [C {}, C{}].my_len();
    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:36:25
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:70:25
    |
-34 |     assert(a == 1);
-35 |     let _ = __dbg([C {}].len());
-36 |     assert([C {}].len() == 1);
+68 |     assert(a == 1);
+69 |     let _ = __dbg([C {}].len());
+70 |     assert([C {}].len() == 1);
    |                         ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
-37 | 
-38 |     let b = [C {}, C{}].my_len();
+71 | 
+72 |     let b = [C {}, C{}].my_len();
    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:40:31
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:74:31
    |
-38 |     let b = [C {}, C{}].my_len();
-39 |     assert(b == 2);
-40 |     let _ = __dbg([C {}, C{}].len());
+72 |     let b = [C {}, C{}].my_len();
+73 |     assert(b == 2);
+74 |     let _ = __dbg([C {}, C{}].len());
    |                               ^^^ No method "len([C; 2])" found for type "[C; 2]".
-41 |     assert([C {}, C{}].len() == 2);
-42 | 
+75 |     assert([C {}, C{}].len() == 2);
+76 | 
    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:41:24
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:75:24
    |
-39 |     assert(b == 2);
-40 |     let _ = __dbg([C {}, C{}].len());
-41 |     assert([C {}, C{}].len() == 2);
+73 |     assert(b == 2);
+74 |     let _ = __dbg([C {}, C{}].len());
+75 |     assert([C {}, C{}].len() == 2);
    |                        ^^^ No method "len([C; 2])" found for type "[C; 2]".
-42 | 
-43 |     let s: S<u64, 3> = S { };
+76 | 
+77 |     let s: S<u64, 3> = S { };
    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:41:30
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:75:30
    |
-39 |     assert(b == 2);
-40 |     let _ = __dbg([C {}, C{}].len());
-41 |     assert([C {}, C{}].len() == 2);
+73 |     assert(b == 2);
+74 |     let _ = __dbg([C {}, C{}].len());
+75 |     assert([C {}, C{}].len() == 2);
    |                              ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
-42 | 
-43 |     let s: S<u64, 3> = S { };
+76 | 
+77 |     let s: S<u64, 3> = S { };
    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:51:14
-   |
-49 |     // string arrays
-50 |     let a: str[3] = __to_str_array("ABC");
-51 |     assert(a.len() == 3);
-   |              ^^^ No method "len(str[3])" found for type "str[3]".
-52 |     let _ = __dbg(a.len());
-53 | 
-   |
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:99:14
+    |
+ 97 |     // string arrays
+ 98 |     let a: str[3] = __to_str_array("ABC");
+ 99 |     assert(a.len() == 3);
+    |              ^^^ No method "len(str[3])" found for type "str[3]".
+100 |     let _ = __dbg(a.len());
+101 | 
+    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:51:20
-   |
-49 |     // string arrays
-50 |     let a: str[3] = __to_str_array("ABC");
-51 |     assert(a.len() == 3);
-   |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
-52 |     let _ = __dbg(a.len());
-53 | 
-   |
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:99:20
+    |
+ 97 |     // string arrays
+ 98 |     let a: str[3] = __to_str_array("ABC");
+ 99 |     assert(a.len() == 3);
+    |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
+100 |     let _ = __dbg(a.len());
+101 | 
+    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:52:21
-   |
-50 |     let a: str[3] = __to_str_array("ABC");
-51 |     assert(a.len() == 3);
-52 |     let _ = __dbg(a.len());
-   |                     ^^^ No method "len(str[3])" found for type "str[3]".
-53 | 
-54 |     let a: str[5] = __to_str_array("ABCDE");
-   |
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:100:21
+    |
+ 98 |     let a: str[3] = __to_str_array("ABC");
+ 99 |     assert(a.len() == 3);
+100 |     let _ = __dbg(a.len());
+    |                     ^^^ No method "len(str[3])" found for type "str[3]".
+101 | 
+102 |     let a: str[5] = __to_str_array("ABCDE");
+    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:55:14
-   |
-53 | 
-54 |     let a: str[5] = __to_str_array("ABCDE");
-55 |     assert(a.len() == 5);
-   |              ^^^ No method "len(str[5])" found for type "str[5]".
-56 |     let _ = __dbg(a.len());
-57 | }
-   |
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:103:14
+    |
+101 | 
+102 |     let a: str[5] = __to_str_array("ABCDE");
+103 |     assert(a.len() == 5);
+    |              ^^^ No method "len(str[5])" found for type "str[5]".
+104 |     let _ = __dbg(a.len());
+105 | }
+    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:55:20
-   |
-53 | 
-54 |     let a: str[5] = __to_str_array("ABCDE");
-55 |     assert(a.len() == 5);
-   |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
-56 |     let _ = __dbg(a.len());
-57 | }
-   |
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:103:20
+    |
+101 | 
+102 |     let a: str[5] = __to_str_array("ABCDE");
+103 |     assert(a.len() == 5);
+    |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
+104 |     let _ = __dbg(a.len());
+105 | }
+    |
 ____
 
 error
-  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:56:21
-   |
-54 |     let a: str[5] = __to_str_array("ABCDE");
-55 |     assert(a.len() == 5);
-56 |     let _ = __dbg(a.len());
-   |                     ^^^ No method "len(str[5])" found for type "str[5]".
-57 | }
-58 | 
-   |
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:104:21
+    |
+102 |     let a: str[5] = __to_str_array("ABCDE");
+103 |     assert(a.len() == 5);
+104 |     let _ = __dbg(a.len());
+    |                     ^^^ No method "len(str[5])" found for type "str[5]".
+105 | }
+106 | 
+    |
 ____
 
-  Aborting due to 16 errors.
->>>>>>> cosnt generics for string array and len methods
+  Aborting due to 20 errors.
 error: Failed to compile const_generics
 
 > forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --experimental const_generics --test-threads 1 --logs --revert-codes
@@ -295,34 +293,22 @@ output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics
    Compiling library std (sway-lib-std)
    Compiling script const_generics (test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics)
-<<<<<<< HEAD
-    Finished debug [unoptimized + fuel] target(s) [5.048 KB] in ???
-=======
-    Finished debug [unoptimized + fuel] target(s) [3.952 KB] in ???
->>>>>>> cosnt generics for string array and len methods
+    Finished debug [unoptimized + fuel] target(s) [6.16 KB] in ???
      Running 1 test, filtered 0 tests
 
 tested -- const_generics
 
-<<<<<<< HEAD
-      test run_main ... ok (???, 8053 gas)
+      test run_main ... ok (???, 11428 gas)
 [src/main.sw:65:13] a = [1, 2]
-[src/main.sw:74:13] s.len_xxx() = 3
-[src/main.sw:80:13] e = OneVariant([1, 2, 3])
-[src/main.sw:85:13] e = Nothing
-[src/main.sw:90:13] return_n::<3>() = 3
-[src/main.sw:91:13] return_n::<5>() = 3
-=======
-      test run_main ... ok (???, 7415 gas)
-[src/main.sw:31:13] a = [1, 2]
-[src/main.sw:35:13] [C {}].len() = 1
-[src/main.sw:40:13] [C {}, C {}].len() = 2
-[src/main.sw:44:13] s.len_xxx() = 3
-[src/main.sw:46:13] return_n::<3>() = 3
-[src/main.sw:47:13] return_n::<5>() = 5
-[src/main.sw:52:13] a.len() = 3
-[src/main.sw:56:13] a.len() = 5
->>>>>>> cosnt generics for string array and len methods
+[src/main.sw:69:13] [C {}].len() = 1
+[src/main.sw:74:13] [C {}, C {}].len() = 2
+[src/main.sw:78:13] s.len_xxx() = 3
+[src/main.sw:84:13] e = OneVariant([1, 2, 3])
+[src/main.sw:89:13] e = Nothing
+[src/main.sw:94:13] return_n::<3>() = 3
+[src/main.sw:95:13] return_n::<5>() = 3
+[src/main.sw:100:13] a.len() = 3
+[src/main.sw:104:13] a.len() = 5
 
 test result: OK. 1 passed; 0 failed; finished in ???
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
@@ -1,6 +1,5 @@
 ---
 source: test/src/snapshot/mod.rs
-snapshot_kind: text
 ---
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --release
 exit status: 1
@@ -21,26 +20,26 @@ warning
 ____
 
 warning
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:98:9
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:101:9
     |
- 96 | 
- 97 |     // string arrays
- 98 |     let a: str[3] = __to_str_array("ABC");
+ 99 | 
+100 |     // string arrays
+101 |     let a: str[3] = __to_str_array("ABC");
     |         - This declaration is never used.
- 99 |     assert(a.len() == 3);
-100 |     let _ = __dbg(a.len());
+102 |     assert(a.len() == 3);
+103 |     let _ = __dbg(a.len());
     |
 ____
 
 warning
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:102:9
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:105:9
     |
-100 |     let _ = __dbg(a.len());
-101 | 
-102 |     let a: str[5] = __to_str_array("ABCDE");
+103 |     let _ = __dbg(a.len());
+104 | 
+105 |     let a: str[5] = __to_str_array("ABCDE");
     |         - This declaration is never used.
-103 |     assert(a.len() == 5);
-104 |     let _ = __dbg(a.len());
+106 |     assert(a.len() == 5);
+107 |     let _ = __dbg(a.len());
     |
 ____
 
@@ -213,74 +212,74 @@ error
 ____
 
 error
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:99:14
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:102:14
     |
- 97 |     // string arrays
- 98 |     let a: str[3] = __to_str_array("ABC");
- 99 |     assert(a.len() == 3);
+100 |     // string arrays
+101 |     let a: str[3] = __to_str_array("ABC");
+102 |     assert(a.len() == 3);
     |              ^^^ No method "len(str[3])" found for type "str[3]".
-100 |     let _ = __dbg(a.len());
-101 | 
+103 |     let _ = __dbg(a.len());
+104 | 
     |
 ____
 
 error
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:99:20
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:102:20
     |
- 97 |     // string arrays
- 98 |     let a: str[3] = __to_str_array("ABC");
- 99 |     assert(a.len() == 3);
+100 |     // string arrays
+101 |     let a: str[3] = __to_str_array("ABC");
+102 |     assert(a.len() == 3);
     |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
-100 |     let _ = __dbg(a.len());
-101 | 
+103 |     let _ = __dbg(a.len());
+104 | 
     |
 ____
 
 error
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:100:21
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:103:21
     |
- 98 |     let a: str[3] = __to_str_array("ABC");
- 99 |     assert(a.len() == 3);
-100 |     let _ = __dbg(a.len());
+101 |     let a: str[3] = __to_str_array("ABC");
+102 |     assert(a.len() == 3);
+103 |     let _ = __dbg(a.len());
     |                     ^^^ No method "len(str[3])" found for type "str[3]".
-101 | 
-102 |     let a: str[5] = __to_str_array("ABCDE");
+104 | 
+105 |     let a: str[5] = __to_str_array("ABCDE");
     |
 ____
 
 error
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:103:14
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:106:14
     |
-101 | 
-102 |     let a: str[5] = __to_str_array("ABCDE");
-103 |     assert(a.len() == 5);
+104 | 
+105 |     let a: str[5] = __to_str_array("ABCDE");
+106 |     assert(a.len() == 5);
     |              ^^^ No method "len(str[5])" found for type "str[5]".
-104 |     let _ = __dbg(a.len());
-105 | }
+107 |     let _ = __dbg(a.len());
+108 | }
     |
 ____
 
 error
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:103:20
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:106:20
     |
-101 | 
-102 |     let a: str[5] = __to_str_array("ABCDE");
-103 |     assert(a.len() == 5);
+104 | 
+105 |     let a: str[5] = __to_str_array("ABCDE");
+106 |     assert(a.len() == 5);
     |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
-104 |     let _ = __dbg(a.len());
-105 | }
+107 |     let _ = __dbg(a.len());
+108 | }
     |
 ____
 
 error
-   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:104:21
+   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:107:21
     |
-102 |     let a: str[5] = __to_str_array("ABCDE");
-103 |     assert(a.len() == 5);
-104 |     let _ = __dbg(a.len());
+105 |     let a: str[5] = __to_str_array("ABCDE");
+106 |     assert(a.len() == 5);
+107 |     let _ = __dbg(a.len());
     |                     ^^^ No method "len(str[5])" found for type "str[5]".
-105 | }
-106 | 
+108 | }
+109 | 
     |
 ____
 
@@ -293,22 +292,22 @@ output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics
    Compiling library std (sway-lib-std)
    Compiling script const_generics (test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics)
-    Finished debug [unoptimized + fuel] target(s) [6.16 KB] in ???
+    Finished debug [unoptimized + fuel] target(s) [6.288 KB] in ???
      Running 1 test, filtered 0 tests
 
 tested -- const_generics
 
-      test run_main ... ok (???, 11428 gas)
+      test run_main ... ok (???, 11510 gas)
 [src/main.sw:65:13] a = [1, 2]
 [src/main.sw:69:13] [C {}].len() = 1
 [src/main.sw:74:13] [C {}, C {}].len() = 2
 [src/main.sw:78:13] s.len_xxx() = 3
 [src/main.sw:84:13] e = OneVariant([1, 2, 3])
 [src/main.sw:89:13] e = Nothing
-[src/main.sw:94:13] return_n::<3>() = 3
-[src/main.sw:95:13] return_n::<5>() = 3
-[src/main.sw:100:13] a.len() = 3
-[src/main.sw:104:13] a.len() = 5
+[src/main.sw:96:13] return_n::<3>() = 3
+[src/main.sw:98:13] return_n::<5>() = 5
+[src/main.sw:103:13] a.len() = 3
+[src/main.sw:107:13] a.len() = 5
 
 test result: OK. 1 passed; 0 failed; finished in ???
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
@@ -8,6 +8,7 @@ output:
    Compiling library std (sway-lib-std)
    Compiling script const_generics (test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics)
 warning
+<<<<<<< HEAD
   --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:50:5
    |
 48 | enum TwoVariants<T, const N: u64> {
@@ -16,6 +17,28 @@ warning
    |     ----- Enum variant Array is never constructed.
 51 | }
 52 | 
+=======
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:50:9
+   |
+48 | 
+49 |     // string arrays
+50 |     let a: str[3] = __to_str_array("ABC");
+   |         - This declaration is never used.
+51 |     assert(a.len() == 3);
+52 |     let _ = __dbg(a.len());
+   |
+____
+
+warning
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:54:9
+   |
+52 |     let _ = __dbg(a.len());
+53 | 
+54 |     let a: str[5] = __to_str_array("ABCDE");
+   |         - This declaration is never used.
+55 |     assert(a.len() == 5);
+56 |     let _ = __dbg(a.len());
+>>>>>>> cosnt generics for string array and len methods
    |
 ____
 
@@ -115,7 +138,155 @@ error
    |
 ____
 
+<<<<<<< HEAD
   Aborting due to 8 errors.
+=======
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:35:26
+   |
+33 |     let a = [C {}].my_len();
+34 |     assert(a == 1);
+35 |     let _ = __dbg([C {}].len());
+   |                          ^^^ No method "len([C; 1])" found for type "[C; 1]".
+36 |     assert([C {}].len() == 1);
+37 | 
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:36:19
+   |
+34 |     assert(a == 1);
+35 |     let _ = __dbg([C {}].len());
+36 |     assert([C {}].len() == 1);
+   |                   ^^^ No method "len([C; 1])" found for type "[C; 1]".
+37 | 
+38 |     let b = [C {}, C{}].my_len();
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:36:25
+   |
+34 |     assert(a == 1);
+35 |     let _ = __dbg([C {}].len());
+36 |     assert([C {}].len() == 1);
+   |                         ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
+37 | 
+38 |     let b = [C {}, C{}].my_len();
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:40:31
+   |
+38 |     let b = [C {}, C{}].my_len();
+39 |     assert(b == 2);
+40 |     let _ = __dbg([C {}, C{}].len());
+   |                               ^^^ No method "len([C; 2])" found for type "[C; 2]".
+41 |     assert([C {}, C{}].len() == 2);
+42 | 
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:41:24
+   |
+39 |     assert(b == 2);
+40 |     let _ = __dbg([C {}, C{}].len());
+41 |     assert([C {}, C{}].len() == 2);
+   |                        ^^^ No method "len([C; 2])" found for type "[C; 2]".
+42 | 
+43 |     let s: S<u64, 3> = S { };
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:41:30
+   |
+39 |     assert(b == 2);
+40 |     let _ = __dbg([C {}, C{}].len());
+41 |     assert([C {}, C{}].len() == 2);
+   |                              ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
+42 | 
+43 |     let s: S<u64, 3> = S { };
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:51:14
+   |
+49 |     // string arrays
+50 |     let a: str[3] = __to_str_array("ABC");
+51 |     assert(a.len() == 3);
+   |              ^^^ No method "len(str[3])" found for type "str[3]".
+52 |     let _ = __dbg(a.len());
+53 | 
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:51:20
+   |
+49 |     // string arrays
+50 |     let a: str[3] = __to_str_array("ABC");
+51 |     assert(a.len() == 3);
+   |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
+52 |     let _ = __dbg(a.len());
+53 | 
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:52:21
+   |
+50 |     let a: str[3] = __to_str_array("ABC");
+51 |     assert(a.len() == 3);
+52 |     let _ = __dbg(a.len());
+   |                     ^^^ No method "len(str[3])" found for type "str[3]".
+53 | 
+54 |     let a: str[5] = __to_str_array("ABCDE");
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:55:14
+   |
+53 | 
+54 |     let a: str[5] = __to_str_array("ABCDE");
+55 |     assert(a.len() == 5);
+   |              ^^^ No method "len(str[5])" found for type "str[5]".
+56 |     let _ = __dbg(a.len());
+57 | }
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:55:20
+   |
+53 | 
+54 |     let a: str[5] = __to_str_array("ABCDE");
+55 |     assert(a.len() == 5);
+   |                    ^^ No method "eq({unknown}, numeric) -> bool" found for type "{unknown}".
+56 |     let _ = __dbg(a.len());
+57 | }
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/src/main.sw:56:21
+   |
+54 |     let a: str[5] = __to_str_array("ABCDE");
+55 |     assert(a.len() == 5);
+56 |     let _ = __dbg(a.len());
+   |                     ^^^ No method "len(str[5])" found for type "str[5]".
+57 | }
+58 | 
+   |
+____
+
+  Aborting due to 16 errors.
+>>>>>>> cosnt generics for string array and len methods
 error: Failed to compile const_generics
 
 > forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --experimental const_generics --test-threads 1 --logs --revert-codes
@@ -124,11 +295,16 @@ output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics
    Compiling library std (sway-lib-std)
    Compiling script const_generics (test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics)
+<<<<<<< HEAD
     Finished debug [unoptimized + fuel] target(s) [5.048 KB] in ???
+=======
+    Finished debug [unoptimized + fuel] target(s) [3.952 KB] in ???
+>>>>>>> cosnt generics for string array and len methods
      Running 1 test, filtered 0 tests
 
 tested -- const_generics
 
+<<<<<<< HEAD
       test run_main ... ok (???, 8053 gas)
 [src/main.sw:65:13] a = [1, 2]
 [src/main.sw:74:13] s.len_xxx() = 3
@@ -136,6 +312,17 @@ tested -- const_generics
 [src/main.sw:85:13] e = Nothing
 [src/main.sw:90:13] return_n::<3>() = 3
 [src/main.sw:91:13] return_n::<5>() = 3
+=======
+      test run_main ... ok (???, 7415 gas)
+[src/main.sw:31:13] a = [1, 2]
+[src/main.sw:35:13] [C {}].len() = 1
+[src/main.sw:40:13] [C {}, C {}].len() = 2
+[src/main.sw:44:13] s.len_xxx() = 3
+[src/main.sw:46:13] return_n::<3>() = 3
+[src/main.sw:47:13] return_n::<5>() = 5
+[src/main.sw:52:13] a.len() = 3
+[src/main.sw:56:13] a.len() = 5
+>>>>>>> cosnt generics for string array and len methods
 
 test result: OK. 1 passed; 0 failed; finished in ???
 


### PR DESCRIPTION
## Description

This PR is part of https://github.com/FuelLabs/sway/issues/6860. It implements "const generics" for "string arrays" and `len` methods for arrays and string arrays.

```sway
#[cfg(experimental_const_generics = true)]
impl<const N: u64> str[N] {
    pub fn len(self) -> u64 {
        N
    }
}
````

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
