### PR TITLE
Add `backtrace` build option

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1579,7 +1579,8 @@ pub fn sway_build_config(
     .with_time_phases(build_profile.time_phases)
     .with_profile(build_profile.profile)
     .with_metrics(build_profile.metrics_outfile.clone())
-    .with_optimization_level(build_profile.optimization_level);
+    .with_optimization_level(build_profile.optimization_level)
+    .with_backtrace(build_profile.backtrace);
     Ok(build_config)
 }
 
@@ -2147,7 +2148,6 @@ fn build_profile_from_opts(
     }
     profile.include_tests |= tests;
     profile.error_on_warnings |= error_on_warnings;
-    // profile.experimental = *experimental;
 
     Ok(profile)
 }

--- a/forc-pkg/tests/sections/Forc.toml
+++ b/forc-pkg/tests/sections/Forc.toml
@@ -20,7 +20,7 @@ include-tests = true
 error-on-warnings = true
 reverse-results = true
 optimization-level = 0
-experimental = { encoding-v1 = true }
+backtrace = "none"
 
 [build-profile.custom_asm]
 print-asm = { virtual = false, allocated = false, final = true }
@@ -30,3 +30,6 @@ print-ir = { initial = true, final = false, modified = true, passes = [
     "dce",
     "sroa",
 ] }
+
+[build-profile.custom_backtrace]
+backtrace = "only_always"

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -341,10 +341,7 @@ impl BuildConfig {
     }
 
     pub fn with_backtrace(self, backtrace: Backtrace) -> Self {
-        Self {
-            backtrace,
-            ..self
-        }
+        Self { backtrace, ..self }
     }
 
     /// Whether or not to include test functions in parsing, type-checking and codegen.

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -182,6 +182,16 @@ impl From<&PrintIr> for PrintPassesOpts {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Backtrace {
+    All,
+    #[default]
+    AllExceptNever,
+    OnlyAlways,
+    None,
+}
+
 /// Configuration for the overall build and compilation process.
 #[derive(Clone)]
 pub struct BuildConfig {
@@ -199,6 +209,10 @@ pub struct BuildConfig {
     pub(crate) print_ir: PrintIr,
     pub(crate) include_tests: bool,
     pub(crate) optimization_level: OptLevel,
+    // TODO: (ABI-BACKTRACING) Remove `#[allow(dead_code)]` once the `backtrace`
+    //       option is used in IR compilation.
+    #[allow(dead_code)]
+    pub(crate) backtrace: Backtrace,
     pub time_phases: bool,
     pub profile: bool,
     pub metrics_outfile: Option<String>,
@@ -251,13 +265,14 @@ impl BuildConfig {
             time_phases: false,
             profile: false,
             metrics_outfile: None,
-            optimization_level: OptLevel::Opt0,
+            optimization_level: OptLevel::default(),
+            backtrace: Backtrace::default(),
             lsp_mode: None,
         }
     }
 
     /// Dummy build config that can be used for testing.
-    /// This is not not valid generally, but asm generation will accept it.
+    /// This is not valid generally, but asm generation will accept it.
     pub fn dummy_for_asm_generation() -> Self {
         Self::root_from_file_name_and_manifest_path(
             PathBuf::from("/"),
@@ -321,6 +336,13 @@ impl BuildConfig {
     pub fn with_optimization_level(self, optimization_level: OptLevel) -> Self {
         Self {
             optimization_level,
+            ..self
+        }
+    }
+
+    pub fn with_backtrace(self, backtrace: Backtrace) -> Self {
+        Self {
+            backtrace,
             ..self
         }
     }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -32,7 +32,9 @@ pub use asm_generation::from_ir::compile_ir_context_to_finalized_asm;
 use asm_generation::FinalizedAsm;
 pub use asm_generation::{CompiledBytecode, FinalizedEntry};
 pub use build_config::DbgGeneration;
-pub use build_config::{Backtrace, BuildConfig, BuildTarget, LspConfig, OptLevel, PrintAsm, PrintIr};
+pub use build_config::{
+    Backtrace, BuildConfig, BuildTarget, LspConfig, OptLevel, PrintAsm, PrintIr,
+};
 use control_flow_analysis::ControlFlowGraph;
 pub use debug_generation::write_dwarf;
 use itertools::Itertools;

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -32,7 +32,7 @@ pub use asm_generation::from_ir::compile_ir_context_to_finalized_asm;
 use asm_generation::FinalizedAsm;
 pub use asm_generation::{CompiledBytecode, FinalizedEntry};
 pub use build_config::DbgGeneration;
-pub use build_config::{BuildConfig, BuildTarget, LspConfig, OptLevel, PrintAsm, PrintIr};
+pub use build_config::{Backtrace, BuildConfig, BuildTarget, LspConfig, OptLevel, PrintAsm, PrintIr};
 use control_flow_analysis::ControlFlowGraph;
 pub use debug_generation::write_dwarf;
 use itertools::Itertools;

--- a/sway-core/src/metadata.rs
+++ b/sway-core/src/metadata.rs
@@ -208,8 +208,8 @@ impl MetadataManager {
         })
     }
 
-    // TODO: (BACKTRACING) Remove `#[allow(dead_code)]` once the backtracing is
-    //       implemented in the IR compilation.
+    // TODO: (ABI-BACKTRACING) Remove `#[allow(dead_code)]` once the backtracing is
+    //       implemented in IR compilation.
     #[allow(dead_code)]
     pub(crate) fn md_to_trace(
         &mut self,


### PR DESCRIPTION
## Description

This PR adds the `backtrace` build option as described in the [ABI Backtracing RFC](https://github.com/FuelLabs/sway-rfcs/blob/ironcev/abi-backtracing/rfcs/0016-abi-backtracing.md).

This is the second step in implementing #7276.

Docs for `backtrace` build option will be added in a separate PR that will document the whole backtracking feature.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.