### PR TITLE
feat: return failed to fetch message for invalid registry lookups

### DIFF
--- a/forc-pkg/src/source/reg/mod.rs
+++ b/forc-pkg/src/source/reg/mod.rs
@@ -510,7 +510,9 @@ where
             anyhow!(
                 "Failed to send request to github to obtain package index file from registry {e}"
             )
-        })?;
+        })?
+        .error_for_status()
+        .map_err(|_| anyhow!("Failed to fetch {pkg_name}"))?;
 
     let contents = index_response.text().await?;
     let index_file: IndexFile = serde_json::from_str(&contents).with_context(|| {


### PR DESCRIPTION
## Description

closes #7186.


Before this PR trying to get a non-existing package would result with:

```sh
error: Unable to deserialize a github registry lookup response. Body was: "404: Not Found"
```

Now we output:

```sh
Failed to fetch {pkg_name}
```

Which is a little bit cleaner in my opinion.