### PR TITLE
Update Merkle library link to current documentation

### DIFF
--- a/docs/book/src/sway-program-types/libraries.md
+++ b/docs/book/src/sway-program-types/libraries.md
@@ -190,7 +190,7 @@ The repository [`sway-libs`](https://github.com/FuelLabs/sway-libs/) is a collec
 
 Some Sway Libraries to try out:
 
-- [Binary Merkle Proof](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/merkle)
+- [Binary Merkle Proof](https://docs.fuel.network/docs/sway-libs/merkle/)
 - [Signed Integers](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/signed_integers)
 - [Ownership](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/ownership)
 


### PR DESCRIPTION
Replaced the outdated GitHub link to the Binary Merkle Proof library with the up-to-date documentation link at https://docs.fuel.network/docs/sway-libs/merkle/. This ensures users have access to the latest usage instructions and examples.