### PR TITLE
Optimisation: only traverse AST's if the cache is stale. 

### DIFF
--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -44,7 +44,8 @@ fn benchmarks(c: &mut Criterion) {
         );
         let session = Arc::new(session::Session::new());
         let member_path = sync.member_path(&uri).unwrap();
-
+        let modified_file = sway_lsp::server_state::modified_file(lsp_mode.as_ref());
+        
         b.iter(|| {
             let _ = black_box(
                 session::traverse(
@@ -54,7 +55,7 @@ fn benchmarks(c: &mut Criterion) {
                     &engines_clone,
                     session.clone(),
                     &state.token_map,
-                    lsp_mode.as_ref(),
+                    modified_file.as_ref(),
                 )
                 .unwrap(),
             );

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -55,7 +55,7 @@ fn benchmarks(c: &mut Criterion) {
                     &engines_clone,
                     session.clone(),
                     &state.token_map,
-                    modified_file.as_ref(),
+                    modified_file,
                 )
                 .unwrap(),
             );

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -45,7 +45,7 @@ fn benchmarks(c: &mut Criterion) {
         let session = Arc::new(session::Session::new());
         let member_path = sync.member_path(&uri).unwrap();
         let modified_file = sway_lsp::server_state::modified_file(lsp_mode.as_ref());
-        
+
         b.iter(|| {
             let _ = black_box(
                 session::traverse(

--- a/sway-lsp/benches/lsp_benchmarks/mod.rs
+++ b/sway-lsp/benches/lsp_benchmarks/mod.rs
@@ -4,7 +4,7 @@ pub mod token_map;
 
 use lsp_types::Url;
 use std::{path::PathBuf, sync::Arc};
-use sway_core::Engines;
+use sway_core::{Engines, LspConfig};
 use sway_lsp::{
     config::GarbageCollectionConfig,
     core::session::{self, Session},
@@ -32,9 +32,13 @@ pub async fn compile_test_project() -> (Url, Arc<Session>, ServerState, Engines)
         version: None,
         gc_options: GarbageCollectionConfig::default(),
     };
+    let lsp_mode = Some(LspConfig {
+        optimized_build: ctx.optimized_build,
+        file_versions: ctx.file_versions.clone(),
+    });
 
     // Compile the project
-    session::parse_project(&temp_uri, &engines_clone, None, &ctx).unwrap();
+    session::parse_project(&temp_uri, &engines_clone, None, &ctx, lsp_mode.as_ref()).unwrap();
     (temp_uri, session, state, engines_clone)
 }
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -302,7 +302,7 @@ pub fn traverse(
     modified_file: Option<&PathBuf>,
 ) -> Result<Option<CompileResults>, LanguageServerError> {
     let _p = tracing::trace_span!("traverse").entered();
-    
+
     // Remove tokens for the modified file from the token map.
     if let Some(path) = modified_file {
         token_map.remove_tokens_for_file(path);
@@ -449,12 +449,7 @@ pub fn parse_project(
         .build_plan_cache
         .get_or_update(&sync.workspace_manifest_path(), || build_plan(uri))?;
 
-    let results = compile(
-        &build_plan,
-        engines_clone,
-        retrigger_compilation,
-        lsp_mode,
-    )?;
+    let results = compile(&build_plan, engines_clone, retrigger_compilation, lsp_mode)?;
 
     // First check if results is empty or if all program values are None,
     // indicating an error occurred in the compiler
@@ -496,7 +491,8 @@ pub fn parse_project(
     }
 
     // Check if we need to reprocess the project.
-    let (needs_reprocessing, modified_file) = server_state::needs_reprocessing(&ctx.token_map, &path, lsp_mode);
+    let (needs_reprocessing, modified_file) =
+        server_state::needs_reprocessing(&ctx.token_map, &path, lsp_mode);
 
     // Only traverse and create runnables if we have no tokens yet, or if a file was modified
     if needs_reprocessing {
@@ -509,11 +505,15 @@ pub fn parse_project(
             &token_map,
             modified_file.as_ref(),
         )?;
-        
+
         // Write diagnostics if not optimized build
-        if let Some(LspConfig { optimized_build: false, .. }) = &lsp_mode {
+        if let Some(LspConfig {
+            optimized_build: false,
+            ..
+        }) = &lsp_mode
+        {
             if let Some((errors, warnings)) = &diagnostics {
-                *session.diagnostics.write() = 
+                *session.diagnostics.write() =
                     capabilities::diagnostic::get_diagnostics(warnings, errors, engines_clone.se());
             }
         }
@@ -536,7 +536,7 @@ pub fn parse_project(
             );
         }
     }
-    
+
     Ok(())
 }
 
@@ -782,8 +782,8 @@ mod tests {
             version: None,
             gc_options: GarbageCollectionConfig::default(),
         };
-        let result =
-            parse_project(&uri, &engines, None, &ctx, None).expect_err("expected ManifestFileNotFound");
+        let result = parse_project(&uri, &engines, None, &ctx, None)
+            .expect_err("expected ManifestFileNotFound");
         assert!(matches!(
             result,
             LanguageServerError::DocumentError(

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -503,7 +503,7 @@ pub fn parse_project(
             engines_clone,
             session.clone(),
             &token_map,
-            modified_file.as_ref(),
+            modified_file,
         )?;
 
         // Write diagnostics if not optimized build
@@ -549,11 +549,10 @@ pub fn parse_lexed_program(
 ) {
     let should_process = |item: &&Annotated<ItemKind>| {
         modified_file
-            .as_ref()
             .map(|path| {
                 item.span()
                     .source_id()
-                    .is_some_and(|id| ctx.engines.se().get_path(id) == **path)
+                    .is_some_and(|id| ctx.engines.se().get_path(id) == *path)
             })
             .unwrap_or(true)
     };
@@ -585,11 +584,10 @@ fn parse_ast_to_tokens(
 ) {
     let should_process = |node: &&AstNode| {
         modified_file
-            .as_ref()
             .map(|path| {
                 node.span
                     .source_id()
-                    .is_some_and(|id| ctx.engines.se().get_path(id) == **path)
+                    .is_some_and(|id| ctx.engines.se().get_path(id) == *path)
             })
             .unwrap_or(true)
     };
@@ -620,11 +618,10 @@ fn parse_ast_to_typed_tokens(
 ) {
     let should_process = |node: &&ty::TyAstNode| {
         modified_file
-            .as_ref()
             .map(|path| {
                 node.span
                     .source_id()
-                    .is_some_and(|id| ctx.engines.se().get_path(id) == **path)
+                    .is_some_and(|id| ctx.engines.se().get_path(id) == *path)
             })
             .unwrap_or(true)
     };

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -440,7 +440,6 @@ pub fn parse_project(
     ctx: &CompilationContext,
     lsp_mode: Option<&LspConfig>,
 ) -> Result<(), LanguageServerError> {
-    let p_now = std::time::Instant::now();
     let _p = tracing::trace_span!("parse_project").entered();
     let engines_original = ctx.engines.clone();
     let session = ctx.session.as_ref().unwrap().clone();
@@ -450,14 +449,12 @@ pub fn parse_project(
         .build_plan_cache
         .get_or_update(&sync.workspace_manifest_path(), || build_plan(uri))?;
 
-    let now = std::time::Instant::now();
     let results = compile(
         &build_plan,
         engines_clone,
         retrigger_compilation,
         lsp_mode,
     )?;
-    eprintln!("time taken to compile: {:?}", now.elapsed());
 
     // First check if results is empty or if all program values are None,
     // indicating an error occurred in the compiler
@@ -498,7 +495,6 @@ pub fn parse_project(
         return Err(LanguageServerError::MemberProgramNotFound);
     }
 
-    let now = std::time::Instant::now();
     // Check if we need to reprocess the project.
     let (needs_reprocessing, modified_file) = server_state::needs_reprocessing(&ctx.token_map, &path, lsp_mode);
 
@@ -522,8 +518,6 @@ pub fn parse_project(
             }
         }
 
-        eprintln!("time taken to traverse: {:?}", now.elapsed());
-
         session.runnables.clear();
         if let Some(metrics) = session.metrics.get(&program_id) {
             // Check if the cached AST was returned by the compiler for the users workspace.
@@ -543,7 +537,6 @@ pub fn parse_project(
         }
     }
     
-    eprintln!("time taken to parse project: {:?}", p_now.elapsed());
     Ok(())
 }
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -442,16 +442,15 @@ pub fn parse_project(
 ) -> Result<(), LanguageServerError> {
     let p_now = std::time::Instant::now();
     let _p = tracing::trace_span!("parse_project").entered();
-    let path = uri.to_file_path().unwrap();
-    let program_id = program_id_from_path(&path, engines_clone)?;
     let engines_original = ctx.engines.clone();
     let session = ctx.session.as_ref().unwrap().clone();
     let sync = ctx.sync.as_ref().unwrap().clone();
     let token_map = ctx.token_map.clone();
-
     let build_plan = session
         .build_plan_cache
         .get_or_update(&sync.workspace_manifest_path(), || build_plan(uri))?;
+    let path = uri.to_file_path().unwrap();
+    let program_id = program_id_from_path(&path, engines_clone)?;
 
     let now = std::time::Instant::now();
     let results = compile(
@@ -790,14 +789,8 @@ mod tests {
             version: None,
             gc_options: GarbageCollectionConfig::default(),
         };
-        let lsp_mode = Some(LspConfig {
-            optimized_build: ctx.optimized_build,
-            file_versions: ctx.file_versions.clone(),
-        });
-
         let result =
-            parse_project(&uri, &engines, None, &ctx, lsp_mode.as_ref()).expect_err("expected ManifestFileNotFound");
-        eprintln!("result: {:#?}", result);
+            parse_project(&uri, &engines, None, &ctx, None).expect_err("expected ManifestFileNotFound");
         assert!(matches!(
             result,
             LanguageServerError::DocumentError(

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -182,7 +182,8 @@ impl ServerState {
                             file_versions: ctx.file_versions.clone(),
                         });
 
-                        let (needs_reprocessing, _) = needs_reprocessing(&ctx.token_map, &path, lsp_mode.as_ref());
+                        let (needs_reprocessing, _) =
+                            needs_reprocessing(&ctx.token_map, &path, lsp_mode.as_ref());
 
                         // Perform garbage collection if enabled and if the file has been modified to manage memory usage.
                         if ctx.gc_options.gc_enabled && needs_reprocessing {
@@ -559,7 +560,9 @@ pub fn needs_reprocessing(
     path: &PathBuf,
     lsp_mode: Option<&LspConfig>,
 ) -> (bool, Option<PathBuf>) {
-    let has_tokens = token_map.iter().any(|item| item.key().path.as_ref() == Some(path));    
+    let has_tokens = token_map
+        .iter()
+        .any(|item| item.key().path.as_ref() == Some(path));
     let modified_file_path = modified_file(lsp_mode);
     let reprocess = !has_tokens || modified_file_path.is_some();
     (reprocess, modified_file_path)

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -171,7 +171,6 @@ impl ServerState {
         let last_compilation_state = self.last_compilation_state.clone();
         std::thread::spawn(move || {
             while let Ok(msg) = rx.recv() {
-                let now = std::time::Instant::now();
                 match msg {
                     TaskMessage::CompilationContext(ctx) => {
                         let uri = ctx.uri.as_ref().unwrap().clone();
@@ -187,7 +186,6 @@ impl ServerState {
 
                         // Perform garbage collection if enabled and if the file has been modified to manage memory usage.
                         if ctx.gc_options.gc_enabled && needs_reprocessing {
-                            let now = std::time::Instant::now();
                             // Call this on the engines clone so we don't clear types that are still in use
                             // and might be needed in the case cancel compilation was triggered.
                             if let Err(err) =
@@ -198,7 +196,6 @@ impl ServerState {
                                     err.to_string()
                                 );
                             }
-                            eprintln!("time taken to garbage collect: {:?}", now.elapsed());
                         }
 
                         // Set the is_compiling flag to true so that the wait_for_parsing function knows that we are compiling
@@ -262,7 +259,6 @@ impl ServerState {
                         return;
                     }
                 }
-                eprintln!("time taken to process compilation task: {:?}", now.elapsed());
             }
         });
     }

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -32,7 +32,7 @@ use std::{
         Arc, OnceLock,
     },
 };
-use sway_core::Engines;
+use sway_core::{Engines, LspConfig};
 use tokio::sync::Notify;
 use tower_lsp::{jsonrpc, Client};
 
@@ -171,14 +171,23 @@ impl ServerState {
         let last_compilation_state = self.last_compilation_state.clone();
         std::thread::spawn(move || {
             while let Ok(msg) = rx.recv() {
+                let now = std::time::Instant::now();
                 match msg {
                     TaskMessage::CompilationContext(ctx) => {
                         let uri = ctx.uri.as_ref().unwrap().clone();
+                        let path = uri.to_file_path().unwrap();
                         let session = ctx.session.as_ref().unwrap().clone();
                         let mut engines_clone = ctx.engines.read().clone();
+                        let lsp_mode = Some(LspConfig {
+                            optimized_build: ctx.optimized_build,
+                            file_versions: ctx.file_versions.clone(),
+                        });
 
-                        // Perform garbage collection if enabled to manage memory usage.
-                        if ctx.gc_options.gc_enabled {
+                        let (needs_reprocessing, _) = needs_reprocessing(&ctx.token_map, &path, lsp_mode.as_ref());
+
+                        // Perform garbage collection if enabled and if the file has been modified to manage memory usage.
+                        if ctx.gc_options.gc_enabled && needs_reprocessing {
+                            let now = std::time::Instant::now();
                             // Call this on the engines clone so we don't clear types that are still in use
                             // and might be needed in the case cancel compilation was triggered.
                             if let Err(err) =
@@ -189,6 +198,7 @@ impl ServerState {
                                     err.to_string()
                                 );
                             }
+                            eprintln!("time taken to garbage collect: {:?}", now.elapsed());
                         }
 
                         // Set the is_compiling flag to true so that the wait_for_parsing function knows that we are compiling
@@ -198,9 +208,9 @@ impl ServerState {
                             &engines_clone,
                             Some(retrigger_compilation.clone()),
                             &ctx,
+                            lsp_mode.as_ref(),
                         ) {
                             Ok(()) => {
-                                let path = uri.to_file_path().unwrap();
                                 // Find the program id from the path
                                 match session::program_id_from_path(&path, &engines_clone) {
                                     Ok(program_id) => {
@@ -252,6 +262,7 @@ impl ServerState {
                         return;
                     }
                 }
+                eprintln!("time taken to process compilation task: {:?}", now.elapsed());
             }
         });
     }
@@ -543,6 +554,28 @@ impl ServerState {
             .get()
             .expect("SyncWorkspace not initialized")
     }
+}
+
+/// Determines if expensive operations (traversal, GC, etc.) should be performed
+/// based on whether tokens exist and if files were modified.
+pub fn needs_reprocessing(
+    token_map: &TokenMap,
+    path: &PathBuf,
+    lsp_mode: Option<&LspConfig>,
+) -> (bool, Option<PathBuf>) {
+    let has_tokens = token_map.iter().any(|item| item.key().path.as_ref() == Some(path));    
+    let modified_file_path = modified_file(lsp_mode);
+    let reprocess = !has_tokens || modified_file_path.is_some();
+    (reprocess, modified_file_path)
+}
+
+/// Returns the modified file from the LspConfig if it exists.
+pub fn modified_file(lsp_mode: Option<&LspConfig>) -> Option<PathBuf> {
+    lsp_mode.and_then(|mode| {
+        mode.file_versions
+            .iter()
+            .find_map(|(path, version)| version.map(|_| path.clone()))
+    })
 }
 
 /// A Least Recently Used (LRU) cache for storing and managing `Session` objects.

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -555,11 +555,11 @@ impl ServerState {
 
 /// Determines if expensive operations (traversal, GC, etc.) should be performed
 /// based on whether tokens exist and if files were modified.
-pub fn needs_reprocessing(
+pub fn needs_reprocessing<'a>(
     token_map: &TokenMap,
-    path: &PathBuf,
-    lsp_mode: Option<&LspConfig>,
-) -> (bool, Option<PathBuf>) {
+    path: &'a PathBuf,
+    lsp_mode: Option<&'a LspConfig>,
+) -> (bool, Option<&'a PathBuf>) {
     let has_tokens = token_map
         .iter()
         .any(|item| item.key().path.as_ref() == Some(path));
@@ -569,11 +569,11 @@ pub fn needs_reprocessing(
 }
 
 /// Returns the modified file from the LspConfig if it exists.
-pub fn modified_file(lsp_mode: Option<&LspConfig>) -> Option<PathBuf> {
+pub fn modified_file(lsp_mode: Option<&LspConfig>) -> Option<&PathBuf> {
     lsp_mode.and_then(|mode| {
         mode.file_versions
             .iter()
-            .find_map(|(path, version)| version.map(|_| path.clone()))
+            .find_map(|(path, version)| version.map(|_| path))
     })
 }
 

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -49,10 +49,7 @@ pub(crate) struct Rename<'a> {
 }
 
 async fn open(server: &ServerState, entry_point: PathBuf) -> Url {
-    let now = std::time::Instant::now();
     let (uri, sway_program) = load_sway_example(entry_point);
-    eprintln!("time taken to load sway example: {:?}", now.elapsed());
-
     let params = DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri: uri.clone(),
@@ -163,13 +160,10 @@ fn did_open() {
 fn did_open_all_std_lib_files() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        //let files = sway_utils::helpers::get_sway_files(std_lib_dir().join("src"));
-        let files = sway_utils::helpers::get_sway_files(test_fixtures_dir().join("diagnostics/multi_file/src"));
-        let now = std::time::Instant::now();
+        let files = sway_utils::helpers::get_sway_files(std_lib_dir().join("src"));
         for file in files {
-            //eprintln!("opening file: {:?}", file.as_path());
+            eprintln!("opening file: {:?}", file.as_path());
 
-            let now2 = std::time::Instant::now();
             // If the workspace is not initialized, we need to initialize it
             // Otherwise, we can just open the file
             let uri = if service.inner().sync_workspace.get().is_none() {
@@ -177,15 +171,11 @@ fn did_open_all_std_lib_files() {
             } else {
                 open(service.inner(), file.to_path_buf()).await
             };
-            eprintln!("time taken to open file: {:?} | {:?}", now2.elapsed(), file.as_path());
 
-            let n2 = std::time::Instant::now();
             // Make sure that semantic tokens are successfully returned for the file
             let semantic_tokens = lsp::get_semantic_tokens_full(service.inner(), &uri).await;
-            eprintln!("time taken to get semantic tokens: {:?}", n2.elapsed());
             assert!(!semantic_tokens.data.is_empty());
         }
-        eprintln!("total time taken: {:?}", now.elapsed());
         shutdown_and_exit(&mut service).await;
     });
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -163,7 +163,8 @@ fn did_open() {
 fn did_open_all_std_lib_files() {
     run_async!({
         let (mut service, _) = LspService::new(ServerState::new);
-        let files = sway_utils::helpers::get_sway_files(std_lib_dir().join("src"));
+        //let files = sway_utils::helpers::get_sway_files(std_lib_dir().join("src"));
+        let files = sway_utils::helpers::get_sway_files(test_fixtures_dir().join("diagnostics/multi_file/src"));
         let now = std::time::Instant::now();
         for file in files {
             //eprintln!("opening file: {:?}", file.as_path());
@@ -178,8 +179,10 @@ fn did_open_all_std_lib_files() {
             };
             eprintln!("time taken to open file: {:?} | {:?}", now2.elapsed(), file.as_path());
 
+            let n2 = std::time::Instant::now();
             // Make sure that semantic tokens are successfully returned for the file
             let semantic_tokens = lsp::get_semantic_tokens_full(service.inner(), &uri).await;
+            eprintln!("time taken to get semantic tokens: {:?}", n2.elapsed());
             assert!(!semantic_tokens.data.is_empty());
         }
         eprintln!("total time taken: {:?}", now.elapsed());


### PR DESCRIPTION
## Description
This PR introduces selective processing to dramatically improve LSP performance when opening multiple files.

### Key Changes
* **Conditional reprocessing**: Only perform expensive traversal operations when tokens don't exist or files have been modified
* **Selective garbage collection**: GC now only runs when files are actually modified, not on every compilation
* **Targeted token map updates**: Remove tokens only for modified files instead of clearing the entire map
* **Improved modified file tracking**: Extract modified file detection into reusable utility functions

### Performance Impact
| Test | Before | After | Improvement |
|------|--------|-------|-------------|
| did_open_all_std_lib_files | 54.96s | 3.76s | 14.6x faster |
| Time reduction | - | - | 93% decrease |

The `did_open_all_std_lib_files` test opens every file in the std lib and publishes the semantic tokens for the file. 

The optimisation is particularly effective for workflows involving opening multiple files where the LSP previously performed unnecessary recompilation and traversal for unchanged files.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
