### PR TITLE
Support ABI errors in `forc test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,6 +2894,7 @@ dependencies = [
  "forc-tracing 0.68.6",
  "forc-util",
  "fs_extra",
+ "fuel-abi-types 0.12.0",
  "fuel-asm",
  "hex",
  "rexpect",
@@ -3205,6 +3206,7 @@ version = "0.68.6"
 dependencies = [
  "anyhow",
  "forc-pkg",
+ "forc-util",
  "fuel-abi-types 0.12.0",
  "fuel-tx",
  "fuel-vm",

--- a/forc-plugins/forc-client/src/op/call/transaction_trace.rs
+++ b/forc-plugins/forc-client/src/op/call/transaction_trace.rs
@@ -263,19 +263,14 @@ impl Node<'_> {
                     Some(data) => {
                         let hex_str = format!("0x{}", hex::encode(data));
                         match self.abis.get(id) {
-                            Some(abi) => {
-                                let program_abi = sway_core::asm_generation::ProgramABI::Fuel(
-                                    abi.program.clone(),
-                                );
-                                forc_util::tx_utils::decode_log_data(
-                                    &rb.to_string(),
-                                    data,
-                                    &program_abi,
-                                )
-                                .ok()
-                                .map(|decoded| decoded.value)
-                                .unwrap_or(hex_str)
-                            }
+                            Some(abi) => forc_util::tx_utils::decode_fuel_vm_log_data(
+                                &rb.to_string(),
+                                data,
+                                &abi.program,
+                            )
+                            .ok()
+                            .map(|decoded| decoded.value)
+                            .unwrap_or(hex_str),
                             None => hex_str,
                         }
                     }

--- a/forc-test/Cargo.toml
+++ b/forc-test/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 forc-pkg.workspace = true
+forc-util.workspace = true
 fuel-abi-types.workspace = true
 fuel-tx = { workspace = true, features = ["test-helpers"] }
 fuel-vm = { workspace = true, features = ["random", "test-helpers"] }

--- a/forc-test/src/ecal.rs
+++ b/forc-test/src/ecal.rs
@@ -25,14 +25,14 @@ impl Syscall {
                 let mut f = unsafe { std::fs::File::from_raw_fd(*fd as i32) };
                 write!(&mut f, "{}", s).unwrap();
 
-                // Dont close the fd
+                // Don't close the fd
                 std::mem::forget(f);
             }
             Syscall::Fflush { fd } => {
                 let mut f = unsafe { std::fs::File::from_raw_fd(*fd as i32) };
                 let _ = f.flush();
 
-                // Dont close the fd
+                // Don't close the fd
                 std::mem::forget(f);
             }
             Syscall::Unknown { ra, rb, rc, rd } => {

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -8,7 +8,8 @@ use crate::setup::{
 };
 use ecal::EcalSyscallHandler;
 use forc_pkg::{self as pkg, BuildOpts};
-use fuel_abi_types::error_codes::ErrorSignal;
+use forc_util::tx_utils::RevertInfo;
+use fuel_abi_types::abi::program::ProgramABI;
 use fuel_tx as tx;
 use fuel_vm::checked_transaction::builder::TransactionBuilderExt;
 use fuel_vm::{self as vm};
@@ -516,12 +517,13 @@ impl TestResult {
         }
     }
 
-    /// Return an [ErrorSignal] for this [TestResult] if the test is failed to pass.
-    pub fn error_signal(&self) -> anyhow::Result<ErrorSignal> {
-        let revert_code = self.revert_code().ok_or_else(|| {
-            anyhow::anyhow!("there is no revert code to convert to `ErrorSignal`")
-        })?;
-        ErrorSignal::try_from_revert_code(revert_code).map_err(|e| anyhow::anyhow!(e))
+    pub fn revert_info(
+        &self,
+        program_abi: Option<&ProgramABI>,
+        logs: &[fuel_tx::Receipt],
+    ) -> Option<RevertInfo> {
+        self.revert_code()
+            .map(|revert_code| RevertInfo::new(revert_code, program_abi, logs))
     }
 
     /// Return [TestDetails] from the span of the function declaring this test.

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -26,6 +26,8 @@ use sway_utils::constants;
 pub mod bytecode;
 pub mod fs_locking;
 pub mod restricted;
+#[cfg(feature = "tx")]
+pub mod tx_utils;
 
 #[macro_use]
 pub mod cli;
@@ -139,111 +141,6 @@ macro_rules! forc_result_bail {
     ($fmt:expr, $($arg:tt)*) => {
         return $crate::ForcResult::Err(anyhow::anyhow!($fmt, $($arg)*).into())
     };
-}
-
-#[cfg(feature = "tx")]
-pub mod tx_utils {
-
-    use anyhow::Result;
-    use clap::Args;
-    use fuels_core::{codec::ABIDecoder, types::param_types::ParamType};
-    use serde::{Deserialize, Serialize};
-    use std::collections::HashMap;
-    use sway_core::{asm_generation::ProgramABI, fuel_prelude::fuel_tx};
-
-    /// Added salt used to derive the contract ID.
-    #[derive(Debug, Args, Default, Deserialize, Serialize)]
-    pub struct Salt {
-        /// Added salt used to derive the contract ID.
-        ///
-        /// By default, this is
-        /// `0x0000000000000000000000000000000000000000000000000000000000000000`.
-        #[clap(long = "salt")]
-        pub salt: Option<fuel_tx::Salt>,
-    }
-
-    /// Format `Log` and `LogData` receipts.
-    pub fn format_log_receipts(
-        receipts: &[fuel_tx::Receipt],
-        pretty_print: bool,
-    ) -> Result<String> {
-        let mut receipt_to_json_array = serde_json::to_value(receipts)?;
-        for (rec_index, receipt) in receipts.iter().enumerate() {
-            let rec_value = receipt_to_json_array.get_mut(rec_index).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Serialized receipts does not contain {} th index",
-                    rec_index
-                )
-            })?;
-            match receipt {
-                fuel_tx::Receipt::LogData {
-                    data: Some(data), ..
-                } => {
-                    if let Some(v) = rec_value.pointer_mut("/LogData/data") {
-                        *v = hex::encode(data).into();
-                    }
-                }
-                fuel_tx::Receipt::ReturnData {
-                    data: Some(data), ..
-                } => {
-                    if let Some(v) = rec_value.pointer_mut("/ReturnData/data") {
-                        *v = hex::encode(data).into();
-                    }
-                }
-                _ => {}
-            }
-        }
-        if pretty_print {
-            Ok(serde_json::to_string_pretty(&receipt_to_json_array)?)
-        } else {
-            Ok(serde_json::to_string(&receipt_to_json_array)?)
-        }
-    }
-
-    /// A `LogData` decoded into a human readable format with its type information.
-    pub struct DecodedLog {
-        pub value: String,
-    }
-
-    pub fn decode_log_data(
-        log_id: &str,
-        log_data: &[u8],
-        program_abi: &ProgramABI,
-    ) -> anyhow::Result<DecodedLog> {
-        let program_abi = match program_abi {
-            ProgramABI::Fuel(fuel_abi) => Some(
-                fuel_abi_types::abi::unified_program::UnifiedProgramABI::from_counterpart(
-                    fuel_abi,
-                )?,
-            ),
-            _ => None,
-        }
-        .ok_or_else(|| anyhow::anyhow!("only fuelvm is supported for log decoding"))?;
-        // Create type lookup (id, TypeDeclaration)
-        let type_lookup = program_abi
-            .types
-            .iter()
-            .map(|decl| (decl.type_id, decl.clone()))
-            .collect::<HashMap<_, _>>();
-
-        let logged_type_lookup: HashMap<_, _> = program_abi
-            .logged_types
-            .iter()
-            .flatten()
-            .map(|logged_type| (logged_type.log_id.as_str(), logged_type.application.clone()))
-            .collect();
-
-        let type_application = logged_type_lookup
-            .get(&log_id)
-            .ok_or_else(|| anyhow::anyhow!("log id is missing"))?;
-
-        let abi_decoder = ABIDecoder::default();
-        let param_type = ParamType::try_from_type_application(type_application, &type_lookup)?;
-        let decoded_str = abi_decoder.decode_as_debug_str(&param_type, log_data)?;
-        let decoded_log = DecodedLog { value: decoded_str };
-
-        Ok(decoded_log)
-    }
 }
 
 pub fn find_file_name<'sc>(manifest_dir: &Path, entry_path: &'sc Path) -> Result<&'sc Path> {

--- a/forc-util/src/tx_utils.rs
+++ b/forc-util/src/tx_utils.rs
@@ -1,0 +1,315 @@
+use anyhow::Result;
+use clap::Args;
+use fuel_abi_types::error_codes::ErrorSignal;
+use fuels_core::{codec::ABIDecoder, types::param_types::ParamType};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use sway_core::{asm_generation::ProgramABI, fuel_prelude::fuel_tx};
+
+/// Added salt used to derive the contract ID.
+#[derive(Debug, Args, Default, Deserialize, Serialize)]
+pub struct Salt {
+    /// Added salt used to derive the contract ID.
+    ///
+    /// By default, this is
+    /// `0x0000000000000000000000000000000000000000000000000000000000000000`.
+    #[clap(long = "salt")]
+    pub salt: Option<fuel_tx::Salt>,
+}
+
+/// Format `Log` and `LogData` receipts.
+pub fn format_log_receipts(receipts: &[fuel_tx::Receipt], pretty_print: bool) -> Result<String> {
+    let mut receipt_to_json_array = serde_json::to_value(receipts)?;
+    for (rec_index, receipt) in receipts.iter().enumerate() {
+        let rec_value = receipt_to_json_array.get_mut(rec_index).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Serialized receipts does not contain {} th index",
+                rec_index
+            )
+        })?;
+        match receipt {
+            fuel_tx::Receipt::LogData {
+                data: Some(data), ..
+            } => {
+                if let Some(v) = rec_value.pointer_mut("/LogData/data") {
+                    *v = hex::encode(data).into();
+                }
+            }
+            fuel_tx::Receipt::ReturnData {
+                data: Some(data), ..
+            } => {
+                if let Some(v) = rec_value.pointer_mut("/ReturnData/data") {
+                    *v = hex::encode(data).into();
+                }
+            }
+            _ => {}
+        }
+    }
+    if pretty_print {
+        Ok(serde_json::to_string_pretty(&receipt_to_json_array)?)
+    } else {
+        Ok(serde_json::to_string(&receipt_to_json_array)?)
+    }
+}
+
+/// A `LogData` decoded into a human readable format with its type information.
+pub struct DecodedLog {
+    pub value: String,
+}
+
+pub fn decode_log_data(
+    log_id: &str,
+    log_data: &[u8],
+    program_abi: &ProgramABI,
+) -> anyhow::Result<DecodedLog> {
+    match program_abi {
+        ProgramABI::Fuel(program_abi) => decode_fuel_vm_log_data(log_id, log_data, program_abi),
+        _ => Err(anyhow::anyhow!(
+            "only Fuel VM is supported for log decoding"
+        )),
+    }
+}
+
+pub fn decode_fuel_vm_log_data(
+    log_id: &str,
+    log_data: &[u8],
+    program_abi: &fuel_abi_types::abi::program::ProgramABI,
+) -> anyhow::Result<DecodedLog> {
+    let program_abi =
+        fuel_abi_types::abi::unified_program::UnifiedProgramABI::from_counterpart(program_abi)?;
+
+    // Create type lookup (id, TypeDeclaration)
+    let type_lookup = program_abi
+        .types
+        .iter()
+        .map(|decl| (decl.type_id, decl.clone()))
+        .collect::<HashMap<_, _>>();
+
+    let logged_type_lookup: HashMap<_, _> = program_abi
+        .logged_types
+        .iter()
+        .flatten()
+        .map(|logged_type| (logged_type.log_id.as_str(), logged_type.application.clone()))
+        .collect();
+
+    let type_application = logged_type_lookup
+        .get(&log_id)
+        .ok_or_else(|| anyhow::anyhow!("log id is missing"))?;
+
+    let abi_decoder = ABIDecoder::default();
+    let param_type = ParamType::try_from_type_application(type_application, &type_lookup)?;
+    let decoded_str = abi_decoder.decode_as_debug_str(&param_type, log_data)?;
+    let decoded_log = DecodedLog { value: decoded_str };
+
+    Ok(decoded_log)
+}
+
+pub struct RevertPosition {
+    pub pkg: String,
+    pub file: String,
+    pub line: u64,
+    pub column: u64,
+}
+
+// TODO: Move `RevertInfo` and related types to `fuel-abi-types` crate.
+//       We temporarily keep it here to get the support for `panic` expression in `forc test` ASAP,
+//       without waiting for the next `fuel-abi-types` release.
+
+/// Information about a revert that occurred during a transaction execution.
+pub struct RevertInfo {
+    pub revert_code: u64,
+    pub kind: RevertKind,
+}
+
+pub enum RevertKind {
+    /// This is the most general kind of a revert, where we only know the revert code.
+    /// E.g., reverts caused by `__revert` calls.
+    RawRevert,
+    /// Reverts caused by known functions, like, e.g., `assert` or `require`, that provide known error signals.
+    /// For such reverts, we can provide the error message.
+    KnownErrorSignal { err_msg: String },
+    Panic {
+        err_msg: Option<String>,
+        err_val: Option<String>,
+        pos: RevertPosition,
+    },
+}
+
+impl RevertInfo {
+    pub fn raw_revert(revert_code: u64) -> Self {
+        Self {
+            revert_code,
+            kind: RevertKind::RawRevert,
+        }
+    }
+
+    pub fn new(
+        revert_code: u64,
+        program_abi: Option<&fuel_abi_types::abi::program::ProgramABI>,
+        logs: &[fuel_tx::Receipt],
+    ) -> Self {
+        /// Types that implement the `std::marker::Error` trait, and whose instances
+        /// can be used as arguments to the `panic` expression.
+        enum ErrorType {
+            Unknown,
+            Unit,
+            Str,
+            Enum,
+        }
+
+        impl ErrorType {
+            fn from_type_name(type_name: &str) -> Self {
+                match type_name {
+                    "()" => ErrorType::Unit,
+                    "str" => ErrorType::Str,
+                    name if name.starts_with("enum ") => ErrorType::Enum,
+                    _ => ErrorType::Unknown,
+                }
+            }
+        }
+
+        if let Ok(error_signal) = ErrorSignal::try_from_revert_code(revert_code) {
+            Self {
+                revert_code,
+                kind: RevertKind::KnownErrorSignal {
+                    err_msg: error_signal.to_string(),
+                },
+            }
+        } else if let Some(program_abi) = program_abi {
+            // We have the program ABI available, and can try to extract more information about the revert.
+            if let Some(error_details) = program_abi
+                .error_codes
+                .as_ref()
+                .and_then(|error_codes| error_codes.get(&revert_code))
+            {
+                // If we have an ABI error code, we always know the position.
+                let pos = RevertPosition {
+                    pkg: error_details.pos.pkg.clone(),
+                    file: error_details.pos.file.clone(),
+                    line: error_details.pos.line,
+                    column: error_details.pos.column,
+                };
+
+                // Message and log ID are mutually exclusive.
+                let (err_msg, err_val) = if let Some(msg) = &error_details.msg {
+                    (Some(msg.clone()), None)
+                } else if let Some(log_id) = &error_details.log_id {
+                    // Because we got the error code, we know that the revert is a result of `panic`king.
+                    // The log receipt created by the `panic` expression will be the last one in the logs.
+                    let err_val = logs
+                        .last()
+                        .and_then(|log| {
+                            if let fuel_tx::Receipt::LogData {
+                                data: Some(data), ..
+                            } = log
+                            {
+                                decode_fuel_vm_log_data(log_id, data, program_abi).ok()
+                            } else {
+                                None
+                            }
+                        })
+                        .map(|decoded_log| decoded_log.value);
+
+                    match program_abi
+                        .logged_types
+                        .as_ref()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .find(|logged_type| logged_type.log_id == *log_id)
+                        .and_then(|logged_type| {
+                            program_abi.concrete_types.iter().find(|concrete_type| {
+                                concrete_type.concrete_type_id == logged_type.concrete_type_id
+                            })
+                        })
+                        .map(|type_decl| &type_decl.type_field)
+                    {
+                        // All of the `(None, err_val)` cases below can happen only if the ABI is malformed.
+                        // We handle that case gracefully by returning `None` for the error message,
+                        // but still returning the error value if it is provided.
+                        // Note that not having an error value is also possible only if the ABI is malformed.
+                        Some(error_type_name) => match ErrorType::from_type_name(error_type_name) {
+                            ErrorType::Unit => (None, err_val),
+                            ErrorType::Str => {
+                                // This is the case where the error value is a non-const evaluated string slice.
+                                // The error message will be null in the JSON ABI and the log value will be the string slice
+                                // decoded like: `AsciiString { data: "<the actual error message>" }`.
+                                // In this case, we will actually show `<the actual error message>` as the error message
+                                // and set the error value to `None`.
+                                // The `AsciiString { data: "<the actual error message>" }` will still be displayed in the logs,
+                                // We "parse" the error message out, by gracefully extracting it from the decoded logged value.
+                                if let Some(err_val) = err_val {
+                                    let left_quote_index = err_val.find('"').unwrap_or_default();
+                                    let right_quote_index = err_val.rfind('"').unwrap_or_default();
+                                    if left_quote_index < right_quote_index {
+                                        let err_msg = err_val[left_quote_index..right_quote_index]
+                                            .trim_matches('"');
+                                        (Some(err_msg.to_string()), None)
+                                    } else {
+                                        (None, Some(err_val)) // Malformed error value, handle gracefully.
+                                    }
+                                } else {
+                                    (None, err_val) // Malformed ABI, handle gracefully.
+                                }
+                            }
+                            ErrorType::Enum => {
+                                if let Some(err_val) = err_val {
+                                    let err_msg = program_abi
+                                        .metadata_types
+                                        .iter()
+                                        .find(|metadata_type| {
+                                            metadata_type.type_field == *error_type_name
+                                        })
+                                        .and_then(|metadata_type| {
+                                            metadata_type.components.as_ref().and_then(
+                                                |components| {
+                                                    // The component name will be the name of the error enum variant.
+                                                    // We extract the concrete error enum variant name from the logged error value.
+                                                    // The logged error value will either be a `SomeErrorVariant` or `SomeErrorVariant(value)`.
+                                                    // So, the name will be the first part of the string, up to the first `(` if it exists.
+                                                    // TODO: Is there a better way to match the logged error value to the component name?
+                                                    err_val.split('(').next().map(|variant_name| {
+                                                        components
+                                                            .iter()
+                                                            .find(|component| {
+                                                                component.name.as_str()
+                                                                    == variant_name
+                                                            })
+                                                            .and_then(|component| {
+                                                                component.error_message.clone()
+                                                            })
+                                                    })
+                                                },
+                                            )
+                                        })
+                                        .flatten();
+
+                                    (err_msg, Some(err_val))
+                                } else {
+                                    (None, err_val) // Malformed ABI, handle gracefully.
+                                }
+                            }
+                            ErrorType::Unknown => (None, err_val), // Malformed ABI, handle gracefully.
+                        },
+                        None => (None, err_val), // Malformed ABI, handle gracefully.
+                    }
+                } else {
+                    (None, None)
+                };
+
+                Self {
+                    revert_code,
+                    kind: RevertKind::Panic {
+                        err_msg,
+                        err_val,
+                        pos,
+                    },
+                }
+            } else {
+                Self::raw_revert(revert_code)
+            }
+        } else {
+            // No known error signal, and no ABI available. We can't extract any additional information.
+            Self::raw_revert(revert_code)
+        }
+    }
+}

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -29,6 +29,7 @@ forc-tracing.workspace = true
 forc-util = { workspace = true, features = ["tx"] }
 fs_extra.workspace = true
 fuel-asm.workspace = true
+fuel-abi-types.workspace = true
 hex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/snapshot.toml
@@ -1,4 +1,4 @@
 cmds = [
     "forc build --path {root} --release",
-    "forc test --path {root} --experimental const_generics --test-threads 1 --logs --revert-codes",
+    "forc test --path {root} --experimental const_generics --test-threads 1 --dbgs --reverts",
 ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
@@ -1,5 +1,6 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --release
 exit status: 1
@@ -286,7 +287,7 @@ ____
   Aborting due to 20 errors.
 error: Failed to compile const_generics
 
-> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --experimental const_generics --test-threads 1 --logs --revert-codes
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics --experimental const_generics --test-threads 1 --dbgs --reverts
 exit status: 0
 output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics
@@ -298,6 +299,7 @@ output:
 tested -- const_generics
 
       test run_main ... ok (???, 11510 gas)
+           debug output:
 [src/main.sw:65:13] a = [1, 2]
 [src/main.sw:69:13] [C {}].len() = 1
 [src/main.sw:74:13] [C {}, C {}].len() = 2

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/snapshot.toml
@@ -1,5 +1,5 @@
 cmds = [
     "forc build --path {root} --asm final | sub ecal",
     "forc build --path {root} --release --asm final | sub ecal",
-    "forc test --path {root} --logs",
+    "forc test --path {root} --dbgs",
 ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/stdout.snap
@@ -1,5 +1,6 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg --asm final | sub ecal
 ecal $r0 $r2 $r3 $$retv       ; ecal id fd buf count
@@ -14,7 +15,7 @@ ecal $r3 $r1 $r2 $one         ; ecal id fd buf count
 
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg --release --asm final | sub ecal
 
-> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg --logs
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg --dbgs
 exit status: 0
 output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg
@@ -26,6 +27,7 @@ output:
 tested -- dbg
 
       test call_main ... ok (???, 96529 gas)
+           debug output:
 [src/main.sw:13:13] () = ()
 [src/main.sw:15:13] true = true
 [src/main.sw:16:13] false = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "panic_handling_in_unit_tests"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-9DDCBE9065EA0BF9"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "panic_handling_in_unit_tests"
+version = "0.1.2" # We want to test the displaying of the package version.
+
+[dependencies]
+std = { path = "../../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/snapshot.toml
@@ -1,0 +1,4 @@
+cmds = [
+    "forc test --path {root} --experimental error_type --logs --raw-logs --dbgs --reverts passing_",
+    "forc test --path {root} --experimental error_type",
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw
@@ -1,0 +1,136 @@
+script;
+
+// This test covers all possible usages of the `panic` expression,
+// and their handling in unit tests.
+// It also includes tests for `revert` and error signaling through `assert`ions and `require`s.
+
+#[error_type]
+enum TestError {
+    #[error(m = "Error A has occurred.")]
+    A: (),
+    #[error(m = "Error B has occurred, with a boolean value.")]
+    B: bool,
+    #[error(m = "")]
+    C: str,
+    #[error(m = "    ")]
+    D: str,
+}
+
+fn main() { }
+
+#[test]
+fn passing_dbgs_and_logs() {
+    let _ = __dbg("This is a passing test containing `__dbg` outputs.");
+    let x = 42;
+    let _ = __dbg(x);
+
+    log("This is a log from the passing test.");
+    log(x);
+}
+
+#[test]
+fn passing_no_dbgs_or_logs() { }
+
+#[test]
+fn failing_revert_intrinsic() {
+    __revert(112233);
+}
+
+#[test]
+fn failing_revert_function_with_dbgs_and_logs() {
+    let _ = __dbg("Reverting in a test function.");
+    let revert_code = 332211;
+    let _ = __dbg(revert_code);
+
+    log("This is a log from the reverting test.");
+    revert(revert_code);
+}
+
+#[test]
+fn failing_error_signal_assert() {
+    let _ = __dbg(TestError::A);
+    assert(false);
+}
+
+#[test]
+fn failing_error_signal_assert_eq() {
+    let _ = __dbg("This is a `__dbg` before the failing assert_eq.");
+    log("We will get logged the asserted values and this message.");
+    assert_eq(1111, 2222);
+}
+
+#[test]
+fn failing_error_signal_assert_ne() {
+    let _ = __dbg("This is a `__dbg` before the failing assert_ne.");
+    log("We will get logged the asserted values and this message.");
+    assert_ne(3333, 3333);
+}
+
+#[test]
+fn failing_error_signal_require_str_error() {
+    require(false, "This is an error message in a `require` call.");
+}
+
+#[test]
+fn failing_error_signal_require_enum_error() {
+    require(false, TestError::B(true));
+}
+
+#[test]
+fn failing_panic_no_arg() {
+    panic;
+}
+
+#[test]
+fn failing_panic_unit_arg() {
+    panic ();
+}
+
+#[test]
+fn failing_panic_const_eval_str_arg() {
+    panic "Panicked with a string argument.";
+}
+
+#[test]
+fn failing_panic_const_eval_empty_str_arg() {
+    panic "";
+}
+
+#[test]
+fn failing_panic_const_eval_whitespace_str_arg() {
+    panic "    ";
+}
+
+#[test]
+fn failing_panic_non_const_eval_str_arg() {
+    panic non_const_eval_str("Panicked with a non-const evaluated string argument.");
+}
+
+#[test]
+fn failing_panic_non_const_eval_str_empty_arg() {
+    panic non_const_eval_str("");
+}
+
+#[test]
+fn failing_panic_non_const_eval_str_whitespace_arg() {
+    panic non_const_eval_str("    ");
+}
+
+#[test]
+fn failing_panic_error_enum_arg() {
+    panic TestError::B(true);
+}
+
+#[test]
+fn failing_panic_error_enum_arg_with_empty_msg() {
+    panic TestError::C("This is an error with an empty error message.");
+}
+
+#[test]
+fn failing_panic_error_enum_arg_with_whitespace_msg() {
+    panic TestError::D("This is an error with a whitespace error message.");
+}
+
+fn non_const_eval_str(error: str) {
+    panic error;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/stdout.snap
@@ -1,0 +1,491 @@
+---
+source: test/src/snapshot/mod.rs
+assertion_line: 162
+---
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests --experimental error_type --logs --raw-logs --dbgs --reverts passing_
+exit status: 0
+output:
+    Building test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests
+   Compiling library std (sway-lib-std)
+   Compiling script panic_handling_in_unit_tests (test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests)
+warning: Error message is empty
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw:13:17
+   |
+...
+13 |     #[error(m = "")]
+   |                 -- Error enum variant "TestError::C" has an empty error message.
+   |                 -- help: Consider adding a helpful error message here.
+   |
+____
+
+  Compiled script "panic_handling_in_unit_tests" with 1 warning.
+    Finished debug [unoptimized + fuel] target(s) [9.12 KB] in ???
+     Running 2 tests, filtered 18 tests
+
+tested -- panic_handling_in_unit_tests
+
+      test passing_dbgs_and_logs ... ok (???, 1845 gas)
+           debug output:
+[src/main.sw:23:13] "This is a passing test containing `__dbg` outputs." = "This is a passing test containing `__dbg` outputs."
+[src/main.sw:25:13] x = 42
+           decoded log values:
+AsciiString { data: "This is a log from the passing test." }, log rb: 10098701174489624218
+42, log rb: 1515152261580153489
+           raw logs:
+[{"LogData":{"data":"0000000000000024546869732069732061206c6f672066726f6d207468652070617373696e6720746573742e","digest":"29d742ad9093cdf81404ff756467a44448729b85ab3c0d65197829fb61d2dd29","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":44,"pc":11016,"ptr":67107840,"ra":0,"rb":10098701174489624218}},{"LogData":{"data":"000000000000002a","digest":"a6bb133cb1e3638ad7b8a3ff0539668e9e56f9b850ef1b2a810f5422eaa6c323","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":16456,"ptr":67106816,"ra":0,"rb":1515152261580153489}}]
+      test passing_no_dbgs_or_logs ... ok (???, 18 gas)
+
+test result: OK. 2 passed; 0 failed; finished in ???
+
+    Finished in ???
+
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests --experimental error_type
+exit status: 101
+output:
+    Building test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests
+   Compiling library std (sway-lib-std)
+   Compiling script panic_handling_in_unit_tests (test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests)
+warning: Error message is empty
+  --> test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw:13:17
+   |
+...
+13 |     #[error(m = "")]
+   |                 -- Error enum variant "TestError::C" has an empty error message.
+   |                 -- help: Consider adding a helpful error message here.
+   |
+____
+
+  Compiled script "panic_handling_in_unit_tests" with 1 warning.
+    Finished debug [unoptimized + fuel] target(s) [9.12 KB] in ???
+     Running 20 tests, filtered 0 tests
+
+tested -- panic_handling_in_unit_tests
+
+      test passing_dbgs_and_logs ... ok (???, 1845 gas)
+      test passing_no_dbgs_or_logs ... ok (???, 18 gas)
+      test failing_revert_intrinsic ... FAILED (???, 19 gas)
+      test failing_revert_function_with_dbgs_and_logs ... FAILED (???, 1739 gas)
+      test failing_error_signal_assert ... FAILED (???, 382 gas)
+      test failing_error_signal_assert_eq ... FAILED (???, 1242 gas)
+      test failing_error_signal_assert_ne ... FAILED (???, 1241 gas)
+      test failing_error_signal_require_str_error ... FAILED (???, 317 gas)
+      test failing_error_signal_require_enum_error ... FAILED (???, 381 gas)
+      test failing_panic_no_arg ... FAILED (???, 198 gas)
+      test failing_panic_unit_arg ... FAILED (???, 198 gas)
+      test failing_panic_const_eval_str_arg ... FAILED (???, 19 gas)
+      test failing_panic_const_eval_empty_str_arg ... FAILED (???, 19 gas)
+      test failing_panic_const_eval_whitespace_str_arg ... FAILED (???, 19 gas)
+      test failing_panic_non_const_eval_str_arg ... FAILED (???, 314 gas)
+      test failing_panic_non_const_eval_str_empty_arg ... FAILED (???, 313 gas)
+      test failing_panic_non_const_eval_str_whitespace_arg ... FAILED (???, 314 gas)
+      test failing_panic_error_enum_arg ... FAILED (???, 378 gas)
+      test failing_panic_error_enum_arg_with_empty_msg ... FAILED (???, 466 gas)
+      test failing_panic_error_enum_arg_with_whitespace_msg ... FAILED (???, 476 gas)
+
+   failures:
+      test failing_revert_intrinsic, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":34
+           revert code: 1b669
+
+
+      test failing_revert_function_with_dbgs_and_logs, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":39
+           revert code: 511b3
+           debug output:
+[src/main.sw:41:13] "Reverting in a test function." = "Reverting in a test function."
+[src/main.sw:43:13] revert_code = 332211
+           decoded log values:
+AsciiString { data: "This is a log from the reverting test." }, log rb: 10098701174489624218
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "0000000000000026546869732069732061206c6f672066726f6d2074686520726576657274696e6720746573742e",
+      "digest": "9888163918d49ac28cfad600031b81fe696ff1377d25c6faf5fc2b761608567d",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 46,
+      "pc": 11592,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 10098701174489624218
+    }
+  }
+]
+
+
+      test failing_error_signal_assert, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":49
+           revert code: ffffffffffff0004
+            └─ error message: Failing call to `std::assert::assert`
+           debug output:
+[src/main.sw:51:13] TestError::A = A
+
+
+      test failing_error_signal_assert_eq, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":55
+           revert code: ffffffffffff0003
+            └─ error message: Failing call to `std::assert::assert_eq`
+           debug output:
+[src/main.sw:57:13] "This is a `__dbg` before the failing assert_eq." = "This is a `__dbg` before the failing assert_eq."
+           decoded log values:
+AsciiString { data: "We will get logged the asserted values and this message." }, log rb: 10098701174489624218
+1111, log rb: 1515152261580153489
+2222, log rb: 1515152261580153489
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000003857652077696c6c20676574206c6f67676564207468652061737365727465642076616c75657320616e642074686973206d6573736167652e",
+      "digest": "7cd2ee64a324feb34d768ff087eed6d5f4f55a01f328f1808211224a996293dd",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 64,
+      "pc": 13040,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 10098701174489624218
+    }
+  },
+  {
+    "LogData": {
+      "data": "0000000000000457",
+      "digest": "a6347082809348ffb57ff10f841e60b202fc450a1c46f292b508cf878602fb21",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 8,
+      "pc": 16456,
+      "ptr": 67106816,
+      "ra": 0,
+      "rb": 1515152261580153489
+    }
+  },
+  {
+    "LogData": {
+      "data": "00000000000008ae",
+      "digest": "c423e036030a4b16c5b00ff36181839b15b8c82274149ca378101d459a25e30c",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 8,
+      "pc": 16456,
+      "ptr": 67105792,
+      "ra": 0,
+      "rb": 1515152261580153489
+    }
+  }
+]
+
+
+      test failing_error_signal_assert_ne, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":62
+           revert code: ffffffffffff0005
+            └─ error message: Failing call to `std::assert::assert_ne`
+           debug output:
+[src/main.sw:64:13] "This is a `__dbg` before the failing assert_ne." = "This is a `__dbg` before the failing assert_ne."
+           decoded log values:
+AsciiString { data: "We will get logged the asserted values and this message." }, log rb: 10098701174489624218
+3333, log rb: 1515152261580153489
+3333, log rb: 1515152261580153489
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000003857652077696c6c20676574206c6f67676564207468652061737365727465642076616c75657320616e642074686973206d6573736167652e",
+      "digest": "7cd2ee64a324feb34d768ff087eed6d5f4f55a01f328f1808211224a996293dd",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 64,
+      "pc": 13456,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 10098701174489624218
+    }
+  },
+  {
+    "LogData": {
+      "data": "0000000000000d05",
+      "digest": "13a0755cd62d23f5931afac99688b50e3c6049a17811a340a79597c51c92fccd",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 8,
+      "pc": 16456,
+      "ptr": 67106816,
+      "ra": 0,
+      "rb": 1515152261580153489
+    }
+  },
+  {
+    "LogData": {
+      "data": "0000000000000d05",
+      "digest": "13a0755cd62d23f5931afac99688b50e3c6049a17811a340a79597c51c92fccd",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 8,
+      "pc": 16456,
+      "ptr": 67105792,
+      "ra": 0,
+      "rb": 1515152261580153489
+    }
+  }
+]
+
+
+      test failing_error_signal_require_str_error, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":69
+           revert code: ffffffffffff0000
+            └─ error message: Failing call to `std::revert::require`
+           decoded log values:
+AsciiString { data: "This is an error message in a `require` call." }, log rb: 10098701174489624218
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000002d5468697320697320616e206572726f72206d65737361676520696e2061206072657175697265602063616c6c2e",
+      "digest": "2d960aa1b6936dd00a6d51e51e3faab405f35bfc49ce2093b7ba13336d583104",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 53,
+      "pc": 13652,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 10098701174489624218
+    }
+  }
+]
+
+
+      test failing_error_signal_require_enum_error, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":74
+           revert code: ffffffffffff0000
+            └─ error message: Failing call to `std::revert::require`
+           decoded log values:
+B(true), log rb: 8516346929033386016
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000000101",
+      "digest": "bd87b2cda99df5b642ac9c0a97d3bc76f9921e2cce16058faa44bc954dbb065f",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 9,
+      "pc": 13764,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 8516346929033386016
+    }
+  }
+]
+
+
+      test failing_panic_no_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":79
+           revert code: ffffffff00000000
+            ├─ panic value:   ()
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:81:5
+           decoded log values:
+(), log rb: 3330666440490685604
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "",
+      "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 0,
+      "pc": 13840,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 3330666440490685604
+    }
+  }
+]
+
+
+      test failing_panic_unit_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":84
+           revert code: ffffffff00000001
+            ├─ panic value:   ()
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:86:5
+           decoded log values:
+(), log rb: 3330666440490685604
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "",
+      "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 0,
+      "pc": 13912,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 3330666440490685604
+    }
+  }
+]
+
+
+      test failing_panic_const_eval_str_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":89
+           revert code: ffffffff00000002
+            ├─ panic message: Panicked with a string argument.
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:91:5
+
+
+      test failing_panic_const_eval_empty_str_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":94
+           revert code: ffffffff00000003
+            ├─ panic message: 
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:96:5
+
+
+      test failing_panic_const_eval_whitespace_str_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":99
+           revert code: ffffffff00000004
+            ├─ panic message:     
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:101:5
+
+
+      test failing_panic_non_const_eval_str_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":104
+           revert code: ffffffff00000005
+            ├─ panic message: Panicked with a non-const evaluated string argument.
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:135:5
+           decoded log values:
+AsciiString { data: "Panicked with a non-const evaluated string argument." }, log rb: 10098701174489624218
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000003450616e69636b656420776974682061206e6f6e2d636f6e7374206576616c756174656420737472696e6720617267756d656e742e",
+      "digest": "3fcfc985ef72a10bd0d1f12fd2d259a10a261f745c95a0fea304d9b2068e5eb9",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 60,
+      "pc": 14060,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 10098701174489624218
+    }
+  }
+]
+
+
+      test failing_panic_non_const_eval_str_empty_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":109
+           revert code: ffffffff00000005
+            ├─ panic message: 
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:135:5
+           decoded log values:
+AsciiString { data: "" }, log rb: 10098701174489624218
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "0000000000000000",
+      "digest": "af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 8,
+      "pc": 14168,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 10098701174489624218
+    }
+  }
+]
+
+
+      test failing_panic_non_const_eval_str_whitespace_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":114
+           revert code: ffffffff00000005
+            ├─ panic message:     
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:135:5
+           decoded log values:
+AsciiString { data: "    " }, log rb: 10098701174489624218
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000000420202020",
+      "digest": "b115410b146aa17a70b8a1fdfd669361410625ed4415cc65b89b718543dc4f32",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 12,
+      "pc": 14280,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 10098701174489624218
+    }
+  }
+]
+
+
+      test failing_panic_error_enum_arg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":119
+           revert code: ffffffff00000009
+            ├─ panic message: Error B has occurred, with a boolean value.
+            ├─ panic value:   B(true)
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:121:5
+           decoded log values:
+B(true), log rb: 8516346929033386016
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000000101",
+      "digest": "bd87b2cda99df5b642ac9c0a97d3bc76f9921e2cce16058faa44bc954dbb065f",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 9,
+      "pc": 14376,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 8516346929033386016
+    }
+  }
+]
+
+
+      test failing_panic_error_enum_arg_with_empty_msg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":124
+           revert code: ffffffff0000000a
+            ├─ panic message: 
+            ├─ panic value:   C(AsciiString { data: "This is an error with an empty error message." })
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:126:5
+           decoded log values:
+C(AsciiString { data: "This is an error with an empty error message." }), log rb: 8516346929033386016
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "0000000000000002000000000000002d5468697320697320616e206572726f72207769746820616e20656d707479206572726f72206d6573736167652e",
+      "digest": "5f00877918eba9a1e5052799a3f57841731138a154d31a1af5575a05feca0c0b",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 61,
+      "pc": 14508,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 8516346929033386016
+    }
+  }
+]
+
+
+      test failing_panic_error_enum_arg_with_whitespace_msg, "test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/src/main.sw":129
+           revert code: ffffffff0000000b
+            ├─ panic message:     
+            ├─ panic value:   D(AsciiString { data: "This is an error with a whitespace error message." })
+            └─ panicked in:   panic_handling_in_unit_tests@0.1.2, src/main.sw:131:5
+           decoded log values:
+D(AsciiString { data: "This is an error with a whitespace error message." }), log rb: 8516346929033386016
+           raw logs:
+[
+  {
+    "LogData": {
+      "data": "000000000000000300000000000000315468697320697320616e206572726f72207769746820612077686974657370616365206572726f72206d6573736167652e",
+      "digest": "97d9bb6a2f1bb59a495f69bddec5aeaf7a072e5424634d2cb56942b8d0b888e7",
+      "id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "is": 10368,
+      "len": 65,
+      "pc": 14640,
+      "ptr": 67107840,
+      "ra": 0,
+      "rb": 8516346929033386016
+    }
+  }
+]
+
+
+
+test result: FAILED. 2 passed; 18 failed; finished in ???
+
+    Finished in ???
+error: Some tests failed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/snapshot.toml
@@ -1,1 +1,3 @@
-cmds = ["forc test --path {root} --release --experimental error_type --test-threads 1 --logs --revert-codes"]
+cmds = [
+    "forc test --path {root} --release --experimental error_type --test-threads 1 --logs --reverts",
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/stdout.snap
@@ -1,7 +1,8 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
-> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract --release --experimental error_type --test-threads 1 --logs --revert-codes
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract --release --experimental error_type --test-threads 1 --logs --reverts
 exit status: 0
 output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract
@@ -14,38 +15,78 @@ output:
 tested -- panicking_contract
 
       test test_directly_panicking_method ... ok (???, 1736 gas)
-Decoded log value: C(true), log rb: 5503570629422409978
-Revert code: ffffffff00000000
+           revert code: ffffffff00000000
+            ├─ panic message: Error C.
+            ├─ panic value:   C(true)
+            └─ panicked in:   panicking_contract@1.2.3, src/main.sw:22:9
+           decoded log values:
+C(true), log rb: 5503570629422409978
       test test_nested_panic_inlined ... ok (???, 3012 gas)
-Decoded log value: E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000005
+           revert code: ffffffff00000005
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:41:9
+           decoded log values:
+E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
       test test_nested_panic_inlined_same_revert_code ... ok (???, 3012 gas)
-Decoded log value: E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000005
+           revert code: ffffffff00000005
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:41:9
+           decoded log values:
+E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
       test test_nested_panic_not_inlined ... ok (???, 3205 gas)
-Decoded log value: E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000006
+           revert code: ffffffff00000006
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:35:5
+           decoded log values:
+E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
       test test_nested_panic_not_inlined_same_revert_code ... ok (???, 3205 gas)
-Decoded log value: E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000006
+           revert code: ffffffff00000006
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:35:5
+           decoded log values:
+E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
       test test_generic_panic_with_unit ... ok (???, 2162 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000004
+           revert code: ffffffff00000004
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_generic_panic_with_unit_same_revert_code ... ok (???, 2162 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000004
+           revert code: ffffffff00000004
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_generic_panic_with_str ... ok (???, 2175 gas)
-Decoded log value: AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
-Revert code: ffffffff00000002
+           revert code: ffffffff00000002
+            ├─ panic message: generic panic with string
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
       test test_generic_panic_with_different_str_same_revert_code ... ok (???, 1857 gas)
-Decoded log value: AsciiString { data: "generic panic with different string" }, log rb: 10098701174489624218
-Revert code: ffffffff00000002
+           revert code: ffffffff00000002
+            ├─ panic message: generic panic with different string
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+AsciiString { data: "generic panic with different string" }, log rb: 10098701174489624218
       test test_generic_panic_with_error_type_enum ... ok (???, 1987 gas)
-Decoded log value: A, log rb: 5503570629422409978
-Revert code: ffffffff00000003
+           revert code: ffffffff00000003
+            ├─ panic message: Error A.
+            ├─ panic value:   A
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+A, log rb: 5503570629422409978
       test test_generic_panic_with_error_type_enum_different_variant_same_revert_code ... ok (???, 2150 gas)
-Decoded log value: B(42), log rb: 5503570629422409978
-Revert code: ffffffff00000003
+           revert code: ffffffff00000003
+            ├─ panic message: Error B.
+            ├─ panic value:   B(42)
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+B(42), log rb: 5503570629422409978
 
 test result: OK. 11 passed; 0 failed; finished in ???
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib/snapshot.toml
@@ -1,1 +1,3 @@
-cmds = ["forc test --path {root} --release --experimental error_type --test-threads 1 --logs --revert-codes"]
+cmds = [
+    "forc test --path {root} --release --experimental error_type --test-threads 1 --logs --reverts"
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib/stdout.snap
@@ -1,7 +1,8 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
-> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib --release --experimental error_type --test-threads 1 --logs --revert-codes
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib --release --experimental error_type --test-threads 1 --logs --reverts
 exit status: 0
 output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib
@@ -13,58 +14,118 @@ output:
 tested -- panicking_lib
 
       test test_nested_panic_inlined ... ok (???, 822 gas)
-Decoded log value: E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 2721958641300806892
-Revert code: ffffffff00000000
+           revert code: ffffffff00000000
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:41:9
+           decoded log values:
+E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 2721958641300806892
       test test_nested_panic_inlined_same_revert_code ... ok (???, 822 gas)
-Decoded log value: E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 2721958641300806892
-Revert code: ffffffff00000000
+           revert code: ffffffff00000000
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:41:9
+           decoded log values:
+E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 2721958641300806892
       test test_nested_panic_not_inlined ... ok (???, 803 gas)
-Decoded log value: E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 2721958641300806892
-Revert code: ffffffff00000001
+           revert code: ffffffff00000001
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:35:5
+           decoded log values:
+E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 2721958641300806892
       test test_nested_panic_not_inlined_same_revert_code ... ok (???, 803 gas)
-Decoded log value: E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 2721958641300806892
-Revert code: ffffffff00000001
+           revert code: ffffffff00000001
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:35:5
+           decoded log values:
+E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 2721958641300806892
       test test_generic_panic_with_unit ... ok (???, 189 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000002
+           revert code: ffffffff00000002
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_generic_panic_with_unit_same_revert_code ... ok (???, 189 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000002
+           revert code: ffffffff00000002
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_generic_panic_with_str ... ok (???, 288 gas)
-Decoded log value: AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
-Revert code: ffffffff00000003
+           revert code: ffffffff00000003
+            ├─ panic message: generic panic with string
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
       test test_generic_panic_with_different_str_same_revert_code ... ok (???, 288 gas)
-Decoded log value: AsciiString { data: "generic panic different string" }, log rb: 10098701174489624218
-Revert code: ffffffff00000003
+           revert code: ffffffff00000003
+            ├─ panic message: generic panic different string
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+AsciiString { data: "generic panic different string" }, log rb: 10098701174489624218
       test test_generic_panic_with_error_type_enum_variant ... ok (???, 327 gas)
-Decoded log value: A, log rb: 2721958641300806892
-Revert code: ffffffff00000004
+           revert code: ffffffff00000004
+            ├─ panic message: Error A.
+            ├─ panic value:   A
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+A, log rb: 2721958641300806892
       test test_generic_panic_with_error_type_enum_different_variant_same_revert_code ... ok (???, 327 gas)
-Decoded log value: A, log rb: 2721958641300806892
-Revert code: ffffffff00000004
+           revert code: ffffffff00000004
+            ├─ panic message: Error A.
+            ├─ panic value:   A
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+A, log rb: 2721958641300806892
       test test_panic_without_arg ... ok (???, 189 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000005
+           revert code: ffffffff00000005
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:113:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_panic_with_unit ... ok (???, 189 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000006
+           revert code: ffffffff00000006
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:118:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_panic_with_str ... ok (???, 19 gas)
-Revert code: ffffffff00000007
+           revert code: ffffffff00000007
+            ├─ panic message: panic with string
+            └─ panicked in:   panicking_lib, src/lib.sw:123:5
       test test_panic_with_error_type_enum ... ok (???, 431 gas)
-Decoded log value: C(true), log rb: 2721958641300806892
-Revert code: ffffffff00000008
+           revert code: ffffffff00000008
+            ├─ panic message: Error C.
+            ├─ panic value:   C(true)
+            └─ panicked in:   panicking_lib, src/lib.sw:128:5
+           decoded log values:
+C(true), log rb: 2721958641300806892
       test test_panic_with_generic_error_type_enum ... ok (???, 348 gas)
-Decoded log value: A(42), log rb: 12408470889216862137
-Revert code: ffffffff00000009
+           revert code: ffffffff00000009
+            ├─ panic value:   A(42)
+            └─ panicked in:   panicking_lib, src/lib.sw:133:5
+           decoded log values:
+A(42), log rb: 12408470889216862137
       test test_panic_with_nested_generic_error_type ... ok (???, 622 gas)
-Decoded log value: B(B(C(true))), log rb: 14988555917426256081
-Revert code: ffffffff0000000a
+           revert code: ffffffff0000000a
+            ├─ panic value:   B(B(C(true)))
+            └─ panicked in:   panicking_lib, src/lib.sw:138:5
+           decoded log values:
+B(B(C(true))), log rb: 14988555917426256081
       test test_panic_with_generic_error_type_enum_with_abi_encode ... ok (???, 348 gas)
-Decoded log value: A(42), log rb: 17388243649088655852
-Revert code: ffffffff0000000b
+           revert code: ffffffff0000000b
+            ├─ panic value:   A(42)
+            └─ panicked in:   panicking_lib, src/lib.sw:143:5
+           decoded log values:
+A(42), log rb: 17388243649088655852
       test test_panic_with_nested_generic_error_type_enum_with_abi_encode ... ok (???, 622 gas)
-Decoded log value: B(B(C(true))), log rb: 3755100321495500961
-Revert code: ffffffff0000000c
+           revert code: ffffffff0000000c
+            ├─ panic value:   B(B(C(true)))
+            └─ panicked in:   panicking_lib, src/lib.sw:148:5
+           decoded log values:
+B(B(C(true))), log rb: 3755100321495500961
 
 test result: OK. 18 passed; 0 failed; finished in ???
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_script/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_script/snapshot.toml
@@ -1,1 +1,3 @@
-cmds = ["forc test --path {root} --release --experimental error_type --test-threads 1 --logs --revert-codes"]
+cmds = [
+    "forc test --path {root} --release --experimental error_type --test-threads 1 --logs --reverts"
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_script/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_script/stdout.snap
@@ -1,7 +1,8 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
-> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_script --release --experimental error_type --test-threads 1 --logs --revert-codes
+> forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_script --release --experimental error_type --test-threads 1 --logs --reverts
 exit status: 0
 output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_script
@@ -14,38 +15,78 @@ output:
 tested -- panicking_script
 
       test test_panic_in_main ... ok (???, 388 gas)
-Decoded log value: C(true), log rb: 5503570629422409978
-Revert code: ffffffff00000000
+           revert code: ffffffff00000000
+            ├─ panic message: Error C.
+            ├─ panic value:   C(true)
+            └─ panicked in:   panicking_script, src/main.sw:6:5
+           decoded log values:
+C(true), log rb: 5503570629422409978
       test test_nested_panic_inlined ... ok (???, 806 gas)
-Decoded log value: E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000001
+           revert code: ffffffff00000001
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:41:9
+           decoded log values:
+E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
       test test_nested_panic_inlined_same_revert_code ... ok (???, 806 gas)
-Decoded log value: E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000001
+           revert code: ffffffff00000001
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:41:9
+           decoded log values:
+E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
       test test_nested_panic_not_inlined ... ok (???, 787 gas)
-Decoded log value: E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000002
+           revert code: ffffffff00000002
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:35:5
+           decoded log values:
+E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
       test test_nested_panic_not_inlined_same_revert_code ... ok (???, 787 gas)
-Decoded log value: E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
-Revert code: ffffffff00000002
+           revert code: ffffffff00000002
+            ├─ panic message: Error E.
+            ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
+            └─ panicked in:   panicking_lib, src/lib.sw:35:5
+           decoded log values:
+E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
       test test_generic_panic_with_unit ... ok (???, 189 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000003
+           revert code: ffffffff00000003
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_generic_panic_with_unit_same_revert_code ... ok (???, 189 gas)
-Decoded log value: (), log rb: 3330666440490685604
-Revert code: ffffffff00000003
+           revert code: ffffffff00000003
+            ├─ panic value:   ()
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+(), log rb: 3330666440490685604
       test test_generic_panic_with_str ... ok (???, 288 gas)
-Decoded log value: AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
-Revert code: ffffffff00000004
+           revert code: ffffffff00000004
+            ├─ panic message: generic panic with string
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
       test test_generic_panic_with_different_str_same_revert_code ... ok (???, 288 gas)
-Decoded log value: AsciiString { data: "generic panic with different string" }, log rb: 10098701174489624218
-Revert code: ffffffff00000004
+           revert code: ffffffff00000004
+            ├─ panic message: generic panic with different string
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+AsciiString { data: "generic panic with different string" }, log rb: 10098701174489624218
       test test_generic_panic_with_error_type_enum ... ok (???, 312 gas)
-Decoded log value: A, log rb: 5503570629422409978
-Revert code: ffffffff00000005
+           revert code: ffffffff00000005
+            ├─ panic message: Error A.
+            ├─ panic value:   A
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+A, log rb: 5503570629422409978
       test test_generic_panic_with_error_type_enum_different_variant_same_revert_code ... ok (???, 369 gas)
-Decoded log value: B(42), log rb: 5503570629422409978
-Revert code: ffffffff00000005
+           revert code: ffffffff00000005
+            ├─ panic message: Error B.
+            ├─ panic value:   B(42)
+            └─ panicked in:   panicking_lib, src/lib.sw:74:5
+           decoded log values:
+B(42), log rb: 5503570629422409978
 
 test result: OK. 11 passed; 0 failed; finished in ???
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/panic_in_non_statement_positions/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/panic_in_non_statement_positions/stdout.snap
@@ -1,5 +1,6 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
 > forc test --path test/src/e2e_vm_tests/test_programs/should_pass/panic_in_non_statement_positions --experimental error_type --logs --test-threads 1
 exit status: 0
@@ -292,37 +293,53 @@ ____
 tested -- panic_in_non_statement_positions
 
       test in_init ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_array ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_length_1_array ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_length_2_array_first ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_length_2_array_second ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_tuple ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_struct ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_parentheses ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_if_condition ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_while_condition ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_enum ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_enum_multivariant ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_fun_arg ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_lazy_and ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_lazy_or ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
       test in_match_scrutinee ... ok (???, 332 gas)
-Decoded log value: E(42), log rb: 5087777005172090899
+           decoded log values:
+E(42), log rb: 5087777005172090899
 
 test result: OK. 16 passed; 0 failed; finished in ???
 


### PR DESCRIPTION
## Description

This PR adds support for ABI errors in `forc test`. If a unit test reverts, the received revert code is inspected for known error signals (e.g., comming from `assert`, or `require`) and for ABI errors.

Analysis of the received revert code is encapsulated within the `forc_util::tx_utils::RevertInfo` struct implementation. This way, it can be reused between the `forc test` and `forc call`. However, on the long term, this abstraction should be moved to `fuel-abi-types`, because its whole logic is ABI related, and it should also be shareable with the Rust SDK.

The reson for temporary placing it within `forc-util` crate is to get the support for ABI errors in `forc test` in the next Sway release, without the need for a new `fuel-abi-types` release that triggers the circular dependency between Sway and Rust SDK repositories.

Additionally, the PR unifies the display of test outputs - logs, debug output, and reverts:
- for passing tests, none of the output is shown by default, unless specified on the CLI.
- for failing tests, all the output is displayed in the "failures" section.
- because the `__dbg` output is not a log, a dedicated `--dbgs` CLI argument is added, for all ecal outputs.
- because the output of a revert now shows all available information and not only the revert code, the `--revert-codes` CLI argument is renamed to `--reverts`.

Closes:
- #7089

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.