### PR TITLE
fix(forc-pkg): Resolve runtime panic in registry dependency fetching

### DIFF
--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -21,7 +21,7 @@ futures.workspace = true
 git2 = { workspace = true, features = ["vendored-libgit2", "vendored-openssl"] }
 gix-url = { workspace = true, features = ["serde"] }
 hex.workspace = true
-ipfs-api-backend-hyper = { workspace = true, features = ["with-builder"] }
+ipfs-api-backend-hyper = { workspace = true, features = ["with-builder", "with-send-sync"] }
 petgraph = { workspace = true, features = ["serde-1"] }
 reqwest.workspace = true
 scopeguard.workspace = true

--- a/forc-pkg/src/source/ipfs.rs
+++ b/forc-pkg/src/source/ipfs.rs
@@ -78,13 +78,15 @@ impl source::Fetch for Pinned {
                     "Fetching",
                     &format!("{} {}", ansiterm::Style::new().bold().paint(ctx.name), self),
                 );
-                let cid = &self.0;
-                let ipfs_client = ipfs_client();
-                let dest = cache_dir();
-                crate::source::reg::block_on_any_runtime(async {
-                    match ctx.ipfs_node() {
+                let cid = self.0.clone();
+                let ipfs_node = ctx.ipfs_node().clone();
+                let dest = repo_path.to_path_buf();
+
+                crate::source::reg::block_on_any_runtime(async move {
+                    match ipfs_node {
                         source::IPFSNode::Local => {
                             println_action_green("Fetching", "with local IPFS node");
+                            let ipfs_client = ipfs_client();
                             cid.fetch_with_client(&ipfs_client, &dest).await
                         }
                         source::IPFSNode::WithUrl(ipfs_node_gateway_url) => {
@@ -95,7 +97,7 @@ impl source::Fetch for Pinned {
                                     ipfs_node_gateway_url
                                 ),
                             );
-                            cid.fetch_with_gateway_url(ipfs_node_gateway_url, &dest)
+                            cid.fetch_with_gateway_url(&ipfs_node_gateway_url, &dest)
                                 .await
                         }
                     }


### PR DESCRIPTION
## Description
Fixes the "cannot start a runtime from within a runtime" panic when fetching registry dependencies.

The synchronous fetch operation now safely blocks on the async IPFS client by spawning a new OS thread when already inside a `tokio` runtime context. Enabled the `with-send-sync` feature for `ipfs-api-backend-hyper` to make its futures thread-safe.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
