### PR TITLE
Removing needless allocations (clone, to_vec, collect etc...)

### DIFF
--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -13,7 +13,6 @@ use ast_elements::type_parameter::GenericTypeParameter;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::VecDeque,
     fmt::{self, Write},
     hash::{Hash, Hasher},
 };
@@ -862,16 +861,17 @@ impl ReplaceDecls for TyExpressionVariant {
                     // including those from the impl trait.
                     if method.is_trait_method_dummy {
                         if let Some(implementing_for_typeid) = method.implementing_for_typeid {
+                            let arguments_types = arguments
+                                .iter()
+                                .map(|a| a.1.return_type)
+                                .collect::<Vec<_>>();
                             let implementing_type_method_ref = ctx.find_method_for_type(
                                 handler,
                                 implementing_for_typeid,
                                 &[ctx.namespace().current_package_name().clone()],
                                 &call_path.suffix,
                                 method.return_type.type_id(),
-                                &arguments
-                                    .iter()
-                                    .map(|a| a.1.return_type)
-                                    .collect::<VecDeque<_>>(),
+                                &arguments_types,
                                 None,
                             )?;
                             method = (*decl_engine.get(&implementing_type_method_ref)).clone();

--- a/sway-core/src/query_engine/mod.rs
+++ b/sway-core/src/query_engine/mod.rs
@@ -185,12 +185,12 @@ impl QueryEngine {
     pub fn get_function(
         &self,
         engines: &Engines,
-        ident: IdentUnique,
+        ident: &IdentUnique,
         sig: TyFunctionSig,
     ) -> Option<DeclRef<DeclId<TyFunctionDecl>>> {
         let cache = self.function_cache.read();
         cache
-            .get(&(ident, sig.get_type_str(engines)))
+            .get(&(ident.clone(), sig.get_type_str(engines)))
             .map(|s| s.fn_decl.clone())
     }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -112,7 +112,7 @@ impl ty::TyAbiDecl {
                             &mod_path,
                             &method_name.clone(),
                             ctx.type_annotation(),
-                            &Default::default(),
+                            &[],
                             None,
                         ) {
                             let superabi_impl_method =
@@ -278,7 +278,7 @@ impl ty::TyAbiDecl {
                                 &mod_path,
                                 &method.name.clone(),
                                 ctx.type_annotation(),
-                                &Default::default(),
+                                &[],
                                 None,
                             ) {
                                 let superabi_method =
@@ -352,7 +352,7 @@ impl ty::TyAbiDecl {
                             &mod_path,
                             &method.name.clone(),
                             ctx.type_annotation(),
-                            &Default::default(),
+                            &[],
                             None,
                         ) {
                             let superabi_impl_method =

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -242,7 +242,7 @@ impl TyImplSelfOrTrait {
                         self_type_id,
                         &implementing_for.span(),
                         "",
-                        None,
+                        || None,
                     );
                     Ok(())
                 })?;
@@ -350,7 +350,7 @@ impl TyImplSelfOrTrait {
                                 self_type_param.type_id,
                                 &implementing_for.span(),
                                 "",
-                                None,
+                                || None,
                             );
                             Ok(())
                         })?;
@@ -542,7 +542,7 @@ impl TyImplSelfOrTrait {
                         self_type_id,
                         &implementing_for.span(),
                         "",
-                        None,
+                        || None,
                     );
                     Ok(())
                 })?;

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -107,7 +107,7 @@ impl ty::TyVariableDecl {
                     variable_decl.body.return_type,
                     &variable_decl.span(),
                     "",
-                    None,
+                    || None,
                 );
             }
         }

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -216,7 +216,7 @@ fn type_check_transmute(
         src_type,
         &first_argument_typed_expr.span,
         "",
-        None,
+        || None,
     );
 
     let mut final_type_arguments = type_arguments.to_vec();

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -215,7 +215,7 @@ pub(super) fn matcher(
 
     // unify the type of the scrutinee with the type of the expression
     handler.scope(|h| {
-        type_engine.unify(h, ctx.engines, type_id, exp.return_type, &span, "", None);
+        type_engine.unify(h, ctx.engines, type_id, exp.return_type, &span, "", || None);
         Ok(())
     })?;
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -106,11 +106,12 @@ impl ty::TyExpression {
             span: call_path.span(),
         };
         let arguments = VecDeque::from(arguments);
+        let arguments_types = arguments.iter().map(|a| a.return_type).collect::<Vec<_>>();
         let (mut decl_ref, _) = resolve_method_name(
             handler,
             ctx.by_ref(),
             &method_name_binding,
-            arguments.iter().map(|a| a.return_type).collect(),
+            &arguments_types,
         )?;
         decl_ref = monomorphize_method(
             handler,
@@ -3146,7 +3147,7 @@ fn type_check_panic(
         ctx.namespace().current_module(),
         engines,
         expr_type_id,
-        |trait_entry| trait_entry.is_std_marker_error_trait(),
+        |trait_entry| trait_entry.inner.is_std_marker_error_trait(),
     ) {
         return Err(
             handler.emit_err(CompileError::PanicExpressionArgumentIsNotError {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -167,7 +167,7 @@ pub(crate) fn instantiate_enum(
                         enum_variant.type_argument.type_id(),
                         &single_expr.span, // Use the span of the instantiator expression.
                         help_text,
-                        None,
+                        || None,
                     );
                     Ok(())
                 })?;
@@ -184,7 +184,7 @@ pub(crate) fn instantiate_enum(
                         type_id,
                         &enum_variant_name.span(),
                         help_text,
-                        None,
+                        || None,
                     );
                     Ok(())
                 })?;

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -70,7 +70,7 @@ pub(crate) fn instantiate_function_application(
         ctx.type_annotation(),
         &call_path_binding.span(),
         "Function return type does not match up with local type annotation.",
-        None,
+        || None,
     );
 
     let mut function_return_type_id = function_decl.return_type.type_id();
@@ -81,7 +81,7 @@ pub(crate) fn instantiate_function_application(
     let new_decl_ref = if let Some(cached_fn_ref) =
         ctx.engines()
             .qe()
-            .get_function(engines, function_ident.clone(), function_sig.clone())
+            .get_function(engines, &function_ident, function_sig.clone())
     {
         cached_fn_ref
     } else {
@@ -206,7 +206,7 @@ fn unify_arguments_and_parameters(
                     param.type_argument.type_id(),
                     &arg.span,
                     UNIFY_ARGS_HELP_TEXT,
-                    None,
+                    || None,
                 );
                 Ok(())
             });

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/if_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/if_expression.rs
@@ -42,7 +42,7 @@ pub(crate) fn instantiate_if_expression(
             ty_to_check,
             &then.span,
             "`then` branch must return expected type.",
-            None,
+            || None,
         );
     }
 
@@ -56,7 +56,7 @@ pub(crate) fn instantiate_if_expression(
                 ty_to_check,
                 &r#else.span,
                 "`else` branch must return expected type.",
-                None,
+                || None,
             );
         }
         Box::new(r#else)

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -801,9 +801,9 @@ pub(crate) fn type_check_method_application(
     }
 
     let expression = ty::TyExpressionVariant::FunctionApplication {
-        call_path: call_path,
+        call_path,
         arguments,
-        fn_ref: fn_ref,
+        fn_ref,
         selector,
         type_binding: Some(method_name_binding.strip_inner()),
         call_path_typeid: Some(call_path_typeid),
@@ -843,11 +843,13 @@ fn unify_arguments_and_parameters(
                     param.type_argument.type_id(),
                     &arg.span,
                     "This argument's type is not castable to the declared parameter type.",
-                    || Some(CompileError::ArgumentParameterTypeMismatch {
-                        span: arg.span.clone(),
-                        provided: engines.help_out(arg.return_type).to_string(),
-                        should_be: engines.help_out(param.type_argument.type_id()).to_string(),
-                    }),
+                    || {
+                        Some(CompileError::ArgumentParameterTypeMismatch {
+                            span: arg.span.clone(),
+                            provided: engines.help_out(arg.return_type).to_string(),
+                            should_be: engines.help_out(param.type_argument.type_id()).to_string(),
+                        })
+                    },
                 );
                 Ok(())
             });
@@ -893,10 +895,10 @@ pub(crate) fn resolve_method_name(
             let decl_ref = ctx.find_method_for_type(
                 handler,
                 type_id,
-                &type_info_prefix,
+                type_info_prefix,
                 method_name,
                 ctx.type_annotation(),
-                &arguments_types,
+                arguments_types,
                 None,
             )?;
 
@@ -940,7 +942,7 @@ pub(crate) fn resolve_method_name(
                 &module_path,
                 &call_path.suffix,
                 ctx.type_annotation(),
-                &arguments_types,
+                arguments_types,
                 None,
             )?;
 
@@ -963,7 +965,7 @@ pub(crate) fn resolve_method_name(
                 module_path.as_slice(),
                 method_name,
                 ctx.type_annotation(),
-                &arguments_types,
+                arguments_types,
                 None,
             )?;
 
@@ -984,10 +986,10 @@ pub(crate) fn resolve_method_name(
             let decl_ref = ctx.find_method_for_type(
                 handler,
                 type_id,
-                &module_path,
+                module_path,
                 method_name,
                 ctx.type_annotation(),
-                &arguments_types,
+                arguments_types,
                 Some(*as_trait),
             )?;
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -88,17 +88,18 @@ pub(crate) fn type_check_method_application(
     }
 
     // resolve the method name to a typed function declaration and type_check
+    let arguments_types = args_opt_buf
+        .iter()
+        .map(|(arg, _, _has_errors)| match arg {
+            Some(arg) => arg.return_type,
+            None => type_engine.new_unknown(),
+        })
+        .collect::<Vec<_>>();
     let method_result = resolve_method_name(
         handler,
         ctx.by_ref(),
         &method_name_binding,
-        args_opt_buf
-            .iter()
-            .map(|(arg, _, _has_errors)| match arg {
-                Some(arg) => arg.return_type,
-                None => type_engine.new_unknown(),
-            })
-            .collect(),
+        &arguments_types,
     );
 
     // In case resolve_method_name fails throw argument errors.
@@ -162,7 +163,7 @@ pub(crate) fn type_check_method_application(
         ctx.type_annotation(),
         &method_name_binding.span(),
         "Function return type does not match up with local type annotation.",
-        None,
+        || None,
     );
 
     // type check the function arguments (2nd pass)
@@ -484,7 +485,7 @@ pub(crate) fn type_check_method_application(
         .parameters
         .iter()
         .map(|m| m.name.clone())
-        .zip(args_buf.iter().cloned())
+        .zip(args_buf)
         .collect::<Vec<_>>();
 
     // unify the types of the arguments with the types of the parameters from the function declaration
@@ -630,7 +631,7 @@ pub(crate) fn type_check_method_application(
 
     // Unify method type parameters with implementing type type parameters.
     if let Some(implementing_for_typeid) = method.implementing_for_typeid {
-        if let Some(TyDecl::ImplSelfOrTrait(t)) = method.clone().implementing_type {
+        if let Some(TyDecl::ImplSelfOrTrait(t)) = method.implementing_type.clone() {
             let t = &engines.de().get(&t.decl_id).implementing_for;
             if let TypeInfo::Custom {
                 type_arguments: Some(type_arguments),
@@ -676,7 +677,7 @@ pub(crate) fn type_check_method_application(
                                         impl_type_param.type_id,
                                         &call_path.span(),
                                         "Function type parameter does not match up with implementing type type parameter.",
-                                        None,
+                                        || None,
                                     );
                                     Ok(())
                                 })?;
@@ -696,11 +697,11 @@ pub(crate) fn type_check_method_application(
     if let Some(cached_fn_ref) =
         ctx.engines()
             .qe()
-            .get_function(engines, method_ident.clone(), method_sig.clone())
+            .get_function(engines, &method_ident, method_sig.clone())
     {
         fn_ref = cached_fn_ref;
     } else {
-        if let Some(TyDecl::ImplSelfOrTrait(t)) = method.clone().implementing_type {
+        if let Some(TyDecl::ImplSelfOrTrait(t)) = method.implementing_type.clone() {
             let t = &engines.de().get(&t.decl_id).implementing_for;
             if let TypeInfo::Custom {
                 qualified_call_path,
@@ -727,7 +728,7 @@ pub(crate) fn type_check_method_application(
                 }
 
                 // This handles the case of substituting the generic blanket type by call_path_typeid.
-                for p in method.type_parameters.clone() {
+                for p in method.type_parameters.iter() {
                     if p.name().as_str() == qualified_call_path.call_path.suffix.as_str() {
                         subst_type_parameters.push(t.initial_type_id());
                         subst_type_arguments.push(call_path_typeid);
@@ -741,14 +742,13 @@ pub(crate) fn type_check_method_application(
                     .type_parameters
                     .iter()
                     .filter(|x| x.as_type_parameter().is_some())
-                    .cloned()
                 {
                     if names_type_ids.contains_key(p.name()) {
                         let type_id = p
                             .as_type_parameter()
                             .expect("only works with type parameters")
                             .type_id;
-                        subst_type_parameters.push(engines.te().new_placeholder(p));
+                        subst_type_parameters.push(engines.te().new_placeholder(p.clone()));
                         subst_type_arguments.push(type_id);
                     }
                 }
@@ -800,10 +800,10 @@ pub(crate) fn type_check_method_application(
         }
     }
 
-    let fn_app = ty::TyExpressionVariant::FunctionApplication {
-        call_path: call_path.clone(),
+    let expression = ty::TyExpressionVariant::FunctionApplication {
+        call_path: call_path,
         arguments,
-        fn_ref: fn_ref.clone(),
+        fn_ref: fn_ref,
         selector,
         type_binding: Some(method_name_binding.strip_inner()),
         call_path_typeid: Some(call_path_typeid),
@@ -812,7 +812,7 @@ pub(crate) fn type_check_method_application(
     };
 
     let exp = ty::TyExpression {
-        expression: fn_app.clone(),
+        expression,
         return_type: method_return_type_id,
         span,
     };
@@ -843,7 +843,7 @@ fn unify_arguments_and_parameters(
                     param.type_argument.type_id(),
                     &arg.span,
                     "This argument's type is not castable to the declared parameter type.",
-                    Some(CompileError::ArgumentParameterTypeMismatch {
+                    || Some(CompileError::ArgumentParameterTypeMismatch {
                         span: arg.span.clone(),
                         provided: engines.help_out(arg.return_type).to_string(),
                         should_be: engines.help_out(param.type_argument.type_id()).to_string(),
@@ -865,7 +865,7 @@ pub(crate) fn resolve_method_name(
     handler: &Handler,
     mut ctx: TypeCheckContext,
     method_name: &TypeBinding<MethodName>,
-    arguments_types: VecDeque<TypeId>,
+    arguments_types: &[TypeId],
 ) -> Result<(DeclRefFunction, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
     let engines = ctx.engines();
@@ -882,13 +882,12 @@ pub(crate) fn resolve_method_name(
                 .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
             // find the module that the symbol is in
-            let type_info_prefix = call_path_binding
+            let type_info_prefix = &call_path_binding
                 .inner
                 .to_fullpath(engines, ctx.namespace())
-                .prefixes
-                .clone();
+                .prefixes;
             ctx.namespace()
-                .require_module_from_absolute_path(handler, &type_info_prefix)?;
+                .require_module_from_absolute_path(handler, type_info_prefix)?;
 
             // find the method
             let decl_ref = ctx.find_method_for_type(
@@ -930,7 +929,7 @@ pub(crate) fn resolve_method_name(
 
             // find the type of the first argument
             let type_id = arguments_types
-                .front()
+                .first()
                 .cloned()
                 .unwrap_or_else(|| type_engine.new_unknown());
 
@@ -949,11 +948,11 @@ pub(crate) fn resolve_method_name(
         }
         MethodName::FromModule { method_name } => {
             // find the module that the symbol is in
-            let module_path = ctx.namespace().current_mod_path().clone();
+            let module_path = ctx.namespace().current_mod_path();
 
             // find the type of the first argument
             let type_id = arguments_types
-                .front()
+                .first()
                 .cloned()
                 .unwrap_or_else(|| type_engine.new_unknown());
 
@@ -961,7 +960,7 @@ pub(crate) fn resolve_method_name(
             let decl_ref = ctx.find_method_for_type(
                 handler,
                 type_id,
-                &module_path,
+                module_path.as_slice(),
                 method_name,
                 ctx.type_annotation(),
                 &arguments_types,
@@ -979,7 +978,7 @@ pub(crate) fn resolve_method_name(
             let type_id = ty.type_id();
 
             // find the module that the symbol is in
-            let module_path = ctx.namespace().current_mod_path().clone();
+            let module_path = ctx.namespace().current_mod_path();
 
             // find the method
             let decl_ref = ctx.find_method_for_type(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -336,7 +336,8 @@ fn collect_struct_constructors(
     namespace.current_module().read(engines, |m| {
         let mut items = vec![];
         m.append_items_for_type(engines, struct_type_id, &mut items);
-        items.iter()
+        items
+            .iter()
             .filter_map(|item| match item {
                 ResolvedTraitImplItem::Parsed(_) => unreachable!(),
                 ResolvedTraitImplItem::Typed(item) => match item {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -289,7 +289,7 @@ pub(crate) fn struct_instantiation(
                 type_id,
                 &span,
                 help_text,
-                None,
+                || None,
             );
             Ok(())
         })?;
@@ -334,8 +334,9 @@ fn collect_struct_constructors(
     // but that would be a way too much of suggestions, and moreover, it is also not a design pattern/guideline
     // that we wish to encourage.
     namespace.current_module().read(engines, |m| {
-        m.get_items_for_type(engines, struct_type_id)
-            .iter()
+        let mut items = vec![];
+        m.append_items_for_type(engines, struct_type_id, &mut items);
+        items.iter()
             .filter_map(|item| match item {
                 ResolvedTraitImplItem::Parsed(_) => unreachable!(),
                 ResolvedTraitImplItem::Typed(item) => match item {
@@ -473,7 +474,7 @@ fn unify_field_arguments_and_struct_fields(
                     struct_field.type_argument.type_id(),
                     &typed_field.value.span, // Use the span of the initialization value.
                     help_text,
-                    None,
+                    || None,
                 );
             }
         }

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -326,12 +326,13 @@ impl Module {
         }
     }
 
-    pub fn get_items_for_type(
+    pub fn append_items_for_type(
         &self,
         engines: &Engines,
         type_id: TypeId,
-    ) -> Vec<ResolvedTraitImplItem> {
-        TraitMap::get_items_for_type(self, engines, type_id)
+        items: &mut Vec<ResolvedTraitImplItem>,
+    ) {
+        TraitMap::append_items_for_type(self, engines, type_id, items)
     }
 
     pub fn resolve_symbol(
@@ -368,8 +369,10 @@ impl Module {
         engines: &Engines,
         type_id: TypeId,
     ) -> Vec<ResolvedFunctionDecl> {
-        self.get_items_for_type(engines, type_id)
-            .into_iter()
+        let mut items = vec![];
+        self.append_items_for_type(engines, type_id, &mut items);
+
+        items.into_iter()
             .filter_map(|item| match item {
                 ResolvedTraitImplItem::Parsed(_) => unreachable!(),
                 ResolvedTraitImplItem::Typed(item) => match item {

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -372,7 +372,8 @@ impl Module {
         let mut items = vec![];
         self.append_items_for_type(engines, type_id, &mut items);
 
-        items.into_iter()
+        items
+            .into_iter()
             .filter_map(|item| match item {
                 ResolvedTraitImplItem::Parsed(_) => unreachable!(),
                 ResolvedTraitImplItem::Typed(item) => match item {

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -89,7 +89,7 @@ impl Namespace {
 
     pub fn current_module_mut(&mut self) -> &mut Module {
         let package_relative_path = Package::package_relative_path(&self.current_mod_path);
-        self.current_package_root_module_mut()
+        self.current_package.root_module_mut()
             .submodule_mut(&package_relative_path)
             .unwrap_or_else(|| {
                 panic!(
@@ -158,17 +158,13 @@ impl Namespace {
         self.current_package.root_module()
     }
 
-    fn current_package_root_module_mut(&mut self) -> &mut Module {
-        self.current_package.root_module_mut()
-    }
-
     pub fn external_packages(
         &self,
     ) -> &im::HashMap<ModuleName, Package, BuildHasherDefault<FxHasher>> {
         &self.current_package.external_packages
     }
 
-    pub(crate) fn get_external_package(&self, package_name: &String) -> Option<&Package> {
+    pub(crate) fn get_external_package(&self, package_name: &str) -> Option<&Package> {
         self.current_package.external_packages.get(package_name)
     }
 
@@ -176,7 +172,7 @@ impl Namespace {
         self.get_external_package(package_name).is_some()
     }
 
-    pub fn module_from_absolute_path(&self, path: &ModulePathBuf) -> Option<&Module> {
+    pub fn module_from_absolute_path(&self, path: &[Ident]) -> Option<&Module> {
         self.current_package.module_from_absolute_path(path)
     }
 
@@ -184,7 +180,7 @@ impl Namespace {
     pub fn require_module_from_absolute_path(
         &self,
         handler: &Handler,
-        path: &ModulePathBuf,
+        path: &[Ident],
     ) -> Result<&Module, ErrorEmitted> {
         if path.is_empty() {
             return Err(handler.emit_err(CompileError::Internal(

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -89,8 +89,9 @@ impl Namespace {
 
     pub fn current_module_mut(&mut self) -> &mut Module {
         let package_relative_path = Package::package_relative_path(&self.current_mod_path);
-        self.current_package.root_module_mut()
-            .submodule_mut(&package_relative_path)
+        self.current_package
+            .root_module_mut()
+            .submodule_mut(package_relative_path)
             .unwrap_or_else(|| {
                 panic!(
                     "Could not retrieve submodule for mod_path: {:?}",
@@ -168,7 +169,7 @@ impl Namespace {
         self.current_package.external_packages.get(package_name)
     }
 
-    pub(super) fn exists_as_external(&self, package_name: &String) -> bool {
+    pub(super) fn exists_as_external(&self, package_name: &str) -> bool {
         self.get_external_package(package_name).is_some()
     }
 
@@ -242,8 +243,7 @@ impl Namespace {
     }
 
     pub fn package_exists(&self, name: &Ident) -> bool {
-        self.module_from_absolute_path(&vec![name.clone()])
-            .is_some()
+        self.module_from_absolute_path(&[name.clone()]).is_some()
     }
 
     pub(crate) fn module_has_binding(
@@ -382,7 +382,7 @@ impl Namespace {
         engines: &Engines,
         src: &ModulePath,
     ) -> Result<(), ErrorEmitted> {
-        let src_mod = self.require_module_from_absolute_path(handler, &src.to_vec())?;
+        let src_mod = self.require_module_from_absolute_path(handler, src)?;
 
         let mut imports = vec![];
 
@@ -456,7 +456,7 @@ impl Namespace {
     ) -> Result<(), ErrorEmitted> {
         self.check_module_visibility(handler, src)?;
 
-        let src_mod = self.require_module_from_absolute_path(handler, &src.to_vec())?;
+        let src_mod = self.require_module_from_absolute_path(handler, src)?;
 
         let mut decls_and_item_imports = vec![];
 
@@ -652,7 +652,7 @@ impl Namespace {
     ) -> Result<(), ErrorEmitted> {
         self.check_module_visibility(handler, src)?;
 
-        let src_mod = self.require_module_from_absolute_path(handler, &src.to_vec())?;
+        let src_mod = self.require_module_from_absolute_path(handler, src)?;
 
         let (decl, path) = self.item_lookup(handler, engines, item, src, false)?;
 
@@ -897,7 +897,7 @@ impl Namespace {
         src: &ModulePath,
         ignore_visibility: bool,
     ) -> Result<(ResolvedDeclaration, ModulePathBuf), ErrorEmitted> {
-        let src_mod = self.require_module_from_absolute_path(handler, &src.to_vec())?;
+        let src_mod = self.require_module_from_absolute_path(handler, src)?;
         let src_items = src_mod.root_items();
 
         let (decl, path, src_visibility) = if let Some(decl) = src_items.symbols.get(item) {
@@ -995,7 +995,7 @@ impl Namespace {
 
         // Check visibility of remaining submodules in the source path
         for prefix in iter_prefixes(src).skip(ignored_prefixes) {
-            if let Some(module) = self.module_from_absolute_path(&prefix.to_vec()) {
+            if let Some(module) = self.module_from_absolute_path(prefix) {
                 if module.visibility().is_private() {
                     let prefix_last = prefix[prefix.len() - 1].clone();
                     handler.emit_err(CompileError::ImportPrivateModule {

--- a/sway-core/src/semantic_analysis/namespace/package.rs
+++ b/sway-core/src/semantic_analysis/namespace/package.rs
@@ -89,12 +89,11 @@ impl Package {
         assert!(!mod_path.is_empty());
         let package_relative_path = Self::package_relative_path(mod_path);
         if mod_path[0] == *self.root_module.name() {
-            self.root_module.submodule(&package_relative_path)
-        } else if let Some(external_package) = self.external_packages.get(mod_path[0].as_str())
-        {
+            self.root_module.submodule(package_relative_path)
+        } else if let Some(external_package) = self.external_packages.get(mod_path[0].as_str()) {
             external_package
                 .root_module()
-                .submodule(&package_relative_path)
+                .submodule(package_relative_path)
         } else {
             None
         }

--- a/sway-core/src/semantic_analysis/namespace/package.rs
+++ b/sway-core/src/semantic_analysis/namespace/package.rs
@@ -1,5 +1,5 @@
 use super::{module::Module, Ident, ModuleName};
-use crate::{language::Visibility, namespace::ModulePathBuf};
+use crate::language::Visibility;
 use rustc_hash::FxHasher;
 use std::hash::BuildHasherDefault;
 use sway_types::{span::Span, ProgramId};
@@ -72,12 +72,12 @@ impl Package {
         self.program_id
     }
 
-    pub(crate) fn check_path_is_in_package(&self, mod_path: &ModulePathBuf) -> bool {
+    pub(crate) fn check_path_is_in_package(&self, mod_path: &[Ident]) -> bool {
         !mod_path.is_empty() && mod_path[0] == *self.root_module.name()
     }
 
-    pub(crate) fn package_relative_path(mod_path: &ModulePathBuf) -> ModulePathBuf {
-        mod_path[1..].to_vec()
+    pub(crate) fn package_relative_path(mod_path: &[Ident]) -> &[Ident] {
+        &mod_path[1..]
     }
 
     pub(super) fn is_contract_package(&self) -> bool {
@@ -85,12 +85,12 @@ impl Package {
     }
 
     // Find module in the current environment. `mod_path` must be a fully qualified path
-    pub fn module_from_absolute_path(&self, mod_path: &ModulePathBuf) -> Option<&Module> {
+    pub fn module_from_absolute_path(&self, mod_path: &[Ident]) -> Option<&Module> {
         assert!(!mod_path.is_empty());
         let package_relative_path = Self::package_relative_path(mod_path);
         if mod_path[0] == *self.root_module.name() {
             self.root_module.submodule(&package_relative_path)
-        } else if let Some(external_package) = self.external_packages.get(&mod_path[0].to_string())
+        } else if let Some(external_package) = self.external_packages.get(mod_path[0].as_str())
         {
             external_package
                 .root_module()

--- a/sway-core/src/semantic_analysis/namespace/trait_coherence.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_coherence.rs
@@ -52,7 +52,11 @@ fn check_orphan_rules_for_impls_in_scope(
     for key in trait_map.trait_impls.keys() {
         for trait_entry in trait_map.trait_impls[key].iter() {
             // 0. If it's a contract then skip it as it's not relevant to coherence.
-            if engines.te().get(trait_entry.inner.key.type_id).is_contract() {
+            if engines
+                .te()
+                .get(trait_entry.inner.key.type_id)
+                .is_contract()
+            {
                 continue;
             }
 
@@ -235,8 +239,10 @@ pub(crate) fn check_impls_for_overlap(
                     &*other_entry.inner.key.name,
                     &PartialEqWithEnginesContext::new(engines),
                 ) && self_entry.inner.value.impl_span != other_entry.inner.value.impl_span
-                    && (unify_check.check(self_entry.inner.key.type_id, other_entry.inner.key.type_id)
-                        || unify_check.check(other_entry.inner.key.type_id, self_entry.inner.key.type_id))
+                    && (unify_check
+                        .check(self_entry.inner.key.type_id, other_entry.inner.key.type_id)
+                        || unify_check
+                            .check(other_entry.inner.key.type_id, self_entry.inner.key.type_id))
                 {
                     let other_tcs: Vec<(CallPath, TypeId)> = other_entry
                         .inner
@@ -309,11 +315,13 @@ pub(crate) fn check_impls_for_overlap(
                                                     .help_out(self_entry.inner.key.type_id)
                                                     .to_string(),
                                                 existing_impl_span: self_entry
-                                                    .inner.value
+                                                    .inner
+                                                    .value
                                                     .impl_span
                                                     .clone(),
                                                 second_impl_span: other_entry
-                                                    .inner.value
+                                                    .inner
+                                                    .value
                                                     .impl_span
                                                     .clone(),
                                             },

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -163,10 +163,33 @@ pub(crate) struct TraitEntry {
     pub(crate) value: TraitValue,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct SharedTraitEntry {
+    pub(crate) inner: Arc<TraitEntry>,
+}
+
+impl SharedTraitEntry {
+    pub fn fork_if_non_unique(&mut self) -> &mut Self {
+        match Arc::get_mut(&mut self.inner) {
+            Some(_) => {},
+            None => {
+                let data =  TraitEntry::clone(&self.inner);
+                self.inner = Arc::new(data);
+            },
+        }
+
+        self
+    }
+
+    pub fn get_mut(&mut self) -> &mut TraitEntry {
+        Arc::get_mut(&mut self.inner).unwrap()
+    }
+}
+
 /// Map of string of type entry id and vec of [TraitEntry].
 /// We are using the HashMap as a wrapper to the vec so the TraitMap algorithms
 /// don't need to traverse every TraitEntry.
-pub(crate) type TraitImpls = BTreeMap<TypeRootFilter, Vec<TraitEntry>>;
+pub(crate) type TraitImpls = BTreeMap<TypeRootFilter, Vec<SharedTraitEntry>>;
 
 #[derive(Clone, Hash, Eq, PartialOrd, Ord, PartialEq, Debug)]
 pub(crate) enum TypeRootFilter {
@@ -273,21 +296,22 @@ impl TraitMap {
             let trait_impls = self.get_impls_mut(engines, unaliased_type_id);
 
             // check to see if adding this trait will produce a conflicting definition
-            for TraitEntry {
-                key:
-                    TraitKey {
-                        name: map_trait_name,
-                        type_id: map_type_id,
-                        trait_decl_span: _,
-                        impl_type_parameters: _,
-                    },
-                value:
-                    TraitValue {
-                        trait_items: map_trait_items,
-                        impl_span: existing_impl_span,
-                    },
-            } in trait_impls.iter()
+            for entry in trait_impls.iter()
             {
+                let TraitEntry {
+                    key:
+                        TraitKey {
+                            name: map_trait_name,
+                            type_id: map_type_id,
+                            trait_decl_span: _,
+                            impl_type_parameters: _,
+                        },
+                    value:
+                        TraitValue {
+                            trait_items: map_trait_items,
+                            impl_span: existing_impl_span,
+                        },
+                } = entry.inner.as_ref();
                 let CallPath {
                     suffix:
                         TraitSuffix {
@@ -496,10 +520,10 @@ impl TraitMap {
             trait_items: trait_methods,
             impl_span,
         };
-        let entry = TraitEntry { key, value };
-        let mut trait_impls: TraitImpls = BTreeMap::<TypeRootFilter, Vec<TraitEntry>>::new();
+        let mut trait_impls: TraitImpls = BTreeMap::new();
         let type_root_filter = Self::get_type_root_filter(engines, type_id);
-        let impls_vector = vec![entry];
+        let entry = TraitEntry { key, value };
+        let impls_vector = vec![SharedTraitEntry{ inner: Arc::new(entry) }];
         trait_impls.insert(type_root_filter, impls_vector);
 
         let trait_map = TraitMap {
@@ -519,20 +543,22 @@ impl TraitMap {
                 self_vec
             } else {
                 self.trait_impls
-                    .insert(impls_key.clone(), Vec::<TraitEntry>::new());
+                    .insert(impls_key.clone(), Vec::<_>::new());
                 self.trait_impls.get_mut(impls_key).unwrap()
             };
 
             for oe in oe_vec.iter() {
                 let pos = self_vec.binary_search_by(|se| {
-                    se.key.cmp(&oe.key, &OrdWithEnginesContext::new(engines))
+                    se.inner.key.cmp(&oe.inner.key, &OrdWithEnginesContext::new(engines))
                 });
 
                 match pos {
                     Ok(pos) => self_vec[pos]
+                        .fork_if_non_unique()
+                        .get_mut()
                         .value
                         .trait_items
-                        .extend(oe.value.trait_items.clone()),
+                        .extend(oe.inner.value.trait_items.clone()),
                     Err(pos) => self_vec.insert(pos, oe.clone()),
                 }
             }
@@ -546,14 +572,14 @@ impl TraitMap {
         for key in self.trait_impls.keys() {
             for self_entry in self.trait_impls[key].iter() {
                 let callpath = CallPath {
-                    prefixes: self_entry.key.name.prefixes.clone(),
-                    suffix: self_entry.key.name.suffix.name.clone(),
-                    callpath_type: self_entry.key.name.callpath_type,
+                    prefixes: self_entry.inner.key.name.prefixes.clone(),
+                    suffix: self_entry.inner.key.name.suffix.name.clone(),
+                    callpath_type: self_entry.inner.key.name.callpath_type,
                 };
                 if let Some(vec) = traits_types.get_mut(&callpath) {
-                    vec.push(self_entry.key.type_id);
+                    vec.push(self_entry.inner.key.type_id);
                 } else {
-                    traits_types.insert(callpath, vec![self_entry.key.type_id]);
+                    traits_types.insert(callpath, vec![self_entry.inner.key.type_id]);
                 }
             }
         }
@@ -567,14 +593,14 @@ impl TraitMap {
         for key in self.trait_impls.keys() {
             let vec = &self.trait_impls[key];
             for entry in vec {
-                if entry.key.trait_decl_span.as_ref() == Some(&trait_decl_span) {
+                if entry.inner.key.trait_decl_span.as_ref() == Some(&trait_decl_span) {
                     let trait_map_vec =
                         if let Some(trait_map_vec) = trait_map.trait_impls.get_mut(key) {
                             trait_map_vec
                         } else {
                             trait_map
                                 .trait_impls
-                                .insert(key.clone(), Vec::<TraitEntry>::new());
+                                .insert(key.clone(), Vec::<_>::new());
                             trait_map.trait_impls.get_mut(key).unwrap()
                         };
 
@@ -684,20 +710,22 @@ impl TraitMap {
                 engines,
                 *type_id,
                 true,
-                |TraitEntry {
-                     key:
-                         TraitKey {
-                             name: map_trait_name,
-                             type_id: map_type_id,
-                             trait_decl_span: map_trait_decl_span,
-                             impl_type_parameters: map_impl_type_parameters,
-                         },
-                     value:
-                         TraitValue {
-                             trait_items: map_trait_items,
-                             impl_span,
-                         },
-                 }| {
+                |entry| {
+                    let TraitEntry {
+                        key:
+                            TraitKey {
+                                name: map_trait_name,
+                                type_id: map_type_id,
+                                trait_decl_span: map_trait_decl_span,
+                                impl_type_parameters: map_impl_type_parameters,
+                            },
+                        value:
+                            TraitValue {
+                                trait_items: map_trait_items,
+                                impl_span,
+                            },
+                    } = entry.inner.as_ref();
+
                     if !type_engine.is_type_changeable(engines, &type_info)
                         && *type_id == *map_type_id
                     {
@@ -844,32 +872,32 @@ impl TraitMap {
     /// - this method does not translate types from the found entries to the
     ///   `type_id` (like in `filter_by_type()`). This is because the only
     ///   entries that qualify as hits are equivalents of `type_id`
-    pub(crate) fn get_items_for_type(
+    pub(crate) fn append_items_for_type(
         module: &Module,
         engines: &Engines,
         type_id: TypeId,
-    ) -> Vec<ResolvedTraitImplItem> {
-        TraitMap::get_items_and_trait_key_for_type(module, engines, type_id)
-            .iter()
-            .map(|i| i.0.clone())
-            .collect::<Vec<_>>()
+        items: &mut Vec<ResolvedTraitImplItem> 
+    ) {
+        TraitMap::find_items_and_trait_key_for_type(module, engines, type_id, &mut |item, _| {
+            items.push(item);
+        });
     }
 
-    fn get_items_and_trait_key_for_type(
+    pub(crate) fn find_items_and_trait_key_for_type(
         module: &Module,
         engines: &Engines,
         type_id: TypeId,
-    ) -> Vec<(ResolvedTraitImplItem, TraitKey)> {
+        callback: &mut impl FnMut(ResolvedTraitImplItem, TraitKey),
+    ) {
         let type_engine = engines.te();
-        let unify_check = UnifyCheck::constraint_subset(engines);
-
         let type_id = engines.te().get_unaliased_type_id(type_id);
-
-        let mut items = vec![];
+        
         // small performance gain in bad case
         if matches!(&*type_engine.get(type_id), TypeInfo::ErrorRecovery(_)) {
-            return items;
+            return;
         }
+
+        let unify_check = UnifyCheck::constraint_subset(engines);
 
         let _ = module.walk_scope_chain_early_return(|lexical_scope| {
             lexical_scope.items.implemented_traits.for_each_impls(
@@ -877,24 +905,24 @@ impl TraitMap {
                 type_id,
                 true,
                 |entry| {
-                    if unify_check.check(type_id, entry.key.type_id) {
+                    if unify_check.check(type_id, entry.inner.key.type_id) {
                         let trait_items = Self::filter_dummy_methods(
-                            &entry.value.trait_items,
+                            &entry.inner.value.trait_items,
                             type_id,
-                            entry.key.type_id,
+                            entry.inner.key.type_id,
                             engines,
                         )
-                        .map(|(_, i)| (i, entry.key.clone()))
-                        .collect::<Vec<_>>();
+                        .map(|(_, i)| (i, entry.inner.key.clone()));
 
-                        items.extend(trait_items);
+                        for i in trait_items {
+                            callback(i.0, i.1);
+                        }
                     }
                 },
             );
 
             Ok(None::<()>)
         });
-        items
     }
 
     /// Find the spans of all impls for the given type.
@@ -927,8 +955,8 @@ impl TraitMap {
                 *type_id,
                 false,
                 |entry| {
-                    if unify_check.check(*type_id, entry.key.type_id) {
-                        spans.push(entry.value.impl_span.clone());
+                    if unify_check.check(*type_id, entry.inner.key.type_id) {
+                        spans.push(entry.inner.value.impl_span.clone());
                     }
                 },
             );
@@ -968,12 +996,12 @@ impl TraitMap {
                             .iter()
                             .filter_map(|entry| {
                                 let map_trait_name = CallPath {
-                                    prefixes: entry.key.name.prefixes.clone(),
-                                    suffix: entry.key.name.suffix.name.clone(),
-                                    callpath_type: entry.key.name.callpath_type,
+                                    prefixes: entry.inner.key.name.prefixes.clone(),
+                                    suffix: entry.inner.key.name.suffix.name.clone(),
+                                    callpath_type: entry.inner.key.name.callpath_type,
                                 };
                                 if &map_trait_name == trait_name {
-                                    Some(entry.value.impl_span.clone())
+                                    Some(entry.inner.value.impl_span.clone())
                                 } else {
                                     None
                                 }
@@ -1021,25 +1049,25 @@ impl TraitMap {
                 .implemented_traits
                 .for_each_impls(engines, type_id, false, |e| {
                     let map_trait_name = CallPath {
-                        prefixes: e.key.name.prefixes.clone(),
-                        suffix: e.key.name.suffix.name.clone(),
-                        callpath_type: e.key.name.callpath_type,
+                        prefixes: e.inner.key.name.prefixes.clone(),
+                        suffix: e.inner.key.name.suffix.name.clone(),
+                        callpath_type: e.inner.key.name.callpath_type,
                     };
                     if &map_trait_name == trait_name
-                        && unify_check.check(type_id, e.key.type_id)
-                        && trait_type_args.len() == e.key.name.suffix.args.len()
+                        && unify_check.check(type_id, e.inner.key.type_id)
+                        && trait_type_args.len() == e.inner.key.name.suffix.args.len()
                         && trait_type_args
                             .iter()
-                            .zip(e.key.name.suffix.args.iter())
+                            .zip(e.inner.key.name.suffix.args.iter())
                             .all(|(t1, t2)| unify_check.check(t1.type_id(), t2.type_id()))
                     {
                         let type_mapping =
-                            TypeSubstMap::from_superset_and_subset(engines, e.key.type_id, type_id);
+                            TypeSubstMap::from_superset_and_subset(engines, e.inner.key.type_id, type_id);
 
                         let mut trait_items = Self::filter_dummy_methods(
-                            &e.value.trait_items,
+                            &e.inner.value.trait_items,
                             type_id,
-                            e.key.type_id,
+                            e.inner.key.type_id,
                             engines,
                         )
                         .map(|(_, i)| {
@@ -1110,13 +1138,13 @@ impl TraitMap {
                 type_id,
                 false,
                 |entry| {
-                    if unify_check.check(type_id, entry.key.type_id) {
+                    if unify_check.check(type_id, entry.inner.key.type_id) {
                         let trait_call_path = CallPath {
-                            prefixes: entry.key.name.prefixes.clone(),
-                            suffix: entry.key.name.suffix.name.clone(),
-                            callpath_type: entry.key.name.callpath_type,
+                            prefixes: entry.inner.key.name.prefixes.clone(),
+                            suffix: entry.inner.key.name.suffix.name.clone(),
+                            callpath_type: entry.inner.key.name.callpath_type,
                         };
-                        trait_names.push((trait_call_path, entry.key.name.suffix.args.clone()));
+                        trait_names.push((trait_call_path, entry.inner.key.name.suffix.args.clone()));
                     }
                 },
             );
@@ -1127,7 +1155,7 @@ impl TraitMap {
 
     /// Returns true if the type represented by the `type_id` implements
     /// any trait that satisfies the `predicate`.
-    pub(crate) fn type_implements_trait<F: Fn(&TraitEntry) -> bool>(
+    pub(crate) fn type_implements_trait<F: Fn(&SharedTraitEntry) -> bool>(
         module: &Module,
         engines: &Engines,
         type_id: TypeId,
@@ -1151,7 +1179,7 @@ impl TraitMap {
                     // We don't have a suitable way to cancel traversal, so we just
                     // skip the checks if any of the previous traits has already matched.
                     if !implements_trait
-                        && unify_check.check(type_id, entry.key.type_id)
+                        && unify_check.check(type_id, entry.inner.key.type_id)
                         && predicate(entry)
                     {
                         implements_trait = true;
@@ -1174,9 +1202,8 @@ impl TraitMap {
         let type_id = engines.te().get_unaliased_type_id(type_id);
 
         let mut candidates = HashMap::<String, ResolvedTraitImplItem>::new();
-        for (trait_item, trait_key) in
-            TraitMap::get_items_and_trait_key_for_type(module, engines, type_id)
-        {
+
+        TraitMap::find_items_and_trait_key_for_type(module, engines, type_id, &mut |trait_item, trait_key| {
             match trait_item {
                 ResolvedTraitImplItem::Parsed(impl_item) => match impl_item {
                     ImplItem::Fn(fn_ref) => {
@@ -1261,7 +1288,7 @@ impl TraitMap {
                     }
                 },
             }
-        }
+        });
 
         match candidates.len().cmp(&1) {
             Ordering::Greater => Err(handler.emit_err(
@@ -1377,7 +1404,7 @@ impl TraitMap {
         let unify_check = UnifyCheck::constraint_subset(engines);
         let mut all_impld_traits = BTreeSet::<(Ident, TypeId)>::new();
         self.for_each_impls(engines, type_id, true, |e| {
-            let key = &e.key;
+            let key = &e.inner.key;
             let suffix = &key.name.suffix;
             if unify_check.check(type_id, key.type_id) {
                 let map_trait_type_id = type_engine.new_custom(
@@ -1484,7 +1511,7 @@ impl TraitMap {
                 .for_each_impls(engines, type_id, true, |e| {
                     let mut traits: Vec<(TypeId, String)> = vec![];
 
-                    let key = &e.key;
+                    let key = &e.inner.key;
                     for constraint in constraints {
                         if key.name.suffix.name == constraint.trait_name.suffix
                             && key
@@ -1517,7 +1544,7 @@ impl TraitMap {
         Ok(impld_traits_type_ids.concat())
     }
 
-    fn get_impls_mut(&mut self, engines: &Engines, type_id: TypeId) -> &mut Vec<TraitEntry> {
+    fn get_impls_mut(&mut self, engines: &Engines, type_id: TypeId) -> &mut Vec<SharedTraitEntry> {
         let type_root_filter = Self::get_type_root_filter(engines, type_id);
         if !self.trait_impls.contains_key(&type_root_filter) {
             self.trait_impls
@@ -1534,7 +1561,7 @@ impl TraitMap {
         include_placeholder: bool,
         mut callback: F,
     ) where
-        F: FnMut(&TraitEntry),
+        F: FnMut(&SharedTraitEntry),
     {
         let type_root_filter = Self::get_type_root_filter(engines, type_id);
         self.trait_impls

--- a/sway-core/src/semantic_analysis/type_resolve.rs
+++ b/sway-core/src/semantic_analysis/type_resolve.rs
@@ -53,7 +53,7 @@ pub fn resolve_type(
                 engines,
                 namespace,
                 module_path,
-                &qualified_call_path,
+                qualified_call_path,
                 self_type,
                 subst_ctx,
                 check_visibility,
@@ -141,7 +141,7 @@ pub fn resolve_type(
                 namespace.current_package_root_module(),
                 handler,
                 engines,
-                &name,
+                name,
                 *trait_type_id,
                 None,
             )?;
@@ -350,7 +350,7 @@ pub(super) fn resolve_symbol_and_mod_path(
             self_type,
         )
     } else {
-        match namespace.get_external_package(&mod_path[0].as_str()) {
+        match namespace.get_external_package(mod_path[0].as_str()) {
             Some(ext_package) => {
                 // The path must be resolved in an external package.
                 // The root module in that package may have a different name than the name we

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -741,7 +741,7 @@ impl GenericTypeParameter {
                                     concrete_trait_type_ids.first().unwrap().0,
                                     access_span,
                                     "Type parameter type does not match up with matched trait implementing type.",
-                                    None,
+                                    || None,
                                 );
                             }
                             Ordering::Greater => {

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -2343,7 +2343,15 @@ impl TypeEngine {
             | TypeInfo::Alias { .. }
             | TypeInfo::TraitType { .. } => {}
             TypeInfo::Numeric => {
-                self.unify(handler, engines, type_id, self.id_of_u64(), span, "", || None);
+                self.unify(
+                    handler,
+                    engines,
+                    type_id,
+                    self.id_of_u64(),
+                    span,
+                    "",
+                    || None,
+                );
             }
         }
         Ok(())

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -2037,7 +2037,7 @@ impl TypeEngine {
         expected: TypeId,
         span: &Span,
         help_text: &str,
-        err_override: Option<CompileError>,
+        err_override: impl FnOnce() -> Option<CompileError>,
     ) {
         Self::unify_helper(
             handler,
@@ -2068,7 +2068,7 @@ impl TypeEngine {
         expected: TypeId,
         span: &Span,
         help_text: &str,
-        err_override: Option<CompileError>,
+        err_override: impl FnOnce() -> Option<CompileError>,
     ) {
         Self::unify_helper(
             handler,
@@ -2099,7 +2099,7 @@ impl TypeEngine {
         expected: TypeId,
         span: &Span,
         help_text: &str,
-        err_override: Option<CompileError>,
+        err_override: impl FnOnce() -> Option<CompileError>,
     ) {
         Self::unify_helper(
             handler,
@@ -2127,14 +2127,14 @@ impl TypeEngine {
         expected: TypeId,
         span: &Span,
         help_text: &str,
-        err_override: Option<CompileError>,
+        err_override: impl FnOnce() -> Option<CompileError>,
         unify_kind: UnifyKind,
         push_unification: bool,
     ) {
         if !UnifyCheck::coercion(engines).check(received, expected) {
             // create a "mismatched type" error unless the `err_override`
             // argument has been provided
-            match err_override {
+            match err_override() {
                 Some(err_override) => {
                     handler.emit_err(err_override);
                 }
@@ -2154,7 +2154,7 @@ impl TypeEngine {
         let unifier = Unifier::new(engines, help_text, unify_kind);
         unifier.unify(handler, received, expected, span, push_unification);
 
-        match err_override {
+        match err_override() {
             Some(err_override) if h.has_errors() => {
                 handler.emit_err(err_override);
             }
@@ -2186,7 +2186,7 @@ impl TypeEngine {
                 unification.expected,
                 &unification.span,
                 &unification.help_text,
-                None,
+                || None,
                 unification.unify_kind.clone(),
                 false,
             )
@@ -2343,7 +2343,7 @@ impl TypeEngine {
             | TypeInfo::Alias { .. }
             | TypeInfo::TraitType { .. } => {}
             TypeInfo::Numeric => {
-                self.unify(handler, engines, type_id, self.id_of_u64(), span, "", None);
+                self.unify(handler, engines, type_id, self.id_of_u64(), span, "", || None);
             }
         }
         Ok(())

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -173,7 +173,9 @@ fn generic_enum_resolution() {
 
     // Unify them together...
     let h = Handler::default();
-    engines.te().unify(&h, &engines, ty_1, ty_2, &sp, "", None);
+    engines
+        .te()
+        .unify(&h, &engines, ty_1, ty_2, &sp, "", || None);
     let (_, errors) = h.consume();
     assert!(errors.is_empty());
 
@@ -201,7 +203,7 @@ fn basic_numeric_unknown() {
 
     // Unify them together...
     let h = Handler::default();
-    engines.te().unify(&h, &engines, id, id2, &sp, "", None);
+    engines.te().unify(&h, &engines, id, id2, &sp, "", || None);
     let (_, errors) = h.consume();
     assert!(errors.is_empty());
 
@@ -223,7 +225,7 @@ fn unify_numerics() {
 
     // Unify them together...
     let h = Handler::default();
-    engines.te().unify(&h, &engines, id2, id, &sp, "", None);
+    engines.te().unify(&h, &engines, id2, id, &sp, "", || None);
     let (_, errors) = h.consume();
     assert!(errors.is_empty());
 
@@ -246,7 +248,7 @@ fn unify_numerics_2() {
 
     // Unify them together...
     let h = Handler::default();
-    type_engine.unify(&h, &engines, id, id2, &sp, "", None);
+    type_engine.unify(&h, &engines, id, id2, &sp, "", || None);
     let (_, errors) = h.consume();
     assert!(errors.is_empty());
 

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -119,7 +119,7 @@ impl Parse for ty::TySideEffect {
 
                         if let Some(span) = ctx
                             .namespace
-                            .module_from_absolute_path(&mod_path.to_vec())
+                            .module_from_absolute_path(mod_path)
                             .and_then(|tgt_submod| tgt_submod.span().clone())
                         {
                             token.type_def = Some(TypeDefinition::Ident(Ident::new(span)));
@@ -1349,7 +1349,7 @@ fn collect_call_path_prefixes(ctx: &ParseContext, prefixes: &[Ident], callpath_t
             token.ast_node = TokenAstNode::Typed(TypedAstToken::Ident(ident.clone()));
             if let Some(span) = ctx
                 .namespace
-                .module_from_absolute_path(&mod_path.to_vec())
+                .module_from_absolute_path(mod_path)
                 .and_then(|tgt_submod| tgt_submod.span().clone())
             {
                 token.kind = SymbolKind::Module;


### PR DESCRIPTION
## Description

This PR remove needless memory allocation:

1 - it removes needless `.clone()`, `.to_vec()` and some `.collect()`;
2 - it wraps `TraitEntry` into a `SharedTraitEntry`. In a lot of cases, `TraitEntry` was being completely cloned, and only occasionally being mutated. Now its `clone()` is cheap, and the occasional needed complete `clone` has the inconvenience of requiring `fork_if_non_unique` to be called before mutation;
3 - `err_override` was cloning a lot of stuff and only used on errors. Now they are behind a closure that is normally not called;
4 - There were a lof of needless `Vec` when dealing with modules;
5 - `find_method_for_type` and others were generating a lot of temporary `Vec`.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
