### PR TITLE
Implement `Hash` for `Vec<T>`

### DIFF
--- a/sway-lib-std/src/hash.sw
+++ b/sway-lib-std/src/hash.sw
@@ -5,6 +5,7 @@ use ::alloc::alloc_bytes;
 use ::bytes::*;
 use ::codec::*;
 use ::debug::*;
+use ::vec::Vec;
 
 pub struct Hasher {
     bytes: Bytes,
@@ -396,6 +397,28 @@ where
         let mut i = 0;
         while __lt(i, N) {
             let item: T = *__elem_at(&self, i);
+            item.hash(state);
+            i = __add(i, 1);
+        }
+    }
+}
+
+impl<T> Hash for Vec<T>
+where
+    T: Hash,
+{
+    fn hash(self, ref mut state: Hasher) {
+        let len = self.len();
+        // `__elem_at` accepts only a reference to a slice or an array.
+        // To satisfy this requirement, we cast the pointer to the underlying
+        // vector data to an array reference.
+        let ptr = asm(ptr: self.ptr()) {
+            ptr: &[T; 0]
+        };
+
+        let mut i = 0;
+        while __lt(i, len) {
+            let item: T = *__elem_at(ptr, i);
             item.hash(state);
             i = __add(i, 1);
         }

--- a/test/src/in_language_tests/test_programs/hash_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/hash_inline_tests/src/main.sw
@@ -429,6 +429,33 @@ fn hash_hasher_sha256_10_array() {
     assert(sha256 == 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
 }
 
+#[test]
+fn hash_hasher_sha256_vec() {
+    let mut vec = Vec::<u64>::new();
+    let mut i = 0;
+    while i < 10 {
+        vec.push(0_u64);
+        i += 1;
+    }
+
+    let mut hasher = Hasher::new();
+    vec.hash(hasher);
+    let sha256 = hasher.sha256();
+    assert(sha256 == 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+
+    let mut vec = Vec::<u64>::new();
+    let mut i = 0;
+    while i < 10 {
+        vec.push(1_u64);
+        i += 1;
+    }
+
+    let mut hasher = Hasher::new();
+    vec.hash(hasher);
+    let sha256 = hasher.sha256();
+    assert(sha256 == 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
+}
+
 #[test()]
 fn hash_sha256() {
     let digest = sha256(0_u64);


### PR DESCRIPTION
## Description

This PR implements `Hash` for `Vec<T>` where `T` is `Hash`. We need this implementation in the `std`, otherwise none of the other packages will be able to provide a `Hash` implementation for `Vec<Something>` because of the orphan rule violation (see: #7216).

Closes:
- #7216

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.