### PR TITLE
refactor(u128): rename as_u64 to try_as_u64 for naming consistency

### DIFF
--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -303,7 +303,6 @@ impl U128 {
         }
     }
 
-    // TODO: Rename to `try_as_u64` to be consistent with all other downcasts
     /// Safely downcast to `u64` without loss of precision.
     ///
     /// # Additional Information
@@ -321,21 +320,37 @@ impl U128 {
     ///
     /// fn foo() {
     ///     let zero_u128 = U128::from(0, 0);
-    ///     let zero_u64 = zero_u128.as_u64().unwrap();
+    ///     let zero_u64 = zero_u128.try_as_u64().unwrap();
     ///
     ///     assert(zero_u64 == 0);
     ///
     ///     let max_u128 = U128::max();
-    ///     let result = max_u128.as_u64();
+    ///     let result = max_u128.try_as_u64();
     ///
     ///     assert(result.is_err()));
     /// }
     /// ```
-    pub fn as_u64(self) -> Result<u64, U128Error> {
+    pub fn try_as_u64(self) -> Result<u64, U128Error> {
         match self.upper {
             0 => Ok(self.lower),
             _ => Err(U128Error::LossOfPrecision),
         }
+    }
+
+    /// Safely downcast to `u64` without loss of precision.
+    ///
+    /// # Additional Information
+    ///
+    /// If the `U128` is larger than `u64::max()`, an error is returned.
+    /// 
+    /// **Deprecated:** Use `try_as_u64` instead for consistency with other downcast functions.
+    ///
+    /// # Returns
+    ///
+    /// * [Result<u64, U128Error>] - The result of the downcast.
+    #[deprecated(note = "Use `try_as_u64` instead for consistency with other downcast functions")]
+    pub fn as_u64(self) -> Result<u64, U128Error> {
+        self.try_as_u64()
     }
 
     /// Upcasts a `U128` to a `u256`.


### PR DESCRIPTION
## Description

Renamed the as_u64 method to try_as_u64 in u128.sw to maintain consistency with other fallible downcast methods. Deprecated the old as_u64 method with a note pointing to try_as_u64.

Fixes #6954 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
