### PR TITLE
feat: add mdbook preprocessing for forc-publish to flatten include directives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "forc-tracing 0.69.0",
  "forc-util",
  "futures-util",
+ "regex",
  "reqwest",
  "semver 1.0.26",
  "serde",

--- a/forc-plugins/forc-publish/Cargo.toml
+++ b/forc-plugins/forc-publish/Cargo.toml
@@ -26,6 +26,7 @@ toml = { workspace = true, features = ["parse"] }
 tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
+regex.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/forc-plugins/forc-publish/src/error.rs
+++ b/forc-plugins/forc-publish/src/error.rs
@@ -31,6 +31,9 @@ pub enum Error {
 
     #[error("Server error")]
     ServerError,
+
+    #[error("Readme pre-process error: {0}")]
+    MDPreProcessError(#[from] crate::md_pre_process::error::MDPreProcessError),
 }
 
 #[derive(Deserialize)]

--- a/forc-plugins/forc-publish/src/lib.rs
+++ b/forc-plugins/forc-publish/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod credentials;
 pub mod error;
 pub mod forc_pub_client;
+mod md_pre_process;
 pub mod tarball;

--- a/forc-plugins/forc-publish/src/md_pre_process/error.rs
+++ b/forc-plugins/forc-publish/src/md_pre_process/error.rs
@@ -1,0 +1,25 @@
+use regex::Error as RegexError;
+use std::io;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MDPreProcessError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("Regex error: {0}")]
+    Regex(#[from] RegexError),
+
+    #[error("Missing include file: {0}")]
+    MissingInclude(PathBuf),
+
+    #[error("Cycle detected in includes!")]
+    Cycle,
+
+    #[error("Failed to canonicalize path: {0}")]
+    Canonicalize(PathBuf),
+
+    #[error("Other error: {0}")]
+    Other(String),
+}

--- a/forc-plugins/forc-publish/src/md_pre_process/mod.rs
+++ b/forc-plugins/forc-publish/src/md_pre_process/mod.rs
@@ -1,0 +1,293 @@
+pub(crate) mod error;
+
+use error::MDPreProcessError;
+use regex::Regex;
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    fs,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug)]
+struct MarkdownFile {
+    path: PathBuf,
+    includes: HashSet<PathBuf>,
+}
+
+impl MarkdownFile {
+    fn parse<P: AsRef<Path>>(path: P) -> Result<Self, MDPreProcessError> {
+        let path = path
+            .as_ref()
+            .canonicalize()
+            .map_err(|_| MDPreProcessError::Canonicalize(path.as_ref().to_path_buf()))?;
+        let content = fs::read_to_string(&path)?;
+        let dir = path.parent().unwrap_or(Path::new("."));
+        let re = Regex::new(r"\{\{#include\s+([^\}]+)\}\}")?;
+
+        let includes = re
+            .captures_iter(&content)
+            .filter_map(|caps| {
+                let inc_rel = caps[1].trim();
+                let inc_path = dir.join(inc_rel);
+                inc_path.canonicalize().ok()
+            })
+            .collect();
+
+        Ok(MarkdownFile { path, includes })
+    }
+}
+
+#[derive(Debug, Default)]
+struct MarkdownDepGraph {
+    graph: HashMap<PathBuf, HashSet<PathBuf>>,
+}
+
+impl MarkdownDepGraph {
+    fn build(entry: &Path) -> Result<Self, MDPreProcessError> {
+        let mut graph = HashMap::new();
+        let mut visited = HashSet::new();
+        Self::build_recursive(entry, &mut graph, &mut visited)?;
+        Ok(MarkdownDepGraph { graph })
+    }
+
+    fn build_recursive(
+        path: &Path,
+        graph: &mut HashMap<PathBuf, HashSet<PathBuf>>,
+        visited: &mut HashSet<PathBuf>,
+    ) -> Result<(), MDPreProcessError> {
+        let file = MarkdownFile::parse(path)?;
+        if visited.insert(file.path.clone()) {
+            for dep in &file.includes {
+                Self::build_recursive(dep, graph, visited)?;
+            }
+            graph.insert(file.path.clone(), file.includes);
+        }
+        Ok(())
+    }
+
+    fn topological_sort(&self) -> Result<Vec<PathBuf>, MDPreProcessError> {
+        let mut in_degree = HashMap::new();
+        for (node, deps) in &self.graph {
+            in_degree.entry(node.clone()).or_insert(0);
+            for dep in deps {
+                *in_degree.entry(dep.clone()).or_insert(0) += 1;
+            }
+        }
+
+        let mut queue: VecDeque<_> = in_degree
+            .iter()
+            .filter(|&(_, &deg)| deg == 0)
+            .map(|(n, _)| n.clone())
+            .collect();
+
+        let mut sorted = Vec::new();
+        let mut processed = 0;
+
+        while let Some(node) = queue.pop_front() {
+            sorted.push(node.clone());
+            processed += 1;
+            if let Some(deps) = self.graph.get(&node) {
+                for dep in deps {
+                    let deg = in_degree.get_mut(dep).unwrap();
+                    *deg -= 1;
+                    if *deg == 0 {
+                        queue.push_back(dep.clone());
+                    }
+                }
+            }
+        }
+
+        if processed != in_degree.len() {
+            return Err(MDPreProcessError::Cycle);
+        }
+        Ok(sorted)
+    }
+}
+
+#[derive(Debug)]
+struct MarkdownFlattener {
+    file_contents: HashMap<PathBuf, String>,
+}
+
+impl MarkdownFlattener {
+    fn flatten_files(order: &[PathBuf]) -> Result<Self, MDPreProcessError> {
+        let mut file_contents = HashMap::new();
+        let re = Regex::new(r"\{\{#include\s+([^\}]+)\}\}")?;
+
+        // Process leaves first (reverse topological order)
+        for file in order.iter().rev() {
+            let content = fs::read_to_string(file)?;
+            let expanded = Self::expand_includes(&content, file, &file_contents, &re)?;
+            file_contents.insert(file.clone(), expanded);
+        }
+
+        Ok(MarkdownFlattener { file_contents })
+    }
+
+    fn expand_includes(
+        content: &str,
+        file: &Path,
+        file_contents: &HashMap<PathBuf, String>,
+        re: &Regex,
+    ) -> Result<String, MDPreProcessError> {
+        let dir = file.parent().unwrap_or(Path::new("."));
+        let mut result = String::new();
+        let mut last_end = 0;
+
+        for caps in re.captures_iter(content) {
+            let match_range = caps.get(0).unwrap();
+
+            // Add content before this match
+            result.push_str(&content[last_end..match_range.start()]);
+
+            // Process the include
+            let inc_rel = caps[1].trim();
+            let inc_path = dir.join(inc_rel);
+
+            match inc_path.canonicalize() {
+                Ok(canonical_path) => match file_contents.get(&canonical_path) {
+                    Some(included_content) => {
+                        result.push_str(included_content);
+                    }
+                    None => {
+                        return Err(MDPreProcessError::MissingInclude(canonical_path));
+                    }
+                },
+                Err(_) => {
+                    return Err(MDPreProcessError::Canonicalize(inc_path));
+                }
+            }
+
+            last_end = match_range.end();
+        }
+
+        // Add remaining content after last match
+        result.push_str(&content[last_end..]);
+        Ok(result)
+    }
+
+    fn get_file(&self, entry: &Path) -> Option<&str> {
+        self.file_contents
+            .get(&entry.canonicalize().ok()?)
+            .map(|s| s.as_str())
+    }
+}
+
+pub fn flatten_markdown(entry: &Path) -> Result<String, MDPreProcessError> {
+    let dep_graph = MarkdownDepGraph::build(entry)?;
+    let order = dep_graph.topological_sort()?;
+    let flattener = MarkdownFlattener::flatten_files(&order)?;
+    flattener
+        .get_file(entry)
+        .map(|s| s.to_string())
+        .ok_or_else(|| MDPreProcessError::Other("Could not flatten entry file".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn write_file<P: AsRef<Path>>(path: P, content: &str) -> Result<(), MDPreProcessError> {
+        if let Some(parent) = path.as_ref().parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, content)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_flatten_single_file_no_includes() -> Result<(), MDPreProcessError> {
+        let dir = tempdir()?;
+        let readme = dir.path().join("README.md");
+        write_file(&readme, "# Title\n\nHello world!")?;
+
+        let result = flatten_markdown(&readme)?;
+        assert!(result.contains("Hello world!"));
+        assert!(result.contains("# Title"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_flatten_simple_include() -> Result<(), MDPreProcessError> {
+        let dir = tempdir()?;
+        let readme = dir.path().join("README.md");
+        let inc = dir.path().join("inc.md");
+        write_file(&inc, "This is included.")?;
+        write_file(&readme, "# Main\n\n{{#include inc.md}}\n\nEnd.")?;
+
+        let result = flatten_markdown(&readme)?;
+        assert!(result.contains("This is included."));
+        assert!(result.contains("# Main"));
+        assert!(result.contains("End."));
+        Ok(())
+    }
+
+    #[test]
+    fn test_flatten_nested_includes() -> Result<(), MDPreProcessError> {
+        let dir = tempdir()?;
+        let readme = dir.path().join("README.md");
+        let sub = dir.path().join("sub.md");
+        let subsub = dir.path().join("deep.md");
+        write_file(&subsub, "Deep content.")?;
+        write_file(&sub, "Subhead\n\n{{#include deep.md}}")?;
+        write_file(&readme, "# Root\n\n{{#include sub.md}}\n\nEnd.")?;
+
+        let result = flatten_markdown(&readme)?;
+        assert!(result.contains("Deep content."));
+        assert!(result.contains("Subhead"));
+        assert!(result.contains("# Root"));
+        assert!(result.contains("End."));
+        Ok(())
+    }
+
+    #[test]
+    fn test_flatten_multiple_includes() -> Result<(), MDPreProcessError> {
+        let dir = tempdir()?;
+        let readme = dir.path().join("README.md");
+        let a = dir.path().join("a.md");
+        let b = dir.path().join("b.md");
+        write_file(&a, "Alpha!")?;
+        write_file(&b, "Bravo!")?;
+        write_file(
+            &readme,
+            "# Combo\n\n{{#include a.md}}\n\n{{#include b.md}}\nDone.",
+        )?;
+
+        let result = flatten_markdown(&readme)?;
+        assert!(result.contains("Alpha!"));
+        assert!(result.contains("Bravo!"));
+        assert!(result.contains("# Combo"));
+        assert!(result.contains("Done."));
+        Ok(())
+    }
+
+    #[test]
+    fn test_flatten_missing_include() -> Result<(), MDPreProcessError> {
+        let dir = tempdir()?;
+        let readme = dir.path().join("README.md");
+        write_file(&readme, "# Main\n\n{{#include missing.md}}\nEnd.")?;
+
+        let result = flatten_markdown(&readme);
+        assert!(matches!(
+            result,
+            Err(MDPreProcessError::Canonicalize(_)) | Err(MDPreProcessError::MissingInclude(_))
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_cycle_detection() -> Result<(), MDPreProcessError> {
+        let dir = tempdir()?;
+        let a = dir.path().join("a.md");
+        let b = dir.path().join("b.md");
+        write_file(&a, "A here\n{{#include b.md}}")?;
+        write_file(&b, "B here\n{{#include a.md}}")?;
+
+        let result = flatten_markdown(&a);
+        assert!(matches!(result, Err(MDPreProcessError::Cycle)));
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description
closes #7263 

This pull request introduces functionality to preprocess Markdown files by handling `{{#include}}` directives, enabling the inclusion of content from other files. It also integrates this functionality into the `forc-publish` plugin to process `README.md` files during tarball creation. The most important changes include the addition of the Markdown preprocessing module, updates to error handling, and modifications to the tarball creation process.

### Markdown Preprocessing Functionality:
* [`forc-plugins/forc-publish/src/md_pre_process/mod.rs`](diffhunk://#diff-1d065227f3eea45f66a3189882f220de977df2e1b7d1fb2de36d2b9baeb39a7aR1-R293): Added a new module to preprocess Markdown files, including features like dependency graph construction, topological sorting, and content flattening for `{{#include}}` directives. Includes comprehensive tests for edge cases like cycles and missing includes.
* [`forc-plugins/forc-publish/src/md_pre_process/error.rs`](diffhunk://#diff-2cb6edf1287489eb7edd794db5e8b727907a28755871f656cfce877aadd886c2R1-R25): Introduced a dedicated error type `MDPreProcessError` to handle issues like I/O errors, missing include files, and cycles in Markdown dependencies.

### Integration with `forc-publish` Plugin:
* [`forc-plugins/forc-publish/src/lib.rs`](diffhunk://#diff-8b5115a5299062687979272a86a86b573a688194c06c044174da61798ef41574R4): Registered the new `md_pre_process` module in the plugin library.
* [`forc-plugins/forc-publish/src/tarball.rs`](diffhunk://#diff-e3f20cadab3a1cf99fc967e0adc12e908f435a185e1529df9b152388927adf45R29-R31): Updated the tarball creation process to preprocess `README.md` files using the `flatten_markdown` function. Added a warning mechanism to log errors without failing the publish process. [[1]](diffhunk://#diff-e3f20cadab3a1cf99fc967e0adc12e908f435a185e1529df9b152388927adf45R29-R31) [[2]](diffhunk://#diff-e3f20cadab3a1cf99fc967e0adc12e908f435a185e1529df9b152388927adf45R44-R60)

### Error Handling Enhancements:
* [`forc-plugins/forc-publish/src/error.rs`](diffhunk://#diff-d09f44c4690282b827488db75a21e561e1e6fa72d549904db3f5fc4313f4819cR34-R36): Extended the `Error` enum to include `MDPreProcessError` for better error propagation during Markdown preprocessing.

### Dependency Updates:
* [`forc-plugins/forc-publish/Cargo.toml`](diffhunk://#diff-2bd34a7b1fa0f1850ad25c6e080d410b2df98c16b6cd75445a138d04e617311aR29): Added `regex` as a workspace dependency to support Markdown parsing.