### PR TITLE
Respect CLI flags in `unit_test_pass` E2E tests

### DIFF
--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -330,6 +330,14 @@ pub(crate) async fn compile_and_run_unit_tests(
                 },
                 experimental: run_config.experimental.experimental.clone(),
                 no_experimental: run_config.experimental.no_experimental.clone(),
+                release: run_config.release,
+                print: PrintOpts {
+                    asm: run_config.print_asm,
+                    bytecode: run_config.print_bytecode,
+                    ir: run_config.print_ir.clone(),
+                    ..Default::default()
+                },
+                build_target: run_config.build_target,
                 ..Default::default()
             })
         }) {


### PR DESCRIPTION
## Description

This PR passes the CLI flags `--release` and `--print...` to the compilation of the tests in the `unit_test_pass` category. Passing the `--release` flag is especially important, because up to now, those tests were always building the debug version of binaries, even when the test suite was executed as `--release`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.