### PR TITLE
Optimize existing and add missing `Hash` implementations

### DIFF
--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -377,7 +377,7 @@ async fn test_simple_deploy() {
     node.kill().unwrap();
     let expected = vec![DeployedPackage::Contract(DeployedContract {
         id: ContractId::from_str(
-            "0ba30c1910edda35dbad1375e59ba85915c0b3af3dbecc028173e2c4875a024d",
+            "11cf2efb802263f4c0117dcfd858231b5602445a075301a4e350b16590326a20",
         )
         .unwrap(),
         proxy: None,
@@ -421,7 +421,7 @@ async fn test_deploy_submit_only() {
     node.kill().unwrap();
     let expected = vec![DeployedPackage::Contract(DeployedContract {
         id: ContractId::from_str(
-            "0ba30c1910edda35dbad1375e59ba85915c0b3af3dbecc028173e2c4875a024d",
+            "11cf2efb802263f4c0117dcfd858231b5602445a075301a4e350b16590326a20",
         )
         .unwrap(),
         proxy: None,
@@ -468,12 +468,12 @@ async fn test_deploy_fresh_proxy() {
     node.kill().unwrap();
     let impl_contract = DeployedPackage::Contract(DeployedContract {
         id: ContractId::from_str(
-            "0ba30c1910edda35dbad1375e59ba85915c0b3af3dbecc028173e2c4875a024d",
+            "11cf2efb802263f4c0117dcfd858231b5602445a075301a4e350b16590326a20",
         )
         .unwrap(),
         proxy: Some(
             ContractId::from_str(
-                "a0f90a3115294c9a0c285569fa6aa577953762a7d206931b861a6f24ee2f9773",
+                "615141f91cf7cd4e80b5283bd55851364414b48d46066b494f79ffd430366491",
             )
             .unwrap(),
         ),

--- a/sway-lib-std/src/address.sw
+++ b/sway-lib-std/src/address.sw
@@ -184,7 +184,6 @@ impl Into<Bytes> for Address {
 
 impl Hash for Address {
     fn hash(self, ref mut state: Hasher) {
-        let Address { bits } = self;
-        bits.hash(state);
+        self.bits.hash(state);
     }
 }

--- a/sway-lib-std/src/asset_id.sw
+++ b/sway-lib-std/src/asset_id.sw
@@ -29,8 +29,7 @@ pub struct AssetId {
 
 impl Hash for AssetId {
     fn hash(self, ref mut state: Hasher) {
-        let Self { bits } = self;
-        bits.hash(state);
+        self.bits.hash(state);
     }
 }
 

--- a/sway-lib-std/src/b512.sw
+++ b/sway-lib-std/src/b512.sw
@@ -9,6 +9,7 @@ use ::option::Option::{self, *};
 use ::raw_slice::*;
 use ::codec::*;
 use ::debug::*;
+use ::hash::*;
 
 /// Stores two `b256`s in contiguous memory.
 /// Guaranteed to be contiguous for use with ec-recover: `std::ecr::ec_recover`.
@@ -221,5 +222,11 @@ impl Into<Bytes> for B512 {
     /// ```
     fn into(self) -> Bytes {
         Bytes::from(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64))
+    }
+}
+
+impl Hash for B512 {
+    fn hash(self, ref mut state: Hasher) {
+        self.bits.hash(state);
     }
 }

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -145,8 +145,7 @@ impl Into<Bytes> for ContractId {
 
 impl Hash for ContractId {
     fn hash(self, ref mut state: Hasher) {
-        let Self { bits } = self;
-        bits.hash(state);
+        self.bits.hash(state);
     }
 }
 

--- a/sway-lib-std/src/crypto/ed25519.sw
+++ b/sway-lib-std/src/crypto/ed25519.sw
@@ -204,6 +204,6 @@ impl Eq for Ed25519 {}
 
 impl Hash for Ed25519 {
     fn hash(self, ref mut state: Hasher) {
-        state.write(Bytes::from(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64)));
+        state.write_raw_slice(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64));
     }
 }

--- a/sway-lib-std/src/crypto/message.sw
+++ b/sway-lib-std/src/crypto/message.sw
@@ -95,6 +95,6 @@ impl Eq for Message {}
 
 impl Hash for Message {
     fn hash(self, ref mut state: Hasher) {
-        state.write(self.bytes);
+        self.bytes.hash(state);
     }
 }

--- a/sway-lib-std/src/crypto/point2d.sw
+++ b/sway-lib-std/src/crypto/point2d.sw
@@ -3,6 +3,7 @@ library;
 use ::convert::{From, TryFrom};
 use ::bytes::{Bytes, *};
 use ::option::Option::{self, *};
+use ::hash::{Hash, Hasher};
 use ::ops::*;
 use ::primitive_conversions::u256::*;
 use ::codec::*;
@@ -30,6 +31,13 @@ impl PartialEq for Point2D {
 // Note that `Point2D` implements `PartialEq` but not `Eq`,
 // because an uninitialized `Point2D`, created by `Point2D::new`
 // is not equal to any other point, including itself.
+
+impl Hash for Point2D {
+    fn hash(self, ref mut state: Hasher) {
+        self.x.hash(state);
+        self.y.hash(state);
+    }
+}
 
 impl Point2D {
     /// Returns a new, uninitialized Point2D.

--- a/sway-lib-std/src/crypto/scalar.sw
+++ b/sway-lib-std/src/crypto/scalar.sw
@@ -3,6 +3,7 @@ library;
 use ::convert::{From, TryFrom};
 use ::bytes::{Bytes, *};
 use ::option::Option::{self, *};
+use ::hash::{Hash, Hasher};
 use ::ops::*;
 use ::primitive_conversions::u256::*;
 use ::codec::*;
@@ -23,6 +24,12 @@ impl PartialEq for Scalar {
 // Note that `Scalar` implements `PartialEq` but not `Eq`,
 // because an uninitialized `Scalar`, created by `Scalar::new`
 // is not equal to any other scalar, including itself.
+
+impl Hash for Scalar {
+    fn hash(self, ref mut state: Hasher) {
+        self.bytes.hash(state);
+    }
+}
 
 impl Scalar {
     /// Returns a new, uninitialized Scalar.

--- a/sway-lib-std/src/crypto/secp256k1.sw
+++ b/sway-lib-std/src/crypto/secp256k1.sw
@@ -421,6 +421,6 @@ impl Eq for Secp256k1 {}
 
 impl Hash for Secp256k1 {
     fn hash(self, ref mut state: Hasher) {
-        state.write(Bytes::from(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64)));
+        state.write_raw_slice(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64));
     }
 }

--- a/sway-lib-std/src/crypto/secp256r1.sw
+++ b/sway-lib-std/src/crypto/secp256r1.sw
@@ -422,6 +422,6 @@ impl Eq for Secp256r1 {}
 
 impl Hash for Secp256r1 {
     fn hash(self, ref mut state: Hasher) {
-        state.write(Bytes::from(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64)));
+        state.write_raw_slice(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64));
     }
 }

--- a/sway-lib-std/src/crypto/signature.sw
+++ b/sway-lib-std/src/crypto/signature.sw
@@ -11,6 +11,7 @@ use ::crypto::{
 };
 use ::option::Option::{self, *};
 use ::result::Result::{self, *};
+use ::hash::{Hash, Hasher};
 use ::vm::evm::evm_address::EvmAddress;
 use ::codec::*;
 use ::debug::*;
@@ -505,3 +506,22 @@ impl PartialEq for Signature {
     }
 }
 impl Eq for Signature {}
+
+impl Hash for Signature {
+    fn hash(self, ref mut state: Hasher) {
+        match self {
+            Self::Secp256k1(sig) => {
+                0_u8.hash(state);
+                sig.hash(state);
+            },
+            Self::Secp256r1(sig) => {
+                1_u8.hash(state);
+                sig.hash(state);
+            },
+            Self::Ed25519(sig) => {
+                2_u8.hash(state);
+                sig.hash(state);
+            },
+        }
+    }
+}

--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -9,6 +9,7 @@ use ::asset_id::AssetId;
 use ::bytes::Bytes;
 use ::contract_id::ContractId;
 use ::option::Option::{self, *};
+use ::hash::{Hash, Hasher};
 use ::tx::{
     GTF_CREATE_INPUT_AT_INDEX,
     GTF_CREATE_INPUTS_COUNT,
@@ -75,6 +76,22 @@ impl PartialEq for Input {
     }
 }
 impl Eq for Input {}
+
+impl Hash for Input {
+    fn hash(self, ref mut state: Hasher) {
+        match self {
+            Self::Coin => {
+                0_u8.hash(state);
+            },
+            Self::Contract => {
+                1_u8.hash(state);
+            },
+            Self::Message => {
+                2_u8.hash(state);
+            },
+        }
+    }
+}
 
 const INPUT_TYPE_COIN: u8 = 0;
 const INPUT_TYPE_CONTRACT: u8 = 1;

--- a/sway-lib-std/src/low_level_call.sw
+++ b/sway-lib-std/src/low_level_call.sw
@@ -11,6 +11,7 @@ use ::debug::*;
 use ::option::Option;
 use ::revert::require;
 use ::vec::Vec;
+use ::hash::{Hash, Hasher};
 
 /// A struct representing the call parameters of a function call.
 pub struct CallParams {
@@ -20,6 +21,14 @@ pub struct CallParams {
     pub asset_id: AssetId,
     /// Gas to forward.
     pub gas: u64,
+}
+
+impl Hash for CallParams {
+    fn hash(self, ref mut state: Hasher) {
+        self.coins.hash(state);
+        self.asset_id.hash(state);
+        self.gas.hash(state);
+    }
 }
 
 /// Represent a raw pointer as a `Bytes`, so it can be concatenated with a payload.

--- a/sway-lib-std/src/option.sw
+++ b/sway-lib-std/src/option.sw
@@ -196,7 +196,7 @@ impl<T> Option<T> {
     /// ```
     pub fn unwrap(self) -> T {
         match self {
-            Self::Some(inner_value) => inner_value,
+            Self::Some(v) => v,
             _ => revert(0),
         }
     }
@@ -221,7 +221,7 @@ impl<T> Option<T> {
     /// ```
     pub fn unwrap_or(self, default: T) -> T {
         match self {
-            Self::Some(x) => x,
+            Self::Some(v) => v,
             Self::None => default,
         }
     }

--- a/sway-lib-std/src/outputs.sw
+++ b/sway-lib-std/src/outputs.sw
@@ -18,6 +18,7 @@ use ::tx::{
     TX_TYPE_MINT,
 };
 use ::option::Option::{self, *};
+use ::hash::{Hash, Hasher};
 use ::ops::*;
 use ::primitive_conversions::u16::*;
 use ::raw_ptr::*;
@@ -66,6 +67,28 @@ impl PartialEq for Output {
     }
 }
 impl Eq for Output {}
+
+impl Hash for Output {
+    fn hash(self, ref mut state: Hasher) {
+        match self {
+            Self::Coin => {
+                0_u8.hash(state);
+            },
+            Self::Contract => {
+                1_u8.hash(state);
+            },
+            Self::Change => {
+                2_u8.hash(state);
+            },
+            Self::Variable => {
+                3_u8.hash(state);
+            },
+            Self::ContractCreated => {
+                4_u8.hash(state);
+            },
+        }
+    }
+}
 
 const OUTPUT_TYPE_COIN: u8 = 0;
 const OUTPUT_TYPE_CONTRACT: u8 = 1;

--- a/sway-lib-std/src/result.sw
+++ b/sway-lib-std/src/result.sw
@@ -169,7 +169,7 @@ impl<T, E> Result<T, E> {
     /// ```
     pub fn unwrap(self) -> T {
         match self {
-            Self::Ok(inner_value) => inner_value,
+            Self::Ok(v) => v,
             _ => revert(0),
         }
     }
@@ -202,7 +202,7 @@ impl<T, E> Result<T, E> {
     /// ```
     pub fn unwrap_or(self, default: T) -> T {
         match self {
-            Self::Ok(inner_value) => inner_value,
+            Self::Ok(v) => v,
             Self::Err(_) => default,
         }
     }

--- a/sway-lib-std/src/str.sw
+++ b/sway-lib-std/src/str.sw
@@ -1,7 +1,7 @@
 library;
 
 impl str {
-    /// Return a `raw_ptr` to the beginning of the string slice on the heap
+    /// Return a `raw_ptr` to the beginning of the string slice.
     pub fn as_ptr(self) -> raw_ptr {
         let (ptr, _) = asm(s: self) {
             s: (raw_ptr, u64)
@@ -9,7 +9,7 @@ impl str {
         ptr
     }
 
-    /// Return the length of the string slice in bytes
+    /// Return the length of the string slice in bytes.
     pub fn len(self) -> u64 {
         let (_, len) = asm(s: self) {
             s: (raw_ptr, u64)

--- a/sway-lib-std/src/string.sw
+++ b/sway-lib-std/src/string.sw
@@ -1,7 +1,7 @@
 //! A UTF-8 encoded growable string.
 library;
 
-use ::assert::assert;
+use ::assert::assert_eq;
 use ::bytes::*;
 use ::convert::*;
 use ::hash::{Hash, Hasher};
@@ -293,7 +293,7 @@ impl From<String> for str {
 #[test]
 fn test_string_str() {
     let string = String::from_ascii_str("Fuel");
-    assert(string.as_str() == "Fuel");
+    assert_eq(string.as_str(), "Fuel");
 }
 
 impl AsRawSlice for String {

--- a/sway-lib-std/src/time.sw
+++ b/sway-lib-std/src/time.sw
@@ -4,6 +4,7 @@ use ::convert::{From, Into};
 use ::ops::*;
 use ::result::Result::{self, *};
 use ::codec::*;
+use ::hash::{Hash, Hasher};
 
 const TAI_64_CONVERTER: u64 = 10 + (1 << 62);
 
@@ -457,6 +458,12 @@ impl Ord for Duration {
 
 impl OrdEq for Duration {}
 
+impl Hash for Duration {
+    fn hash(self, ref mut state: Hasher) {
+        self.seconds.hash(state);
+    }
+}
+
 impl From<u64> for Duration {
     fn from(seconds: u64) -> Self {
         Self { seconds }
@@ -830,3 +837,9 @@ impl Ord for Time {
 }
 
 impl OrdEq for Time {}
+
+impl Hash for Time {
+    fn hash(self, ref mut state: Hasher) {
+        self.unix.hash(state);
+    }
+}

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -3,6 +3,7 @@ library;
 
 use ::revert::revert;
 use ::option::Option::{self, *};
+use ::hash::{Hash, Hasher};
 use ::alloc::alloc_bytes;
 use ::ops::*;
 use ::codec::*;
@@ -80,6 +81,31 @@ impl PartialEq for Transaction {
     }
 }
 impl Eq for Transaction {}
+
+impl Hash for Transaction {
+    fn hash(self, ref mut state: Hasher) {
+        match self {
+            Self::Script => {
+                0_u8.hash(state);
+            },
+            Self::Create => {
+                1_u8.hash(state);
+            },
+            Self::Mint => {
+                2_u8.hash(state);
+            },
+            Self::Upgrade => {
+                3_u8.hash(state);
+            },
+            Self::Upload => {
+                4_u8.hash(state);
+            },
+            Self::Blob => {
+                5_u8.hash(state);
+            },
+        }
+    }
+}
 
 pub const TX_TYPE_SCRIPT: u8 = 0u8;
 pub const TX_TYPE_CREATE: u8 = 1u8;

--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -14,6 +14,7 @@ use ::math::*;
 use ::result::Result::{self, *};
 use ::option::Option::{self, None, Some};
 use ::revert::revert;
+use ::hash::{Hash, Hasher};
 use ::ops::*;
 use ::codec::*;
 use ::debug::*;
@@ -166,6 +167,13 @@ impl Ord for U128 {
 }
 
 impl OrdEq for U128 {}
+
+impl Hash for U128 {
+    fn hash(self, ref mut state: Hasher) {
+        self.upper.hash(state);
+        self.lower.hash(state);
+    }
+}
 
 impl u64 {
     /// Performs addition between two `u64` values, returning a `U128`.

--- a/sway-lib-std/src/vm/evm/evm_address.sw
+++ b/sway-lib-std/src/vm/evm/evm_address.sw
@@ -205,7 +205,6 @@ impl Into<Bytes> for EvmAddress {
 
 impl Hash for EvmAddress {
     fn hash(self, ref mut state: Hasher) {
-        let Address { bits } = self;
-        bits.hash(state);
+        self.bits.hash(state);
     }
 }

--- a/test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-conversions/reduced_lib.config
+++ b/test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-conversions/reduced_lib.config
@@ -47,3 +47,4 @@ primitive_conversions/u64.sw
 primitive_conversions/u256.sw
 primitive_conversions/u8.sw
 debug.sw
+hash.sw

--- a/test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-conversions/src/lib.sw
+++ b/test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-conversions/src/lib.sw
@@ -32,5 +32,6 @@ pub mod array_conversions;
 pub mod bytes_conversions;
 pub mod clone;
 pub mod debug;
+pub mod hash;
 
 pub mod prelude;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
@@ -63,97 +63,97 @@
       "concreteTypeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
       "indirect": false,
       "name": "BOOL",
-      "offset": 6016
+      "offset": 5784
     },
     {
       "concreteTypeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
       "indirect": false,
       "name": "U8",
-      "offset": 6208
+      "offset": 5976
     },
     {
       "concreteTypeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
       "indirect": false,
       "name": "ANOTHER_U8",
-      "offset": 5944
+      "offset": 5712
     },
     {
       "concreteTypeId": "29881aad8730c5ab11d275376323d8e4ff4179aae8ccb6c13fe4902137e162ef",
       "indirect": false,
       "name": "U16",
-      "offset": 6152
+      "offset": 5920
     },
     {
       "concreteTypeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc",
       "indirect": false,
       "name": "U32",
-      "offset": 6192
+      "offset": 5960
     },
     {
       "concreteTypeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc",
       "indirect": false,
       "name": "U64",
-      "offset": 6200
+      "offset": 5968
     },
     {
       "concreteTypeId": "1b5759d94094368cfd443019e7ca5ec4074300e544e5ea993a979f5da627261e",
       "indirect": false,
       "name": "U256",
-      "offset": 6160
+      "offset": 5928
     },
     {
       "concreteTypeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
       "indirect": false,
       "name": "B256",
-      "offset": 5984
+      "offset": 5752
     },
     {
       "concreteTypeId": "81fc10c4681a3271cf2d66b2ec6fbc8ed007a442652930844fcf11818c295bff",
       "indirect": false,
       "name": "CONFIGURABLE_STRUCT",
-      "offset": 6104
+      "offset": 5872
     },
     {
       "concreteTypeId": "a2922861f03be8a650595dd76455b95383a61b46dd418f02607fa2e00dc39d5c",
       "indirect": false,
       "name": "CONFIGURABLE_ENUM_A",
-      "offset": 6024
+      "offset": 5792
     },
     {
       "concreteTypeId": "a2922861f03be8a650595dd76455b95383a61b46dd418f02607fa2e00dc39d5c",
       "indirect": false,
       "name": "CONFIGURABLE_ENUM_B",
-      "offset": 6064
+      "offset": 5832
     },
     {
       "concreteTypeId": "4926d35d1a5157936b0a29bc126b8aace6d911209a5c130e9b716b0c73643ea6",
       "indirect": false,
       "name": "ARRAY_BOOL",
-      "offset": 5952
+      "offset": 5720
     },
     {
       "concreteTypeId": "776fb5a3824169d6736138565fdc20aad684d9111266a5ff6d5c675280b7e199",
       "indirect": false,
       "name": "ARRAY_U64",
-      "offset": 5960
+      "offset": 5728
     },
     {
       "concreteTypeId": "c998ca9a5f221fe7b5c66ae70c8a9562b86d964408b00d17f883c906bc1fe4be",
       "indirect": false,
       "name": "TUPLE_BOOL_U64",
-      "offset": 6136
+      "offset": 5904
     },
     {
       "concreteTypeId": "94f0fa95c830be5e4f711963e83259fe7e8bc723278ab6ec34449e791a99b53a",
       "indirect": false,
       "name": "STR_4",
-      "offset": 6128
+      "offset": 5896
     },
     {
       "concreteTypeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
       "indirect": false,
       "name": "NOT_USED",
-      "offset": 6120
+      "offset": 5888
     }
   ],
   "encodingVersion": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x94db39f409a31b9f2ebcadeea44378e419208c20de90f5d8e1e33dc1523754cb;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x4d12bab98eb732b34ff35567adc2396ff44280907419d86978e0d2ee9bfa4abc; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
+const CONTRACT_ID = 0x10d06e2e4c69e67842bbf7954d8cfa175f3ee69dad14c7977908a513fc57a363; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -5,7 +5,7 @@ use storage_enum_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc601d11767195485a6654d566c67774134668863d8c797a8c69e8778fb1f89e9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xb6ba6ba99abd8226eda8bb079433d1077d01ef8cff81a4e6b000edd7bec7347a; // AUTO-CONTRACT-ID ../../test_contracts/storage_enum_contract --release
+const CONTRACT_ID = 0x0bf8f2f602d9a50e65094bde3714fc47edefad0ad70550fd8e1305b994202ac6; // AUTO-CONTRACT-ID ../../test_contracts/storage_enum_contract --release
 
 fn main() -> u64 {
     let caller = abi(StorageEnum, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x3bc28acd66d327b8c1b9624c1fabfc07e9ffa1b5d71c2832c3bfaaf8f4b805e9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x4f19b667c789249b8743667501b5f52bb126c1b786609d8d067b8f4d73c5120d; // AUTO-CONTRACT-ID ../../test_contracts/storage_access_contract --release
+const CONTRACT_ID = 0xc54dca1fd1b7e489549349fec49fcabb8c567d97c802c25b245c367479a715f3; // AUTO-CONTRACT-ID ../../test_contracts/storage_access_contract --release
 
 fn main() -> bool {
     let caller = abi(StorageAccess, CONTRACT_ID);

--- a/test/src/in_language_tests/test_programs/hash_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/hash_inline_tests/src/main.sw
@@ -1,436 +1,657 @@
 library;
 
-use std::{bytes::Bytes, hash::{Hash, Hasher, keccak256, sha256, sha256_str_array}};
+use std::address::Address;
+use std::asset_id::AssetId;
+use std::bytes::Bytes;
+use std::b512::B512;
+use std::contract_id::ContractId;
+use std::crypto::ed25519::Ed25519;
+use std::crypto::message::Message;
+use std::crypto::public_key::PublicKey;
+use std::crypto::point2d::Point2D;
+use std::crypto::scalar::Scalar;
+use std::crypto::signature::Signature;
+use std::crypto::secp256k1::Secp256k1;
+use std::crypto::secp256r1::Secp256r1;
+use std::time::{Duration, Time};
+use std::vm::evm::evm_address::EvmAddress;
+use std::hash::*;
+use std::identity::Identity;
+use std::inputs::Input;
+use std::low_level_call::CallParams;
+use std::outputs::Output;
+use std::string::String;
+use std::tx::Transaction;
+use std::u128::U128;
+
+// Test `Hasher` methods and `std::hash` functions.
 
 #[test()]
 fn hash_hasher_write_str() {
     let mut hasher = Hasher::new();
+    hasher.write_str("");
+    assert_eq(hasher.sha256(), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(hasher.keccak256(), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
+
+    let mut hasher = Hasher::new();
     hasher.write_str("test");
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(hasher.sha256(), 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(hasher.keccak256(), 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
 
     let mut hasher = Hasher::new();
     hasher.write_str("Fastest Modular Execution Layer!");
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
-}
-
-#[test()]
-fn hash_hasher_keccak256_str() {
-    let mut hasher = Hasher::new();
-    hasher.write_str("test");
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
-
-    let mut hasher = Hasher::new();
-    hasher.write_str("Fastest Modular Execution Layer!");
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
+    assert_eq(hasher.sha256(), 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    assert_eq(hasher.keccak256(), 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
 }
 
 #[test()]
 fn hash_hasher_write_str_array() {
     let mut hasher = Hasher::new();
+    hasher.write_str_array(__to_str_array(""));
+    assert_eq(hasher.sha256(), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(hasher.keccak256(), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
+
+    let mut hasher = Hasher::new();
     hasher.write_str_array(__to_str_array("test"));
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(hasher.sha256(), 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(hasher.keccak256(), 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
 
     let mut hasher = Hasher::new();
     hasher.write_str_array(__to_str_array("Fastest Modular Execution Layer!"));
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    assert_eq(hasher.sha256(), 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    assert_eq(hasher.keccak256(), 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
 }
 
 #[test()]
-fn hash_hasher_keccak256_str_array() {
-    let mut hasher = Hasher::new();
-    hasher.write_str_array(__to_str_array("test"));
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
+fn hash_fn_sha256_str_array() {
+    let digest = sha256_str_array(__to_str_array(""));
+    assert_eq(digest, 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
 
-    let mut hasher = Hasher::new();
-    hasher.write_str_array(__to_str_array("Fastest Modular Execution Layer!"));
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
+    let digest = sha256_str_array(__to_str_array("test"));
+    assert_eq(digest, 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+
+    let digest = sha256_str_array(__to_str_array("Fastest Modular Execution Layer!"));
+    assert_eq(digest, 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
 }
 
-// The hashes for the following test can be obtained in Rust by running the following script:
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=a2d83e9ea48b35a3e991c904c3451ed5
+// Test `Hash` implementations for all `std` types.
+// Standard library types that implement `Hash` trait can be used in cases that
+// semantically assume that the hash is deterministic. E.g., as a key in a `StorageMap`.
+// These tests ensure that the hash values for these types are stable and deterministic.
+
+// Note that we test `std::hash::sha256` and `std::hash::keccak256` module functions
+// next to the `Hasher::sha256` and `Hasher::keccak256`. The reason is that their
+// implementations use differently initialized `Hasher` instances, optimized for the
+// hashed type size, whereas the `Hasher` used in tests are always initialized with
+// `Hasher::new`.
+
+// The hashes used in tests can be obtained in Rust by running the following script:
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cc885f4ba8c7ded1da707909ce38c11b
+//
+// Note that the **script cannot be executed directly in the Rust Playground**, because
+// of the missing dependencies.
+//
+// To run the script, you need to create a new Rust project, copy the script into the `main.rs` file,
+// and add the following dependencies to your `Cargo.toml` file:
+// sha2   = "0.10"
+// tiny-keccak = { version = "2.0.0", features = ["keccak"] }
+// hex    = "0.4"
+// bincode = "1.3"
+// serde  = { version = "1", features = ["derive"] }
 #[test()]
-fn hash_hasher_sha256_u8() {
+fn hash_u8() {
     let mut hasher = Hasher::new();
     0_u8.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(hasher.sha256(), 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(sha256(0_u8), 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(hasher.keccak256(), 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
+    assert_eq(keccak256(0_u8), 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
 
     let mut hasher = Hasher::new();
     1_u8.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(hasher.sha256(), 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(sha256(1_u8), 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(hasher.keccak256(), 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
+    assert_eq(keccak256(1_u8), 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
+
+    let mut hasher = Hasher::new();
+    42_u8.hash(hasher);
+    assert_eq(hasher.sha256(), 0x684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1);
+    assert_eq(sha256(42_u8), 0x684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1);
+    assert_eq(hasher.keccak256(), 0x04994f67dc55b09e814ab7ffc8df3686b4afb2bb53e60eae97ef043fe03fb829);
+    assert_eq(keccak256(42_u8), 0x04994f67dc55b09e814ab7ffc8df3686b4afb2bb53e60eae97ef043fe03fb829);
+
+    let mut hasher = Hasher::new();
+    u8::max().hash(hasher);
+    assert_eq(hasher.sha256(), 0xa8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89);
+    assert_eq(sha256(u8::max()), 0xa8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89);
+    assert_eq(hasher.keccak256(), 0x8b1a944cf13a9a1c08facb2c9e98623ef3254d2ddb48113885c3e8e97fec8db9);
+    assert_eq(keccak256(u8::max()), 0x8b1a944cf13a9a1c08facb2c9e98623ef3254d2ddb48113885c3e8e97fec8db9);
 }
 
 #[test()]
-fn hash_hasher_keccak256_u8() {
-    let mut hasher = Hasher::new();
-    0_u8.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
-
-    let mut hasher = Hasher::new();
-    1_u8.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
-}
-
-#[test()]
-fn hash_hasher_sha256_u16() {
+fn hash_u16() {
     let mut hasher = Hasher::new();
     0_u16.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7);
+    assert_eq(hasher.sha256(), 0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7);
+    assert_eq(sha256(0_u16), 0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7);
+    assert_eq(hasher.keccak256(), 0x54a8c0ab653c15bfb48b47fd011ba2b9617af01cb45cab344acd57c924d56798);
+    assert_eq(keccak256(0_u16), 0x54a8c0ab653c15bfb48b47fd011ba2b9617af01cb45cab344acd57c924d56798);
 
     let mut hasher = Hasher::new();
     1_u16.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xb413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2);
+    assert_eq(hasher.sha256(), 0xb413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2);
+    assert_eq(sha256(1_u16), 0xb413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2);
+    assert_eq(hasher.keccak256(), 0x49d03a195e239b52779866b33024210fc7dc66e9c2998975c0aa45c1702549d5);
+    assert_eq(keccak256(1_u16), 0x49d03a195e239b52779866b33024210fc7dc66e9c2998975c0aa45c1702549d5);
+
+    let mut hasher = Hasher::new();
+    42_u16.hash(hasher);
+    assert_eq(hasher.sha256(), 0x587bae728805519c3542d21766295396bd01087b6c47765ae3cadbf679813bbe);
+    assert_eq(sha256(42_u16), 0x587bae728805519c3542d21766295396bd01087b6c47765ae3cadbf679813bbe);
+    assert_eq(hasher.keccak256(), 0x0643ec401d1673f6c0a7fdf5eb86c0896a7783ad7502e8e08e4b844f204f9bfd);
+    assert_eq(keccak256(42_u16), 0x0643ec401d1673f6c0a7fdf5eb86c0896a7783ad7502e8e08e4b844f204f9bfd);
+
+    let mut hasher = Hasher::new();
+    u16::max().hash(hasher);
+    assert_eq(hasher.sha256(), 0xca2fd00fa001190744c15c317643ab092e7048ce086a243e2be9437c898de1bb);
+    assert_eq(sha256(u16::max()), 0xca2fd00fa001190744c15c317643ab092e7048ce086a243e2be9437c898de1bb);
+    assert_eq(hasher.keccak256(), 0x06d41322d79dfed27126569cb9a80eb0967335bf2f3316359d2a93c779fcd38a);
+    assert_eq(keccak256(u16::max()), 0x06d41322d79dfed27126569cb9a80eb0967335bf2f3316359d2a93c779fcd38a);
 }
 
 #[test()]
-fn hash_hasher_keccak256_u16() {
-    let mut hasher = Hasher::new();
-    0_u16.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x54a8c0ab653c15bfb48b47fd011ba2b9617af01cb45cab344acd57c924d56798);
-
-    let mut hasher = Hasher::new();
-    1_u16.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x49d03a195e239b52779866b33024210fc7dc66e9c2998975c0aa45c1702549d5);
-}
-
-#[test()]
-fn hash_hasher_sha256_u32() {
+fn hash_u32() {
     let mut hasher = Hasher::new();
     0_u32.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119);
+    assert_eq(hasher.sha256(), 0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119);
+    assert_eq(sha256(0_u32), 0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119);
+    assert_eq(hasher.keccak256(), 0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c);
+    assert_eq(keccak256(0_u32), 0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c);
 
     let mut hasher = Hasher::new();
     1_u32.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xb40711a88c7039756fb8a73827eabe2c0fe5a0346ca7e0a104adc0fc764f528d);
+    assert_eq(hasher.sha256(), 0xb40711a88c7039756fb8a73827eabe2c0fe5a0346ca7e0a104adc0fc764f528d);
+    assert_eq(sha256(1_u32), 0xb40711a88c7039756fb8a73827eabe2c0fe5a0346ca7e0a104adc0fc764f528d);
+    assert_eq(hasher.keccak256(), 0x51f81bcdfc324a0dff2b5bec9d92e21cbebc4d5e29d3a3d30de3e03fbeab8d7f);
+    assert_eq(keccak256(1_u32), 0x51f81bcdfc324a0dff2b5bec9d92e21cbebc4d5e29d3a3d30de3e03fbeab8d7f);
+
+    let mut hasher = Hasher::new();
+    42_u32.hash(hasher);
+    assert_eq(hasher.sha256(), 0xae3c8b8d99a39542f78af83dbbb42c81cd94199ec1b5f60a0801063e95842570);
+    assert_eq(sha256(42_u32), 0xae3c8b8d99a39542f78af83dbbb42c81cd94199ec1b5f60a0801063e95842570);
+    assert_eq(hasher.keccak256(), 0x8ee05353f8b0422de4215090f2a54f3b3f9d13eb2e7e23ef1733da62e7b746de);
+    assert_eq(keccak256(42_u32), 0x8ee05353f8b0422de4215090f2a54f3b3f9d13eb2e7e23ef1733da62e7b746de);
+
+    let mut hasher = Hasher::new();
+    u32::max().hash(hasher);
+    assert_eq(hasher.sha256(), 0xad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e);
+    assert_eq(sha256(u32::max()), 0xad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e);
+    assert_eq(hasher.keccak256(), 0x29045a592007d0c246ef02c2223570da9522d0cf0f73282c79a1bc8f0bb2c238);
+    assert_eq(keccak256(u32::max()), 0x29045a592007d0c246ef02c2223570da9522d0cf0f73282c79a1bc8f0bb2c238);
 }
 
 #[test()]
-fn hash_hasher_keccak256_u32() {
-    let mut hasher = Hasher::new();
-    0_u32.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c);
-
-    let mut hasher = Hasher::new();
-    1_u32.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x51f81bcdfc324a0dff2b5bec9d92e21cbebc4d5e29d3a3d30de3e03fbeab8d7f);
-}
-
-#[test()]
-fn hash_hasher_sha256_u64() {
+fn hash_u64() {
     let mut hasher = Hasher::new();
     0_u64.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(hasher.sha256(), 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(sha256(0_u64), 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(hasher.keccak256(), 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
+    assert_eq(keccak256(0_u64), 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
 
     let mut hasher = Hasher::new();
     1_u64.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(hasher.sha256(), 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(sha256(1_u64), 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(hasher.keccak256(), 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
+    assert_eq(keccak256(1_u64), 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
+
+    let mut hasher = Hasher::new();
+    42_u64.hash(hasher);
+    assert_eq(hasher.sha256(), 0xa6bb133cb1e3638ad7b8a3ff0539668e9e56f9b850ef1b2a810f5422eaa6c323);
+    assert_eq(sha256(42_u64), 0xa6bb133cb1e3638ad7b8a3ff0539668e9e56f9b850ef1b2a810f5422eaa6c323);
+    assert_eq(hasher.keccak256(), 0xc915e80eae100359639667317a39e43392d56b02d9328e8069bb872011b6e63b);
+    assert_eq(keccak256(42_u64), 0xc915e80eae100359639667317a39e43392d56b02d9328e8069bb872011b6e63b);
+
+    let mut hasher = Hasher::new();
+    u64::max().hash(hasher);
+    assert_eq(hasher.sha256(), 0x12a3ae445661ce5dee78d0650d33362dec29c4f82af05e7e57fb595bbbacf0ca);
+    assert_eq(sha256(u64::max()), 0x12a3ae445661ce5dee78d0650d33362dec29c4f82af05e7e57fb595bbbacf0ca);
+    assert_eq(hasher.keccak256(), 0xad0bfb4b0a66700aeb759d88c315168cc0a11ee99e2a680e548ecf0a464e7daf);
+    assert_eq(keccak256(u64::max()), 0xad0bfb4b0a66700aeb759d88c315168cc0a11ee99e2a680e548ecf0a464e7daf);
 }
 
 #[test()]
-fn hash_hasher_keccak256_u64() {
+fn hash_u256() {
     let mut hasher = Hasher::new();
-    0_u64.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
+    0_u256.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256(0_u256), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256(0_u256), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
 
     let mut hasher = Hasher::new();
-    1_u64.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
+    1_u256.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(sha256(1_u256), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+    assert_eq(keccak256(1_u256), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    42_u256.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(sha256(42_u256), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+    assert_eq(keccak256(42_u256), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    u256::max().hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(sha256(u256::max()), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(hasher.keccak256(), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+    assert_eq(keccak256(u256::max()), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
 }
 
 #[test()]
-fn hash_hasher_sha256_b256() {
+fn hash_b256() {
     let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000000
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    0x0000000000000000000000000000000000000000000000000000000000000000.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256(0x0000000000000000000000000000000000000000000000000000000000000000), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256(0x0000000000000000000000000000000000000000000000000000000000000000), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
 
     let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000001
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    0x0000000000000000000000000000000000000000000000000000000000000001.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(sha256(0x0000000000000000000000000000000000000000000000000000000000000001), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+    assert_eq(keccak256(0x0000000000000000000000000000000000000000000000000000000000000001), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    0x000000000000000000000000000000000000000000000000000000000000002a.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(sha256(0x000000000000000000000000000000000000000000000000000000000000002a), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+    assert_eq(keccak256(0x000000000000000000000000000000000000000000000000000000000000002a), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(sha256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(hasher.keccak256(), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+    assert_eq(keccak256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
 }
 
 #[test()]
-fn hash_hasher_keccak256_b256() {
-    let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000000
-        .hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
-
-    let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000001
-        .hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
-}
-
-#[test]
-fn hash_hasher_sha256_u256() {
-    let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000000_u256
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
-
-    let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000001_u256
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
-}
-
-#[test]
-fn hash_hasher_keccak256_u256() {
-    let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000000_u256
-        .hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
-
-    let mut hasher = Hasher::new();
-    0x0000000000000000000000000000000000000000000000000000000000000001_u256
-        .hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
-}
-
-#[test()]
-fn hash_hasher_sha256_bool() {
+fn hash_bool() {
     let mut hasher = Hasher::new();
     false.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(hasher.sha256(), 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(sha256(false), 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(hasher.keccak256(), 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
+    assert_eq(keccak256(false), 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
 
     let mut hasher = Hasher::new();
     true.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(hasher.sha256(), 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(sha256(true), 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(hasher.keccak256(), 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
+    assert_eq(keccak256(true), 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
 }
 
 #[test()]
-fn hash_hasher_keccak256_bool() {
+fn hash_str() {
     let mut hasher = Hasher::new();
-    false.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
+    "".hash(hasher);
+    assert_eq(hasher.sha256(), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(sha256(""), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(hasher.keccak256(), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
+    assert_eq(keccak256(""), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
 
     let mut hasher = Hasher::new();
-    true.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
+    "test".hash(hasher);
+    assert_eq(hasher.sha256(), 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(sha256("test"), 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(hasher.keccak256(), 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
+    assert_eq(keccak256("test"), 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
+
+    let mut hasher = Hasher::new();
+    "Fastest Modular Execution Layer!".hash(hasher);
+    assert_eq(hasher.sha256(), 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    assert_eq(sha256("Fastest Modular Execution Layer!"), 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    assert_eq(hasher.keccak256(), 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
+    assert_eq(keccak256("Fastest Modular Execution Layer!"), 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
+}
+
+#[test()]
+fn hash_unit() {
+    let mut hasher = Hasher::new();
+    ().hash(hasher);
+    assert_eq(hasher.sha256(), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(sha256(()), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(hasher.keccak256(), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
+    assert_eq(keccak256(()), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
 }
 
 #[test]
-fn hash_hasher_sha256_bytes() {
+fn hash_tuple_1() {
     let mut hasher = Hasher::new();
-    let mut bytes = Bytes::new();
-    bytes.push(0u8);
-    bytes.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    (0_u64, ).hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(sha256((0_u64, )), 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(hasher.keccak256(), 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
+    assert_eq(keccak256((0_u64, )), 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
 
     let mut hasher = Hasher::new();
-    let mut bytes = Bytes::new();
-    bytes.push(1u8);
-    bytes.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    (1_u64, ).hash(hasher);
+    assert_eq(hasher.sha256(), 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(sha256((1_u64, )), 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(hasher.keccak256(), 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
+    assert_eq(keccak256((1_u64, )), 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
 }
 
 #[test]
-fn hash_hasher_keccak256_bytes() {
+fn hash_tuple_2() {
     let mut hasher = Hasher::new();
-    let mut bytes = Bytes::with_capacity(1);
-    bytes.push(0u8);
-    bytes.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
+    (0_u64, 0_u64).hash(hasher);
+    assert_eq(hasher.sha256(), 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb);
+    assert_eq(sha256((0_u64, 0_u64)), 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb);
+    assert_eq(hasher.keccak256(), 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4);
+    assert_eq(keccak256((0_u64, 0_u64)), 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4);
 
     let mut hasher = Hasher::new();
-    let mut bytes = Bytes::with_capacity(1);
-    bytes.push(1u8);
-    bytes.hash(hasher);
-    let keccak256 = hasher.keccak256();
-    assert(keccak256 == 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
+    (1_u64, 1_u64).hash(hasher);
+    assert_eq(hasher.sha256(), 0x532deabf88729cb43995ab5a9cd49bf9b90a079904dc0645ecda9e47ce7345a9);
+    assert_eq(sha256((1_u64, 1_u64)), 0x532deabf88729cb43995ab5a9cd49bf9b90a079904dc0645ecda9e47ce7345a9);
+    assert_eq(hasher.keccak256(), 0x5dd50243f81eaa0bd39ace71862b46f2054c3ea1c2b69a79093b5795061e3851);
+    assert_eq(keccak256((1_u64, 1_u64)), 0x5dd50243f81eaa0bd39ace71862b46f2054c3ea1c2b69a79093b5795061e3851);
 }
 
 #[test]
-fn hash_hasher_sha256_3_tuple() {
+fn hash_tuple_3() {
     let mut hasher = Hasher::new();
     (0_u64, 0_u64, 0_u64).hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x9d908ecfb6b256def8b49a7c504e6c889c4b0e41fe6ce3e01863dd7b61a20aa0);
+    assert_eq(hasher.sha256(), 0x9d908ecfb6b256def8b49a7c504e6c889c4b0e41fe6ce3e01863dd7b61a20aa0);
+    assert_eq(sha256((0_u64, 0_u64, 0_u64)), 0x9d908ecfb6b256def8b49a7c504e6c889c4b0e41fe6ce3e01863dd7b61a20aa0);
+    assert_eq(hasher.keccak256(), 0x827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd);
+    assert_eq(keccak256((0_u64, 0_u64, 0_u64)), 0x827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd);
 
     let mut hasher = Hasher::new();
     (1_u64, 1_u64, 1_u64).hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xf3dd2c58f4b546018d9a5e147e195b7744eee27b76cae299dad63f221173cca0);
+    assert_eq(hasher.sha256(), 0xf3dd2c58f4b546018d9a5e147e195b7744eee27b76cae299dad63f221173cca0);
+    assert_eq(sha256((1_u64, 1_u64, 1_u64)), 0xf3dd2c58f4b546018d9a5e147e195b7744eee27b76cae299dad63f221173cca0);
+    assert_eq(hasher.keccak256(), 0xc9385a4b1b6112f4dca587451a622a8dad8846adb4e78b90124930eecf5c2830);
+    assert_eq(keccak256((1_u64, 1_u64, 1_u64)), 0xc9385a4b1b6112f4dca587451a622a8dad8846adb4e78b90124930eecf5c2830);
 }
 
 #[test]
-fn hash_hasher_sha256_4_tuple() {
+fn hash_tuple_4() {
     let mut hasher = Hasher::new();
     (0_u64, 0_u64, 0_u64, 0_u64).hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256((0_u64, 0_u64, 0_u64, 0_u64)), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256((0_u64, 0_u64, 0_u64, 0_u64)), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
 
     let mut hasher = Hasher::new();
     (1_u64, 1_u64, 1_u64, 1_u64).hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x696547da2108716208569c8d60e78fcb423e7ad45cb8c700eeda8a8805bf2571);
+    assert_eq(hasher.sha256(), 0x696547da2108716208569c8d60e78fcb423e7ad45cb8c700eeda8a8805bf2571);
+    assert_eq(sha256((1_u64, 1_u64, 1_u64, 1_u64)), 0x696547da2108716208569c8d60e78fcb423e7ad45cb8c700eeda8a8805bf2571);
+    assert_eq(hasher.keccak256(), 0x4861a1848ac650fbed0906f372ea2ce38824a879872c49eb27da3b5b2d2ee868);
+    assert_eq(keccak256((1_u64, 1_u64, 1_u64, 1_u64)), 0x4861a1848ac650fbed0906f372ea2ce38824a879872c49eb27da3b5b2d2ee868);
 }
 
 #[test]
-fn hash_hasher_sha256_5_tuple() {
+fn hash_tuple_5() {
     let mut hasher = Hasher::new();
     (0_u64, 0_u64, 0_u64, 0_u64, 0_u64).hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x2c34ce1df23b838c5abf2a7f6437cca3d3067ed509ff25f11df6b11b582b51eb);
+    assert_eq(hasher.sha256(), 0x2c34ce1df23b838c5abf2a7f6437cca3d3067ed509ff25f11df6b11b582b51eb);
+    assert_eq(sha256((0_u64, 0_u64, 0_u64, 0_u64, 0_u64)), 0x2c34ce1df23b838c5abf2a7f6437cca3d3067ed509ff25f11df6b11b582b51eb);
+    assert_eq(hasher.keccak256(), 0xdaa77426c30c02a43d9fba4e841a6556c524d47030762eb14dc4af897e605d9b);
+    assert_eq(keccak256((0_u64, 0_u64, 0_u64, 0_u64, 0_u64)), 0xdaa77426c30c02a43d9fba4e841a6556c524d47030762eb14dc4af897e605d9b);
 
     let mut hasher = Hasher::new();
     (1_u64, 1_u64, 1u64, 1_u64, 1_u64).hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x7bf87db15ea1fff61e936a88ff181b511e66b22417ed270ebb90c298c2088c10);
+    assert_eq(hasher.sha256(), 0x7bf87db15ea1fff61e936a88ff181b511e66b22417ed270ebb90c298c2088c10);
+    assert_eq(sha256((1_u64, 1_u64, 1u64, 1_u64, 1_u64)), 0x7bf87db15ea1fff61e936a88ff181b511e66b22417ed270ebb90c298c2088c10);
+    assert_eq(hasher.keccak256(), 0x7755da38b585018ea81bdf1a67e2c7de3014469999d4c11eb8c2d99c6285df6c);
+    assert_eq(keccak256((1_u64, 1_u64, 1u64, 1_u64, 1_u64)), 0x7755da38b585018ea81bdf1a67e2c7de3014469999d4c11eb8c2d99c6285df6c);
+}
+
+#[test()]
+fn hash_array_empty() {
+    let mut hasher = Hasher::new();
+    let empty_array: [u64; 0] = [];
+    empty_array.hash(hasher);
+    assert_eq(hasher.sha256(), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(sha256(empty_array), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(hasher.keccak256(), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
+    assert_eq(keccak256(empty_array), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
 }
 
 #[test]
-fn hash_hasher_sha256_1_array() {
+fn hash_array_1() {
     let mut hasher = Hasher::new();
     [0_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(hasher.sha256(), 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(sha256([0_u64]), 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+    assert_eq(hasher.keccak256(), 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
+    assert_eq(keccak256([0_u64]), 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
 
     let mut hasher = Hasher::new();
     [1_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(hasher.sha256(), 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(sha256([1_u64]), 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    assert_eq(hasher.keccak256(), 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
+    assert_eq(keccak256([1_u64]), 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
 }
 
 #[test]
-fn hash_hasher_sha256_2_array() {
+fn hash_array_2() {
     let mut hasher = Hasher::new();
     [0_u64, 0_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb);
+    assert_eq(hasher.sha256(), 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb);
+    assert_eq(sha256([0_u64, 0_u64]), 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb);
+    assert_eq(hasher.keccak256(), 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4);
+    assert_eq(keccak256([0_u64, 0_u64]), 0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4);
 
     let mut hasher = Hasher::new();
     [1_u64, 1_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x532deabf88729cb43995ab5a9cd49bf9b90a079904dc0645ecda9e47ce7345a9);
+    assert_eq(hasher.sha256(), 0x532deabf88729cb43995ab5a9cd49bf9b90a079904dc0645ecda9e47ce7345a9);
+    assert_eq(sha256([1_u64, 1_u64]), 0x532deabf88729cb43995ab5a9cd49bf9b90a079904dc0645ecda9e47ce7345a9);
+    assert_eq(hasher.keccak256(), 0x5dd50243f81eaa0bd39ace71862b46f2054c3ea1c2b69a79093b5795061e3851);
+    assert_eq(keccak256([1_u64, 1_u64]), 0x5dd50243f81eaa0bd39ace71862b46f2054c3ea1c2b69a79093b5795061e3851);
 }
 
 #[test]
-fn hash_hasher_sha256_4_array() {
+fn hash_array_3() {
+    let mut hasher = Hasher::new();
+    [0_u64, 0_u64, 0_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x9d908ecfb6b256def8b49a7c504e6c889c4b0e41fe6ce3e01863dd7b61a20aa0);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64]), 0x9d908ecfb6b256def8b49a7c504e6c889c4b0e41fe6ce3e01863dd7b61a20aa0);
+    assert_eq(hasher.keccak256(), 0x827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64]), 0x827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd);
+
+    let mut hasher = Hasher::new();
+    [1_u64, 1_u64, 1_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0xf3dd2c58f4b546018d9a5e147e195b7744eee27b76cae299dad63f221173cca0);
+    assert_eq(sha256([1_u64, 1_u64, 1_u64]), 0xf3dd2c58f4b546018d9a5e147e195b7744eee27b76cae299dad63f221173cca0);
+    assert_eq(hasher.keccak256(), 0xc9385a4b1b6112f4dca587451a622a8dad8846adb4e78b90124930eecf5c2830);
+    assert_eq(keccak256([1_u64, 1_u64, 1_u64]), 0xc9385a4b1b6112f4dca587451a622a8dad8846adb4e78b90124930eecf5c2830);
+}
+
+#[test]
+fn hash_array_4() {
     let mut hasher = Hasher::new();
     [0_u64, 0_u64, 0_u64, 0_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64, 0_u64]), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64, 0_u64]), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
 
     let mut hasher = Hasher::new();
     [1_u64, 1_u64, 1_u64, 1_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x696547da2108716208569c8d60e78fcb423e7ad45cb8c700eeda8a8805bf2571);
+    assert_eq(hasher.sha256(), 0x696547da2108716208569c8d60e78fcb423e7ad45cb8c700eeda8a8805bf2571);
+    assert_eq(sha256([1_u64, 1_u64, 1_u64, 1_u64]), 0x696547da2108716208569c8d60e78fcb423e7ad45cb8c700eeda8a8805bf2571);
+    assert_eq(hasher.keccak256(), 0x4861a1848ac650fbed0906f372ea2ce38824a879872c49eb27da3b5b2d2ee868);
+    assert_eq(keccak256([1_u64, 1_u64, 1_u64, 1_u64]), 0x4861a1848ac650fbed0906f372ea2ce38824a879872c49eb27da3b5b2d2ee868);
 }
 
 #[test]
-fn hash_hasher_sha256_5_array() {
+fn hash_array_5() {
     let mut hasher = Hasher::new();
     [0_u64, 0_u64, 0_u64, 0_u64, 0_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x2c34ce1df23b838c5abf2a7f6437cca3d3067ed509ff25f11df6b11b582b51eb);
+    assert_eq(hasher.sha256(), 0x2c34ce1df23b838c5abf2a7f6437cca3d3067ed509ff25f11df6b11b582b51eb);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0x2c34ce1df23b838c5abf2a7f6437cca3d3067ed509ff25f11df6b11b582b51eb);
+    assert_eq(hasher.keccak256(), 0xdaa77426c30c02a43d9fba4e841a6556c524d47030762eb14dc4af897e605d9b);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0xdaa77426c30c02a43d9fba4e841a6556c524d47030762eb14dc4af897e605d9b);
 
     let mut hasher = Hasher::new();
-    [1_u64, 1_u64, 1_u64, 1_u64, 1_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x7bf87db15ea1fff61e936a88ff181b511e66b22417ed270ebb90c298c2088c10);
+    [1_u64, 1_u64, 1u64, 1_u64, 1_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x7bf87db15ea1fff61e936a88ff181b511e66b22417ed270ebb90c298c2088c10);
+    assert_eq(sha256([1_u64, 1_u64, 1u64, 1_u64, 1_u64]), 0x7bf87db15ea1fff61e936a88ff181b511e66b22417ed270ebb90c298c2088c10);
+    assert_eq(hasher.keccak256(), 0x7755da38b585018ea81bdf1a67e2c7de3014469999d4c11eb8c2d99c6285df6c);
+    assert_eq(keccak256([1_u64, 1_u64, 1u64, 1_u64, 1_u64]), 0x7755da38b585018ea81bdf1a67e2c7de3014469999d4c11eb8c2d99c6285df6c);
 }
 
 #[test]
-fn hash_hasher_sha256_6_array() {
+fn hash_array_6() {
     let mut hasher = Hasher::new();
     [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x17b0761f87b081d5cf10757ccc89f12be355c70e2e29df288b65b30710dcbcd1);
+    assert_eq(hasher.sha256(), 0x17b0761f87b081d5cf10757ccc89f12be355c70e2e29df288b65b30710dcbcd1);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0x17b0761f87b081d5cf10757ccc89f12be355c70e2e29df288b65b30710dcbcd1);
+    assert_eq(hasher.keccak256(), 0xc980e59163ce244bb4bb6211f48c7b46f88a4f40943e84eb99bdc41e129bd293);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0xc980e59163ce244bb4bb6211f48c7b46f88a4f40943e84eb99bdc41e129bd293);
 
     let mut hasher = Hasher::new();
-    [1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64].hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x9cd65c79280fcb0d834da54ea98364d11439ec21e106447abcee2893765809a4);
+    [1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x9cd65c79280fcb0d834da54ea98364d11439ec21e106447abcee2893765809a4);
+    assert_eq(sha256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64]), 0x9cd65c79280fcb0d834da54ea98364d11439ec21e106447abcee2893765809a4);
+    assert_eq(hasher.keccak256(), 0xe25b47d30a6a4dc767566eb44c1ca3bb814bc7d05336e407cb7e4fcbb62dfd51);
+    assert_eq(keccak256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64]), 0xe25b47d30a6a4dc767566eb44c1ca3bb814bc7d05336e407cb7e4fcbb62dfd51);
 }
 
 #[test]
-fn hash_hasher_sha256_8_array() {
+fn hash_array_7() {
     let mut hasher = Hasher::new();
-    [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0xd4817aa5497628e7c77e6b606107042bbba3130888c5f47a375e6179be789fbb);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0xd4817aa5497628e7c77e6b606107042bbba3130888c5f47a375e6179be789fbb);
+    assert_eq(hasher.keccak256(), 0x660b057b36925d4a0da5bf6588b4c64cff7f27ee34e9c90b052829bf8e2a3168);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0x660b057b36925d4a0da5bf6588b4c64cff7f27ee34e9c90b052829bf8e2a3168);
 
     let mut hasher = Hasher::new();
-    [1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x794dde2d7e1d63dc28474122bd094bd35499447b3764dbf6cdf7c75ca73918dc);
+    [1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x68ac8a4116c57147cbdf1560d0aa00bd087e8c3ca484ff219cf85ac2c3249a7b);
+    assert_eq(sha256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0x68ac8a4116c57147cbdf1560d0aa00bd087e8c3ca484ff219cf85ac2c3249a7b);
+    assert_eq(hasher.keccak256(), 0x4b085430c7e79e4862c111c5b93c007a7c264c60726a71c85fd5cf48927b873a);
+    assert_eq(keccak256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0x4b085430c7e79e4862c111c5b93c007a7c264c60726a71c85fd5cf48927b873a);
 }
 
 #[test]
-fn hash_hasher_sha256_9_array() {
+fn hash_array_8() {
     let mut hasher = Hasher::new();
-    [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x834a709ba2534ebe3ee1397fd4f7bd288b2acc1d20a08d6c862dcd99b6f04400);
+    [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(hasher.keccak256(), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
 
     let mut hasher = Hasher::new();
-    [1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0xe62386a1ec5b8fd0ece7344a7cae775d73179cfc0950c4fdeed26c7e8944e795);
+    [1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x794dde2d7e1d63dc28474122bd094bd35499447b3764dbf6cdf7c75ca73918dc);
+    assert_eq(sha256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0x794dde2d7e1d63dc28474122bd094bd35499447b3764dbf6cdf7c75ca73918dc);
+    assert_eq(hasher.keccak256(), 0x4d7178fc9dd0659e4f25a41774e1905f280a2561076e876ee49350d24bdc9077);
+    assert_eq(keccak256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0x4d7178fc9dd0659e4f25a41774e1905f280a2561076e876ee49350d24bdc9077);
 }
 
 #[test]
-fn hash_hasher_sha256_10_array() {
+fn hash_array_9() {
     let mut hasher = Hasher::new();
-    [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x834a709ba2534ebe3ee1397fd4f7bd288b2acc1d20a08d6c862dcd99b6f04400);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0x834a709ba2534ebe3ee1397fd4f7bd288b2acc1d20a08d6c862dcd99b6f04400);
+    assert_eq(hasher.keccak256(), 0x3cac317908c699fe873a7f6ee4e8cd63fbe9918b2315c97be91585590168e301);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0x3cac317908c699fe873a7f6ee4e8cd63fbe9918b2315c97be91585590168e301);
 
     let mut hasher = Hasher::new();
-    [1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]
-        .hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
+    [1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0xe62386a1ec5b8fd0ece7344a7cae775d73179cfc0950c4fdeed26c7e8944e795);
+    assert_eq(sha256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0xe62386a1ec5b8fd0ece7344a7cae775d73179cfc0950c4fdeed26c7e8944e795);
+    assert_eq(hasher.keccak256(), 0xf552e01b7c0e9b548702da13aeef5dafb7ae298fa02b0dd91dd24e89e1bb8462);
+    assert_eq(keccak256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0xf552e01b7c0e9b548702da13aeef5dafb7ae298fa02b0dd91dd24e89e1bb8462);
 }
 
 #[test]
-fn hash_hasher_sha256_vec() {
+fn hash_array_10() {
+    let mut hasher = Hasher::new();
+    [0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(sha256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(hasher.keccak256(), 0x3a709301f7eafe917c7a06e209b077a9f3942799fb24b913407674a4c1485893);
+    assert_eq(keccak256([0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64, 0_u64]), 0x3a709301f7eafe917c7a06e209b077a9f3942799fb24b913407674a4c1485893);
+
+    let mut hasher = Hasher::new();
+    [1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64].hash(hasher);
+    assert_eq(hasher.sha256(), 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
+    assert_eq(sha256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
+    assert_eq(hasher.keccak256(), 0x48c5807e2d7a4a4d6568acae97a996fa10fbe2a664ffc97c86dbf883331962bd);
+    assert_eq(keccak256([1_u64, 1_u64, 1u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64, 1_u64]), 0x48c5807e2d7a4a4d6568acae97a996fa10fbe2a664ffc97c86dbf883331962bd);
+}
+
+#[test]
+fn hash_bytes() {
+    let mut hasher = Hasher::new();
+    let mut bytes = Bytes::new();
+    bytes.push(0_u8);
+    bytes.hash(hasher);
+    assert_eq(hasher.sha256(), 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(sha256(bytes), 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d);
+    assert_eq(hasher.keccak256(), 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
+    assert_eq(keccak256(bytes), 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a);
+
+    let mut hasher = Hasher::new();
+    let mut bytes = Bytes::new();
+    bytes.push(1_u8);
+    bytes.hash(hasher);
+    assert_eq(hasher.sha256(), 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(sha256(bytes), 0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a);
+    assert_eq(hasher.keccak256(), 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
+    assert_eq(keccak256(bytes), 0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2);
+
+    let mut bytes = Bytes::new();
+    let mut i = 0;
+    while i < 10 {
+        bytes.push(0_u8);
+        i += 1;
+    }
+
+    let mut hasher = Hasher::new();
+    bytes.hash(hasher);
+    assert_eq(hasher.sha256(), 0x01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca);
+    assert_eq(sha256(bytes), 0x01d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca);
+    assert_eq(hasher.keccak256(), 0x6bd2dd6bd408cbee33429358bf24fdc64612fbf8b1b4db604518f40ffd34b607);
+    assert_eq(keccak256(bytes), 0x6bd2dd6bd408cbee33429358bf24fdc64612fbf8b1b4db604518f40ffd34b607);
+
+    let mut bytes = Bytes::new();
+    let mut i = 0;
+    while i < 10 {
+        bytes.push(1_u8);
+        i += 1;
+    }
+
+    let mut hasher = Hasher::new();
+    bytes.hash(hasher);
+    assert_eq(hasher.sha256(), 0xffadf8d89d37b3b55fe1847b513cf92e3be87e4c168708c7851845df96fb36be);
+    assert_eq(sha256(bytes), 0xffadf8d89d37b3b55fe1847b513cf92e3be87e4c168708c7851845df96fb36be);
+    assert_eq(hasher.keccak256(), 0xe3f42f79c06bc68dee65a965f26b9c1a1d40d3195f24341127150f7242979709);
+    assert_eq(keccak256(bytes), 0xe3f42f79c06bc68dee65a965f26b9c1a1d40d3195f24341127150f7242979709);
+}
+
+#[test]
+fn hash_vec() {
     let mut vec = Vec::<u64>::new();
     let mut i = 0;
     while i < 10 {
@@ -440,8 +661,10 @@ fn hash_hasher_sha256_vec() {
 
     let mut hasher = Hasher::new();
     vec.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(hasher.sha256(), 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(sha256(vec), 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(hasher.keccak256(), 0x3a709301f7eafe917c7a06e209b077a9f3942799fb24b913407674a4c1485893);
+    assert_eq(keccak256(vec), 0x3a709301f7eafe917c7a06e209b077a9f3942799fb24b913407674a4c1485893);
 
     let mut vec = Vec::<u64>::new();
     let mut i = 0;
@@ -452,8 +675,10 @@ fn hash_hasher_sha256_vec() {
 
     let mut hasher = Hasher::new();
     vec.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
+    assert_eq(hasher.sha256(), 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
+    assert_eq(sha256(vec), 0x5f80cf4c3ec64f652ea4ba4db7ea12896224546bd2ed4dd2032a8ce12fde16f9);
+    assert_eq(hasher.keccak256(), 0x48c5807e2d7a4a4d6568acae97a996fa10fbe2a664ffc97c86dbf883331962bd);
+    assert_eq(keccak256(vec), 0x48c5807e2d7a4a4d6568acae97a996fa10fbe2a664ffc97c86dbf883331962bd);
 
     let mut vec = Vec::<(u64, Vec<u64>)>::new();
     let mut inner_vec = Vec::<u64>::new();
@@ -466,33 +691,673 @@ fn hash_hasher_sha256_vec() {
 
     let mut hasher = Hasher::new();
     vec.hash(hasher);
-    let sha256 = hasher.sha256();
-    assert(sha256 == 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(hasher.sha256(), 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(sha256(vec), 0x5b6fb58e61fa475939767d68a446f97f1bff02c0e5935a3ea8bb51e6515783d8);
+    assert_eq(hasher.keccak256(), 0x3a709301f7eafe917c7a06e209b077a9f3942799fb24b913407674a4c1485893);
+    assert_eq(keccak256(vec), 0x3a709301f7eafe917c7a06e209b077a9f3942799fb24b913407674a4c1485893);
 }
 
 #[test()]
-fn hash_sha256() {
-    let digest = sha256(0_u64);
-    assert(digest == 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc);
+fn hash_address() {
+    let mut hasher = Hasher::new();
+    let address = Address::from(0x0000000000000000000000000000000000000000000000000000000000000000);
+    address.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256(address), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256(address), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
 
-    let digest = sha256(1_u64);
-    assert(digest == 0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50);
+    let mut hasher = Hasher::new();
+    let address = Address::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    address.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(sha256(address), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+    assert_eq(keccak256(address), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    let address = Address::from(0x000000000000000000000000000000000000000000000000000000000000002a);
+    address.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(sha256(address), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+    assert_eq(keccak256(address), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    let address = Address::from(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+    address.hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(sha256(address), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(hasher.keccak256(), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+    assert_eq(keccak256(address), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
 }
 
 #[test()]
-fn hash_sha256_str_array() {
-    let digest = sha256_str_array(__to_str_array("test"));
-    assert(digest == 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+fn hash_asset_id() {
+    let mut hasher = Hasher::new();
+    let asset_id = AssetId::from(0x0000000000000000000000000000000000000000000000000000000000000000);
+    asset_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256(asset_id), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256(asset_id), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
 
-    let digest = sha256_str_array(__to_str_array("Fastest Modular Execution Layer!"));
-    assert(digest == 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    let mut hasher = Hasher::new();
+    let asset_id = AssetId::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    asset_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(sha256(asset_id), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+    assert_eq(keccak256(asset_id), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    let asset_id = AssetId::from(0x000000000000000000000000000000000000000000000000000000000000002a);
+    asset_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(sha256(asset_id), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+    assert_eq(keccak256(asset_id), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    let asset_id = AssetId::from(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+    asset_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(sha256(asset_id), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(hasher.keccak256(), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+    assert_eq(keccak256(asset_id), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
 }
 
 #[test()]
-fn hash_keccak256() {
-    let digest = keccak256(0_u64);
-    assert(digest == 0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce);
+fn hash_contract_id() {
+    let mut hasher = Hasher::new();
+    let contract_id = ContractId::from(0x0000000000000000000000000000000000000000000000000000000000000000);
+    contract_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256(contract_id), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256(contract_id), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
 
-    let digest = keccak256(1_u64);
-    assert(digest == 0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f);
+    let mut hasher = Hasher::new();
+    let contract_id = ContractId::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    contract_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(sha256(contract_id), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+    assert_eq(keccak256(contract_id), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    let contract_id = ContractId::from(0x000000000000000000000000000000000000000000000000000000000000002a);
+    contract_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(sha256(contract_id), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+    assert_eq(keccak256(contract_id), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    let contract_id = ContractId::from(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+    contract_id.hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(sha256(contract_id), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(hasher.keccak256(), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+    assert_eq(keccak256(contract_id), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+}
+
+#[test()]
+fn hash_identity() {
+    // Identity::Address variant.
+    let mut hasher = Hasher::new();
+    let identity = Identity::Address(Address::from(0x0000000000000000000000000000000000000000000000000000000000000000));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0x7f9c9e31ac8256ca2f258583df262dbc7d6f68f2a03043d5c99a4ae5a7396ce9);
+    assert_eq(sha256(identity), 0x7f9c9e31ac8256ca2f258583df262dbc7d6f68f2a03043d5c99a4ae5a7396ce9);
+    assert_eq(hasher.keccak256(), 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3);
+    assert_eq(keccak256(identity), 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3);
+
+    let mut hasher = Hasher::new();
+    let identity = Identity::Address(Address::from(0x0000000000000000000000000000000000000000000000000000000000000001));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0x1fd4247443c9440cb3c48c28851937196bc156032d70a96c98e127ecb347e45f);
+    assert_eq(sha256(identity), 0x1fd4247443c9440cb3c48c28851937196bc156032d70a96c98e127ecb347e45f);
+    assert_eq(hasher.keccak256(), 0xc13ad76448cbefd1ee83b801bcd8f33061f2577d6118395e7b44ea21c7ef62e0);
+    assert_eq(keccak256(identity), 0xc13ad76448cbefd1ee83b801bcd8f33061f2577d6118395e7b44ea21c7ef62e0);
+
+    let mut hasher = Hasher::new();
+    let identity = Identity::Address(Address::from(0x000000000000000000000000000000000000000000000000000000000000002a));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0xeda2bb11a7b275bd1ca710aef2e01d5d245b76b8966ef8dbac5935e637ad3a69);
+    assert_eq(sha256(identity), 0xeda2bb11a7b275bd1ca710aef2e01d5d245b76b8966ef8dbac5935e637ad3a69);
+    assert_eq(hasher.keccak256(), 0x2bdb76988595837f708230562ad1a4f4efb3d358e4c778478dcaae229c64a0fd);
+    assert_eq(keccak256(identity), 0x2bdb76988595837f708230562ad1a4f4efb3d358e4c778478dcaae229c64a0fd);
+
+    let mut hasher = Hasher::new();
+    let identity = Identity::Address(Address::from(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0x5e16d316ecd5773e50c3b02737d424192b02f25b4245822079181c557aafda7d);
+    assert_eq(sha256(identity), 0x5e16d316ecd5773e50c3b02737d424192b02f25b4245822079181c557aafda7d);
+    assert_eq(hasher.keccak256(), 0x831fe840469ac85581e3a78ca61980fecd4dfe720ab051fe5300153b77f28e4f);
+    assert_eq(keccak256(identity), 0x831fe840469ac85581e3a78ca61980fecd4dfe720ab051fe5300153b77f28e4f);
+
+    // Identity::ContractId variant.
+    let mut hasher = Hasher::new();
+    let identity = Identity::ContractId(ContractId::from(0x0000000000000000000000000000000000000000000000000000000000000000));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0x1a7dfdeaffeedac489287e85be5e9c049a2ff6470f55cf30260f55395ac1b159);
+    assert_eq(sha256(identity), 0x1a7dfdeaffeedac489287e85be5e9c049a2ff6470f55cf30260f55395ac1b159);
+    assert_eq(hasher.keccak256(), 0x0d678e31a4b2825b806fe160675cd01dab159802c7f94397ce45ed91b5f3aac6);
+    assert_eq(keccak256(identity), 0x0d678e31a4b2825b806fe160675cd01dab159802c7f94397ce45ed91b5f3aac6);
+
+    let mut hasher = Hasher::new();
+    let identity = Identity::ContractId(ContractId::from(0x0000000000000000000000000000000000000000000000000000000000000001));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0x2e255099d6d6bee307c8e7075acc78f949897c5f67b53adf60724c814d7b90cb);
+    assert_eq(sha256(identity), 0x2e255099d6d6bee307c8e7075acc78f949897c5f67b53adf60724c814d7b90cb);
+    assert_eq(hasher.keccak256(), 0x9b68e489a07c86105b2c34adda59d3851d6f33abd41be6e9559cf783147db5dd);
+    assert_eq(keccak256(identity), 0x9b68e489a07c86105b2c34adda59d3851d6f33abd41be6e9559cf783147db5dd);
+
+    let mut hasher = Hasher::new();
+    let identity = Identity::ContractId(ContractId::from(0x000000000000000000000000000000000000000000000000000000000000002a));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0xc69bfa18830e0f03230520a6d504b3a958d395214560575317d524d8731dfb58);
+    assert_eq(sha256(identity), 0xc69bfa18830e0f03230520a6d504b3a958d395214560575317d524d8731dfb58);
+    assert_eq(hasher.keccak256(), 0x109c7d1a56a8d4555ebed5c963048374daedb9b1e99458bd3683101437843e0e);
+    assert_eq(keccak256(identity), 0x109c7d1a56a8d4555ebed5c963048374daedb9b1e99458bd3683101437843e0e);
+
+    let mut hasher = Hasher::new();
+    let identity = Identity::ContractId(ContractId::from(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    identity.hash(hasher);
+    assert_eq(hasher.sha256(), 0x29fb7cd3be48a8d76bb031f0abce26caa9e092c000cd16bb101d30f63c4c1bc1);
+    assert_eq(sha256(identity), 0x29fb7cd3be48a8d76bb031f0abce26caa9e092c000cd16bb101d30f63c4c1bc1);
+    assert_eq(hasher.keccak256(), 0x02a0f2d2b92e1b8c9cc103818a30b344401fce2fb233101610dfdd1a24afee09);
+    assert_eq(keccak256(identity), 0x02a0f2d2b92e1b8c9cc103818a30b344401fce2fb233101610dfdd1a24afee09);
+}
+
+#[test()]
+fn hash_string() {
+    let mut hasher = Hasher::new();
+    let string = String::from("");
+    string.hash(hasher);
+    assert_eq(hasher.sha256(), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(sha256(string), 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855);
+    assert_eq(hasher.keccak256(), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
+    assert_eq(keccak256(string), 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470);
+
+    let mut hasher = Hasher::new();
+    let string = String::from("test");
+    string.hash(hasher);
+    assert_eq(hasher.sha256(), 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(sha256(string), 0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08);
+    assert_eq(hasher.keccak256(), 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
+    assert_eq(keccak256(string), 0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658);
+
+    let mut hasher = Hasher::new();
+    let string = String::from("Fastest Modular Execution Layer!");
+    string.hash(hasher);
+    assert_eq(hasher.sha256(), 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    assert_eq(sha256(string), 0x4a3cd7c8b44dbf7941e55179425f746adeaa97fe2d99b571fffee78e9b41743c);
+    assert_eq(hasher.keccak256(), 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
+    assert_eq(keccak256(string), 0xab8e83e041e001bcf797c9cc7d6bc472bfdb8c736bab7999f13b7c26f48c354f);
+}
+
+#[test()]
+fn hash_ed25519() {
+    let mut hasher = Hasher::new();
+    let ed25519 = Ed25519::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000000));
+    ed25519.hash(hasher);
+    assert_eq(hasher.sha256(), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(sha256(ed25519), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(hasher.keccak256(), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+    assert_eq(keccak256(ed25519), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+
+    let mut hasher = Hasher::new();
+    let ed25519 = Ed25519::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000001));
+    ed25519.hash(hasher);
+    assert_eq(hasher.sha256(), 0x90f4b39548df55ad6187a1d20d731ecee78c545b94afd16f42ef7592d99cd365);
+    assert_eq(sha256(ed25519), 0x90f4b39548df55ad6187a1d20d731ecee78c545b94afd16f42ef7592d99cd365);
+    assert_eq(hasher.keccak256(), 0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49);
+    assert_eq(keccak256(ed25519), 0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49);
+
+    let mut hasher = Hasher::new();
+    let ed25519 = Ed25519::from((b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a));
+    ed25519.hash(hasher);
+    assert_eq(hasher.sha256(), 0xc77673a8cc11eb4f660ce1a4ca446423df3b68677ba4c1c1846351ddbeb2e5ef);
+    assert_eq(sha256(ed25519), 0xc77673a8cc11eb4f660ce1a4ca446423df3b68677ba4c1c1846351ddbeb2e5ef);
+    assert_eq(hasher.keccak256(), 0x25a1a901705ed15d5376e82511cff743d9474883c82d145cebcc7811e0424a9c);
+    assert_eq(keccak256(ed25519), 0x25a1a901705ed15d5376e82511cff743d9474883c82d145cebcc7811e0424a9c);
+
+    let mut hasher = Hasher::new();
+    let ed25519 = Ed25519::from((b256::max(), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    ed25519.hash(hasher);
+    assert_eq(hasher.sha256(), 0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7);
+    assert_eq(sha256(ed25519), 0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7);
+    assert_eq(hasher.keccak256(), 0xbd8b151773dbbefd7b0df67f2dcc482901728b6df477f4fb2f192733a005d396);
+    assert_eq(keccak256(ed25519), 0xbd8b151773dbbefd7b0df67f2dcc482901728b6df477f4fb2f192733a005d396);
+}
+
+#[test()]
+fn hash_message() {
+    let mut hasher = Hasher::new();
+    let message = Message::from(0x0000000000000000000000000000000000000000000000000000000000000000);
+    message.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+
+    let mut hasher = Hasher::new();
+    let message = Message::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    message.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    let message = Message::from(0x000000000000000000000000000000000000000000000000000000000000002a);
+    message.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    let message = Message::from(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+    message.hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(hasher.keccak256(), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+}
+
+#[test()]
+fn hash_public_key() {
+    let mut hasher = Hasher::new();
+    let public_key = PublicKey::from(0x0000000000000000000000000000000000000000000000000000000000000000);
+    public_key.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256(public_key), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256(public_key), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+
+    let mut hasher = Hasher::new();
+    let public_key = PublicKey::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    public_key.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(sha256(public_key), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+    assert_eq(keccak256(public_key), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    let public_key = PublicKey::from(0x000000000000000000000000000000000000000000000000000000000000002a);
+    public_key.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(sha256(public_key), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+    assert_eq(keccak256(public_key), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    let public_key = PublicKey::from(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+    public_key.hash(hasher);
+    assert_eq(hasher.sha256(), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(sha256(public_key), 0xaf9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051);
+    assert_eq(hasher.keccak256(), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+    assert_eq(keccak256(public_key), 0xa9c584056064687e149968cbab758a3376d22aedc6a55823d1b3ecbee81b8fb9);
+}
+
+#[test()]
+fn hash_secp256k1() {
+    let mut hasher = Hasher::new();
+    let secp256k1 = Secp256k1::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000000));
+    secp256k1.hash(hasher);
+    assert_eq(hasher.sha256(), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(sha256(secp256k1), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(hasher.keccak256(), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+    assert_eq(keccak256(secp256k1), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+
+    let mut hasher = Hasher::new();
+    let secp256k1 = Secp256k1::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000001));
+    secp256k1.hash(hasher);
+    assert_eq(hasher.sha256(), 0x90f4b39548df55ad6187a1d20d731ecee78c545b94afd16f42ef7592d99cd365);
+    assert_eq(sha256(secp256k1), 0x90f4b39548df55ad6187a1d20d731ecee78c545b94afd16f42ef7592d99cd365);
+    assert_eq(hasher.keccak256(), 0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49);
+    assert_eq(keccak256(secp256k1), 0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49);
+
+    let mut hasher = Hasher::new();
+    let secp256k1 = Secp256k1::from((b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a));
+    secp256k1.hash(hasher);
+    assert_eq(hasher.sha256(), 0xc77673a8cc11eb4f660ce1a4ca446423df3b68677ba4c1c1846351ddbeb2e5ef);
+    assert_eq(sha256(secp256k1), 0xc77673a8cc11eb4f660ce1a4ca446423df3b68677ba4c1c1846351ddbeb2e5ef);
+    assert_eq(hasher.keccak256(), 0x25a1a901705ed15d5376e82511cff743d9474883c82d145cebcc7811e0424a9c);
+    assert_eq(keccak256(secp256k1), 0x25a1a901705ed15d5376e82511cff743d9474883c82d145cebcc7811e0424a9c);
+
+    let mut hasher = Hasher::new();
+    let secp256k1 = Secp256k1::from((b256::max(), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    secp256k1.hash(hasher);
+    assert_eq(hasher.sha256(), 0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7);
+    assert_eq(sha256(secp256k1), 0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7);
+    assert_eq(hasher.keccak256(), 0xbd8b151773dbbefd7b0df67f2dcc482901728b6df477f4fb2f192733a005d396);
+    assert_eq(keccak256(secp256k1), 0xbd8b151773dbbefd7b0df67f2dcc482901728b6df477f4fb2f192733a005d396);
+}
+
+#[test()]
+fn hash_secp256r1() {
+    let mut hasher = Hasher::new();
+    let secp256r1 = Secp256r1::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000000));
+    secp256r1.hash(hasher);
+    assert_eq(hasher.sha256(), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(sha256(secp256r1), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(hasher.keccak256(), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+    assert_eq(keccak256(secp256r1), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+
+    let mut hasher = Hasher::new();
+    let secp256r1 = Secp256r1::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000001));
+    secp256r1.hash(hasher);
+    assert_eq(hasher.sha256(), 0x90f4b39548df55ad6187a1d20d731ecee78c545b94afd16f42ef7592d99cd365);
+    assert_eq(sha256(secp256r1), 0x90f4b39548df55ad6187a1d20d731ecee78c545b94afd16f42ef7592d99cd365);
+    assert_eq(hasher.keccak256(), 0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49);
+    assert_eq(keccak256(secp256r1), 0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49);
+
+    let mut hasher = Hasher::new();
+    let secp256r1 = Secp256r1::from((b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a));
+    secp256r1.hash(hasher);
+    assert_eq(hasher.sha256(), 0xc77673a8cc11eb4f660ce1a4ca446423df3b68677ba4c1c1846351ddbeb2e5ef);
+    assert_eq(sha256(secp256r1), 0xc77673a8cc11eb4f660ce1a4ca446423df3b68677ba4c1c1846351ddbeb2e5ef);
+    assert_eq(hasher.keccak256(), 0x25a1a901705ed15d5376e82511cff743d9474883c82d145cebcc7811e0424a9c);
+    assert_eq(keccak256(secp256r1), 0x25a1a901705ed15d5376e82511cff743d9474883c82d145cebcc7811e0424a9c);
+
+    let mut hasher = Hasher::new();
+    let secp256r1 = Secp256r1::from((b256::max(), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    secp256r1.hash(hasher);
+    assert_eq(hasher.sha256(), 0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7);
+    assert_eq(sha256(secp256r1), 0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7);
+    assert_eq(hasher.keccak256(), 0xbd8b151773dbbefd7b0df67f2dcc482901728b6df477f4fb2f192733a005d396);
+    assert_eq(keccak256(secp256r1), 0xbd8b151773dbbefd7b0df67f2dcc482901728b6df477f4fb2f192733a005d396);
+}
+
+#[test()]
+fn hash_evm_address() {
+    let mut hasher = Hasher::new();
+    let evm_address = EvmAddress::from(0x0000000000000000000000000000000000000000000000000000000000000000);
+    evm_address.hash(hasher);
+    assert_eq(hasher.sha256(), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(sha256(evm_address), 0x66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+    assert_eq(hasher.keccak256(), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+    assert_eq(keccak256(evm_address), 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563);
+
+    let mut hasher = Hasher::new();
+    let evm_address = EvmAddress::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    evm_address.hash(hasher);
+    assert_eq(hasher.sha256(), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(sha256(evm_address), 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
+    assert_eq(hasher.keccak256(), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+    assert_eq(keccak256(evm_address), 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6);
+
+    let mut hasher = Hasher::new();
+    let evm_address = EvmAddress::from(0x000000000000000000000000000000000000000000000000000000000000002a);
+    evm_address.hash(hasher);
+    assert_eq(hasher.sha256(), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(sha256(evm_address), 0x0a28e9ffef0073f9a6a674cf57ee77307f38f0f1bebb087888d9011ed0eeefdf);
+    assert_eq(hasher.keccak256(), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+    assert_eq(keccak256(evm_address), 0xbeced09521047d05b8960b7e7bcc1d1292cf3e4b2a6b63f48335cbde5f7545d2);
+
+    let mut hasher = Hasher::new();
+    // An EVM address is only 20 bytes, so the first 12 are set to zero.
+    let evm_address = EvmAddress::from(0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff);
+    evm_address.hash(hasher);
+    assert_eq(hasher.sha256(), 0x78230345cedf8e92525c3cfdb8a95e947de1ed72e881b055dd80f9e523ff33e0);
+    assert_eq(sha256(evm_address), 0x78230345cedf8e92525c3cfdb8a95e947de1ed72e881b055dd80f9e523ff33e0);
+    assert_eq(hasher.keccak256(), 0xd4e438d33b9d837cd8ac2c60c0ab93462b774f17bb358eb7e74d97f49064fd72);
+    assert_eq(keccak256(evm_address), 0xd4e438d33b9d837cd8ac2c60c0ab93462b774f17bb358eb7e74d97f49064fd72);
+}
+
+#[test()]
+fn hash_b512() {
+    let mut hasher = Hasher::new();
+    let b512 = B512::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000000));
+    b512.hash(hasher);
+    assert_eq(hasher.sha256(), 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
+    assert_eq(hasher.keccak256(), 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5);
+
+    let mut hasher = Hasher::new();
+    let b512 = B512::from((b256::min(), 0x0000000000000000000000000000000000000000000000000000000000000001));
+    b512.hash(hasher);
+    assert_eq(hasher.sha256(), 0x90f4b39548df55ad6187a1d20d731ecee78c545b94afd16f42ef7592d99cd365);
+    assert_eq(hasher.keccak256(), 0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49);
+
+    let mut hasher = Hasher::new();
+    let b512 = B512::from((b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a));
+    b512.hash(hasher);
+    assert_eq(hasher.sha256(), 0xc77673a8cc11eb4f660ce1a4ca446423df3b68677ba4c1c1846351ddbeb2e5ef);
+    assert_eq(hasher.keccak256(), 0x25a1a901705ed15d5376e82511cff743d9474883c82d145cebcc7811e0424a9c);
+
+    let mut hasher = Hasher::new();
+    let b512 = B512::from((b256::max(), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+    b512.hash(hasher);
+    assert_eq(hasher.sha256(), 0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7);
+    assert_eq(hasher.keccak256(), 0xbd8b151773dbbefd7b0df67f2dcc482901728b6df477f4fb2f192733a005d396);
+}
+
+#[test()]
+fn hash_call_params() {
+    assert_eq_hashes(
+        CallParams {
+            coins: 42,
+            asset_id: AssetId::from(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb),
+            gas: 112233
+        },
+        (
+            42_u64,
+            AssetId::from(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb),
+            112233_u64
+        ),
+    );
+}
+
+#[test()]
+fn hash_duration() {
+    assert_eq_hashes(
+        Duration::seconds(42),
+        42_u64,
+    );
+}
+
+#[test()]
+fn hash_time() {
+    assert_eq_hashes(
+        Time::from(42),
+        42_u64,
+    );
+}
+
+#[test()]
+fn hash_u128() {
+    assert_eq_hashes(
+        U128::from((42, 42)),
+        (42_u64, 42_u64),
+    );
+}
+
+#[test()]
+fn hash_point2d() {
+    assert_eq_hashes(
+        Point2D::from([42_u256, 42_u256]),
+        (42_u256, 42_u256),
+    );
+}
+
+#[test()]
+fn hash_scalar() {
+    assert_eq_hashes(
+        Scalar::from(42_u256),
+        42_u256,
+    );
+}
+
+#[test()]
+fn hash_input() {
+    assert_eq_hashes(
+        Input::Coin,
+        0_u8,
+    );
+    assert_eq_hashes(
+        Input::Contract,
+        1_u8,
+    );
+    assert_eq_hashes(
+        Input::Message,
+        2_u8,
+    );
+}
+
+#[test()]
+fn hash_output() {
+    assert_eq_hashes(
+        Output::Coin,
+        0_u8,
+    );
+    assert_eq_hashes(
+        Output::Contract,
+        1_u8,
+    );
+    assert_eq_hashes(
+        Output::Change,
+        2_u8,
+    );
+    assert_eq_hashes(
+        Output::Variable,
+        3_u8,
+    );
+    assert_eq_hashes(
+        Output::ContractCreated,
+        4_u8,
+    );
+}
+
+#[test()]
+fn hash_transaction() {
+    assert_eq_hashes(
+        Transaction::Script,
+        0_u8,
+    );
+    assert_eq_hashes(
+        Transaction::Create,
+        1_u8,
+    );
+    assert_eq_hashes(
+        Transaction::Mint,
+        2_u8,
+    );
+    assert_eq_hashes(
+        Transaction::Upgrade,
+        3_u8,
+    );
+    assert_eq_hashes(
+        Transaction::Upload,
+        4_u8,
+    );
+    assert_eq_hashes(
+        Transaction::Blob,
+        5_u8,
+    );
+}
+
+#[test()]
+fn hash_signature() {
+    assert_eq_hashes(
+        Signature::Secp256k1(Secp256k1::from((b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a))),
+        (
+            0_u8,
+            (b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a)
+        )
+    );
+    assert_eq_hashes(
+        Signature::Secp256r1(Secp256r1::from((b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a))),
+        (
+            1_u8,
+            (b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a)
+        )
+    );
+    assert_eq_hashes(
+        Signature::Ed25519(Ed25519::from((b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a))),
+        (
+            2_u8,
+            (b256::min(), 0x000000000000000000000000000000000000000000000000000000000000002a)
+        )
+    );
+}
+
+#[test()]
+fn hash_option() {
+    assert_eq_hashes(
+        Option::<u8>::None,
+        0_u8,
+    );
+    assert_eq_hashes(
+        Option::<u64>::None,
+        0_u8,
+    );
+
+    assert_eq_hashes(
+        Option::<u8>::Some(42),
+        (
+            1_u8,
+            42_u8,
+        )
+    );
+    assert_eq_hashes(
+        Option::<u64>::Some(42),
+        (
+            1_u8,
+            42_u64,
+        )
+    );
+}
+
+#[test()]
+fn hash_result() {
+    assert_eq_hashes(
+        Result::<u8, u8>::Ok(42),
+        (
+            0_u8,
+            42_u8,
+        )
+    );
+    assert_eq_hashes(
+        Result::<u8, u8>::Err(42),
+        (
+            1_u8,
+            42_u8,
+        )
+    );
+
+    assert_eq_hashes(
+        Result::<u64, u64>::Ok(42),
+        (
+            0_u8,
+            42_u64,
+        )
+    );
+    assert_eq_hashes(
+        Result::<u64, u64>::Err(42),
+        (
+            1_u8,
+            42_u64,
+        )
+    );
+}
+
+/// Asserts that two values `a` and `b` hash to the same SHA256 and Keccak256 hashes.
+fn assert_eq_hashes<A, B>(a: A, b: B) 
+where
+    A: Hash,
+    B: Hash,
+{
+    let mut hasher_a = Hasher::new();
+    a.hash(hasher_a);
+    let sha256_a = hasher_a.sha256();
+    let keccak256_a = hasher_a.keccak256();
+
+    let mut hasher_b = Hasher::new();
+    b.hash(hasher_b);
+    let sha256_b = hasher_b.sha256();
+    let keccak256_b = hasher_b.keccak256();
+
+    assert_eq(sha256_a, sha256_b);
+    assert_eq(sha256_a, sha256(a));
+    assert_eq(sha256_b, sha256(b));
+
+    assert_eq(keccak256_a, keccak256_b);
+    assert_eq(keccak256_a, keccak256(a));
+    assert_eq(keccak256_b, keccak256(b));
 }

--- a/test/src/sdk-harness/test_projects/block/src/main.sw
+++ b/test/src/sdk-harness/test_projects/block/src/main.sw
@@ -24,7 +24,7 @@ impl BlockTest for Contract {
         let res = block_header_hash(h);
         match res {
             Ok(h) => h,
-            Err(e) => revert(0),
+            Err(_) => revert(0),
         }
     }
 


### PR DESCRIPTION
## Description

This PR:
- optimizes the existing `std::hash::Hash` implementations in the `std`, for bytecode size and gas usage. The optimizations are based on eliminations of intensive memory allocations and memory copying.
- fixes #7234
- adds `Hash` implementations for:
  - unit type `()`,
  - tuples of a single element `(T, )`,
  - empty arrays `[T; 0]`,
  - other `std` types that were missing `Hash` implementations, like, e.g.: `Duration`, `Time`, `U128`, `B512`, etc. Note that `Hash` implementations were not provided for various Error enums.

## Breaking Changes

Strictly seen, adding `Hash` implementations for `std` types like `Option<T>` represents a breaking change for those who eventually had their own implementations. However, if such implementations existed, after introducing strict trait coherence checks, they already became invalid, because neither the `Hash` trait nor the types `Hash` is implemented for are part of third party packages, but contained within the `std`.

Thus, we can have a breaking change only if someone migrates from an older version that does not have trait coherence in place. But in that case, the trait coherence itself will already report breaking change errors.

Because `Hash` implementations for `std` types must and should have already been provided within the `std`, we can treat adding those implementations as a bug fix.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.