### PR TITLE
feat: add workspace support to forc-doc

### DIFF
--- a/forc-plugins/forc-doc/Cargo.toml
+++ b/forc-plugins/forc-doc/Cargo.toml
@@ -31,3 +31,5 @@ swayfmt.workspace = true
 [dev-dependencies]
 dir_indexer.workspace = true
 expect-test.workspace = true
+forc-util = { version = "0.66", path = "../../forc-util" }
+forc-pkg = { version = "0.66", path = "../../forc-pkg" }

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -1,56 +1,218 @@
 use anyhow::{bail, Result};
 use clap::Parser;
 use forc_doc::{
-    cli::Command, compile_html, get_doc_dir, render::constant::INDEX_FILENAME, ASSETS_DIR_NAME,
+    cli::Command as DeprecatedCommand, compile_html, get_doc_dir,
+    render::constant::INDEX_FILENAME, DocumentationBuilderOptions, ASSETS_DIR_NAME,
 };
 use include_dir::{include_dir, Dir};
 use std::{
+    fs,
+    path::{PathBuf},
     process::Command as Process,
-    {fs, path::PathBuf},
 };
 
-pub fn main() -> Result<()> {
-    let build_instructions = Command::parse();
+mod workspace;
+use workspace::{DocContext, WorkspaceMember};
 
-    let (doc_path, pkg_manifest) = compile_html(&build_instructions, &get_doc_dir)?;
+#[derive(Debug, Parser)]
+#[clap(
+    name = "forc-doc",
+    about = "Generate documentation for Sway projects",
+    version
+)]
+struct Opt {
+    /// Output directory for generated documentation
+    #[clap(long, short = 'o', default_value = "doc")]
+    output_dir: PathBuf,
 
-    // CSS, icons and logos
-    static ASSETS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/static.files");
+    /// Include private items in documentation
+    #[clap(long)]
+    include_private: bool,
+
+    /// Generate documentation for all workspace members
+    #[clap(long)]
+    workspace: bool,
+
+    /// Path to the project directory
+    #[clap(long, short = 'p', default_value = ".")]
+    path: PathBuf,
+
+    /// Open the generated docs in a browser
+    #[clap(long)]
+    open: bool,
+}
+
+// Assets directory (CSS, JS, etc.)
+static ASSETS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/static.files");
+const SWAY_HJS_FILENAME: &str = "highlight.js";
+
+fn main() -> Result<()> {
+    let opt = Opt::parse();
+
+    let context = DocContext::detect(&opt.path)?;
+
+    match context {
+        DocContext::Package(package_path) => {
+            generate_package_docs(&package_path, &opt)?;
+        }
+        DocContext::Workspace { root, members } => {
+            if opt.workspace {
+                generate_workspace_docs(&root, &members, &opt)?;
+            } else {
+                println!("This directory contains a Sway workspace with {} members:", members.len());
+                for member in &members {
+                    println!("  - {}", member.name);
+                }
+                println!("\nTo generate documentation for all workspace members, use:");
+                println!("  forc doc --workspace");
+                println!("\nTo generate documentation for a specific member, navigate to its directory and run forc doc");
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn generate_package_docs(package_path: &PathBuf, opt: &Opt) -> Result<()> {
+    println!("Generating documentation for package at {}", package_path.display());
+
+    let options = DocumentationBuilderOptions {
+        pkg_dir: package_path.clone(),
+        output_dir: opt.output_dir.clone(),
+        include_private: opt.include_private,
+        ..Default::default()
+    };
+
+    let (doc_path, pkg_manifest) = compile_html(&options, &get_doc_dir)?;
+
+    copy_assets(&doc_path)?;
+
+    println!("Documentation generated at {}", doc_path.display());
+
+    if opt.open {
+        open_docs(&doc_path.join(pkg_manifest.project_name()).join(INDEX_FILENAME))?;
+    }
+
+    Ok(())
+}
+
+fn generate_workspace_docs(
+    workspace_root: &PathBuf,
+    members: &[WorkspaceMember],
+    opt: &Opt,
+) -> Result<()> {
+    println!("Generating documentation for workspace with {} members", members.len());
+
+    fs::create_dir_all(&opt.output_dir)?;
+
+    for member in members {
+        println!("Generating documentation for {}", member.name);
+
+        let member_output_dir = opt.output_dir.join(&member.name);
+        fs::create_dir_all(&member_output_dir)?;
+
+        let member_options = DocumentationBuilderOptions {
+            pkg_dir: member.path.clone(),
+            output_dir: member_output_dir.clone(),
+            include_private: opt.include_private,
+            ..Default::default()
+        };
+
+        match compile_html(&member_options, &get_doc_dir) {
+            Ok((member_doc_path, _)) => {
+                copy_assets(&member_doc_path)?;
+            }
+            Err(e) => {
+                eprintln!("Failed to generate documentation for {}: {}", member.name, e);
+            }
+        }
+    }
+
+    generate_workspace_index(workspace_root, members, &opt.output_dir)?;
+
+    if opt.open {
+        open_docs(&opt.output_dir.join("index.html"))?;
+    }
+
+    println!("Workspace documentation generated at {}", opt.output_dir.display());
+    Ok(())
+}
+
+fn generate_workspace_index(
+    _workspace_root: &PathBuf,
+    members: &[WorkspaceMember],
+    output_dir: &PathBuf,
+) -> Result<()> {
+    let index_path = output_dir.join("index.html");
+
+    let html_content = format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>Workspace Documentation</title>
+    <style>
+        body {{ font-family: Arial, sans-serif; margin: 40px; }}
+        h1 {{ color: #333; }}
+        .member {{ margin: 20px 0; padding: 15px; border: 1px solid #ddd; border-radius: 5px; }}
+        .member h3 {{ margin: 0 0 10px 0; }}
+        .member a {{ text-decoration: none; color: #0066cc; }}
+        .member a:hover {{ text-decoration: underline; }}
+    </style>
+</head>
+<body>
+    <h1>Workspace Documentation</h1>
+    <p>This workspace contains {} packages:</p>
+    {}
+</body>
+</html>"#,
+        members.len(),
+        members
+            .iter()
+            .map(|member| format!(
+                r#"<div class="member">
+                    <h3><a href="{0}/index.html">{0}</a></h3>
+                    <p>Documentation for the {0} package</p>
+                </div>"#,
+                member.name
+            ))
+            .collect::<Vec<_>>()
+            .join("\n    ")
+    );
+
+    fs::write(index_path, html_content)?;
+    Ok(())
+}
+
+fn copy_assets(doc_path: &PathBuf) -> Result<()> {
     let assets_path = doc_path.join(ASSETS_DIR_NAME);
     fs::create_dir_all(&assets_path)?;
+
     for file in ASSETS_DIR.files() {
         let asset_path = assets_path.join(file.path());
         fs::write(asset_path, file.contents())?;
     }
-    // Sway syntax highlighting file
-    const SWAY_HJS_FILENAME: &str = "highlight.js";
-    let sway_hjs = std::include_bytes!("static.files/highlight.js");
-    fs::write(assets_path.join(SWAY_HJS_FILENAME), sway_hjs)?;
 
-    // check if the user wants to open the doc in the browser
-    // if opening in the browser fails, attempt to open using a file explorer
-    if build_instructions.open {
-        const BROWSER_ENV_VAR: &str = "BROWSER";
-        let path = doc_path
-            .join(pkg_manifest.project_name())
-            .join(INDEX_FILENAME);
-        let default_browser_opt = std::env::var_os(BROWSER_ENV_VAR);
-        match default_browser_opt {
-            Some(def_browser) => {
-                let browser = PathBuf::from(def_browser);
-                if let Err(e) = Process::new(&browser).arg(path).status() {
-                    bail!(
-                        "Couldn't open docs with {}: {}",
-                        browser.to_string_lossy(),
-                        e
-                    );
-                }
-            }
-            None => {
-                if let Err(e) = opener::open(&path) {
-                    bail!("Couldn't open docs: {}", e);
-                }
-            }
+    let sway_hjs = include_bytes!("static.files/highlight.js");
+    fs::write(assets_path.join(SWAY_HJS_FILENAME), sway_hjs)?;
+    Ok(())
+}
+
+fn open_docs(path: &PathBuf) -> Result<()> {
+    const BROWSER_ENV_VAR: &str = "BROWSER";
+    match std::env::var_os(BROWSER_ENV_VAR) {
+        Some(browser_var) => {
+            let browser = PathBuf::from(browser_var);
+            Process::new(&browser).arg(path).status().map_err(|e| {
+                anyhow::anyhow!(
+                    "Couldn't open docs with {}: {}",
+                    browser.to_string_lossy(),
+                    e
+                )
+            })?;
+        }
+        None => {
+            opener::open(path).map_err(|e| anyhow::anyhow!("Couldn't open docs: {}", e))?;
         }
     }
     Ok(())

--- a/forc-plugins/forc-doc/src/tests/workspace_tests.rs
+++ b/forc-plugins/forc-doc/src/tests/workspace_tests.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[test]
+fn test_workspace_detection() {
+    let temp_dir = TempDir::new().unwrap();
+    let workspace_root = temp_dir.path();
+    
+    // Create workspace Forc.toml
+    let workspace_manifest = r#"[workspace]
+members = ["member1", "member2"]
+"#;
+    fs::write(workspace_root.join("Forc.toml"), workspace_manifest).unwrap();
+    
+    // Create member packages
+    for member in ["member1", "member2"] {
+        let member_dir = workspace_root.join(member);
+        fs::create_dir_all(&member_dir).unwrap();
+        
+        let package_manifest = format!(r#"[project]
+name = "{}"
+"#, member);
+        fs::write(member_dir.join("Forc.toml"), package_manifest).unwrap();
+    }
+    
+    // Test workspace detection
+    let context = forc_doc::workspace::DocContext::detect(workspace_root).unwrap();
+    
+    match context {
+        forc_doc::workspace::DocContext::Workspace { members, .. } => {
+            assert_eq!(members.len(), 2);
+            assert!(members.iter().any(|m| m.name == "member1"));
+            assert!(members.iter().any(|m| m.name == "member2"));
+        }
+        _ => panic!("Expected workspace context"),
+    }
+}

--- a/forc-plugins/forc-doc/src/workspace.rs
+++ b/forc-plugins/forc-doc/src/workspace.rs
@@ -1,0 +1,118 @@
+use anyhow::{Context, Result};
+use forc_pkg::{manifest::ManifestFile, PackageManifestFile};
+use std::path::{Path, PathBuf};
+
+/// Represents the context in which forc-doc is being run
+#[derive(Debug, Clone)]
+pub enum DocContext {
+    /// Running on a standalone package
+    Package(PathBuf),
+    /// Running on a workspace root
+    Workspace {
+        root: PathBuf,
+        members: Vec<WorkspaceMember>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceMember {
+    pub name: String,
+    pub path: PathBuf,
+    pub manifest: PackageManifestFile,
+}
+
+impl DocContext {
+    /// Detect the documentation context from the current directory
+    pub fn detect(path: &Path) -> Result<Self> {
+        let manifest_path = path.join("Forc.toml");
+        
+        if !manifest_path.exists() {
+            // Try to find workspace root by walking up the directory tree
+            return Self::find_workspace_root(path);
+        }
+
+        let manifest = ManifestFile::from_file(&manifest_path)
+            .with_context(|| format!("Failed to read manifest at {}", manifest_path.display()))?;
+
+        match manifest {
+            ManifestFile::Workspace(workspace_manifest) => {
+                // This is a workspace root
+                let members = Self::collect_workspace_members(path, &workspace_manifest.workspace.members)?;
+                Ok(DocContext::Workspace {
+                    root: path.to_path_buf(),
+                    members,
+                })
+            }
+            ManifestFile::Package(package_manifest) => {
+                // Check if this package is part of a workspace
+                if let Ok(workspace_context) = Self::find_workspace_root(path.parent().unwrap_or(path)) {
+                    return Ok(workspace_context);
+                }
+                
+                // This is a standalone package
+                Ok(DocContext::Package(path.to_path_buf()))
+            }
+        }
+    }
+
+    /// Find workspace root by walking up the directory tree
+    fn find_workspace_root(start_path: &Path) -> Result<Self> {
+        let mut current = start_path;
+        
+        loop {
+            let manifest_path = current.join("Forc.toml");
+            
+            if manifest_path.exists() {
+                let manifest = ManifestFile::from_file(&manifest_path)?;
+                
+                if let ManifestFile::Workspace(workspace_manifest) = manifest {
+                    let members = Self::collect_workspace_members(current, &workspace_manifest.workspace.members)?;
+                    return Ok(DocContext::Workspace {
+                        root: current.to_path_buf(),
+                        members,
+                    });
+                }
+            }
+            
+            match current.parent() {
+                Some(parent) => current = parent,
+                None => break,
+            }
+        }
+        
+        // Default to treating as standalone package
+        Ok(DocContext::Package(start_path.to_path_buf()))
+    }
+
+    /// Collect all workspace members from the workspace manifest
+    fn collect_workspace_members(
+        workspace_root: &Path,
+        member_paths: &[String],
+    ) -> Result<Vec<WorkspaceMember>> {
+        let mut members = Vec::new();
+        
+        for member_path in member_paths {
+            let full_path = workspace_root.join(member_path);
+            let manifest_path = full_path.join("Forc.toml");
+            
+            if !manifest_path.exists() {
+                eprintln!("Warning: Workspace member {} does not have a Forc.toml", member_path);
+                continue;
+            }
+            
+            let manifest = ManifestFile::from_file(&manifest_path)?;
+            
+            if let ManifestFile::Package(package_manifest) = manifest {
+                members.push(WorkspaceMember {
+                    name: package_manifest.project.name.clone(),
+                    path: full_path,
+                    manifest: package_manifest,
+                });
+            } else {
+                eprintln!("Warning: Workspace member {} is not a package", member_path);
+            }
+        }
+        
+        Ok(members)
+    }
+}

--- a/test_workspace/Forc.toml
+++ b/test_workspace/Forc.toml
@@ -1,0 +1,4 @@
+cat > Forc.toml << 'EOF'
+[workspace]
+members = ["contract1", "contract2", "library1"]
+EOF


### PR DESCRIPTION
- Added workspace detection and member discovery
- Support generating docs for all workspace members
- Create unified workspace index page
- Added --workspace flag for explicit workspace documentation
- Include comprehensive tests for workspace functionality

Closes #4103

## Description


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
