### PR TITLE
feat: introduce fuel-telemetry macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3014,7 +3023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -3026,8 +3035,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3037,7 +3058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -4034,7 +4055,7 @@ dependencies = [
  "sway-features",
  "sway-types",
  "sway-utils",
- "sysinfo",
+ "sysinfo 0.29.11",
  "tar",
  "tempfile",
  "tokio",
@@ -4109,6 +4130,7 @@ name = "forc-tracing"
 version = "0.69.6"
 dependencies = [
  "ansiterm",
+ "fuel-telemetry",
  "regex",
  "tracing",
  "tracing-subscriber",
@@ -4937,6 +4959,40 @@ name = "fuel-storage"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca73c81646409e9cacac532ff790567d629bc6c512c10ff986536e2335de22c9"
+
+[[package]]
+name = "fuel-telemetry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b6ff154c1f80b4b1a0ca31a4bf1883f48d30eef66ee2c47917b05ab9c44c5c"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "dirs 6.0.0",
+ "fuel-telemetry-macros",
+ "influxdb-line-protocol",
+ "libc",
+ "nix 0.29.0",
+ "regex",
+ "reqwest 0.12.22",
+ "sysinfo 0.33.1",
+ "thiserror 2.0.12",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "uuid 1.17.0",
+]
+
+[[package]]
+name = "fuel-telemetry-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b81c8bba9a5be76590fabfb8741f9027bf593710ecce22d13e1b404c1d4ef692"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "fuel-tx"
@@ -6060,7 +6116,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6215,7 +6271,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration 0.6.1",
  "tokio",
- "windows",
+ "windows 0.53.0",
 ]
 
 [[package]]
@@ -6385,6 +6441,19 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "influxdb-line-protocol"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fa7ee6be451ea0b1912b962c91c8380835e97cf1584a77e18264e908448dcb"
+dependencies = [
+ "bytes",
+ "log",
+ "nom",
+ "smallvec",
+ "snafu",
+]
 
 [[package]]
 name = "inout"
@@ -9318,6 +9387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9462,6 +9542,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.11",
@@ -11081,7 +11162,7 @@ dependencies = [
  "sway-types",
  "sway-utils",
  "swayfmt",
- "sysinfo",
+ "sysinfo 0.29.11",
  "thiserror 1.0.69",
  "toml 0.8.23",
  "tracing",
@@ -11371,6 +11452,20 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -12275,6 +12370,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13134,6 +13241,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13145,22 +13262,21 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result 0.3.4",
- "windows-strings",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13169,9 +13285,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,9 @@ fuel-types = "0.62"
 fuel-tx = "0.62"
 fuel-vm = "0.62"
 
+# Dependencies for Fuel Telemetry
+fuel-telemetry = "0.1"
+
 # Dependencies from the `forc-wallet` repository:
 forc-wallet = "0.15"
 

--- a/forc-plugins/forc-publish/src/main.rs
+++ b/forc-plugins/forc-publish/src/main.rs
@@ -26,7 +26,8 @@ pub struct Opt {
 
 #[tokio::main]
 async fn main() {
-    init_tracing_subscriber(TracingSubscriberOptions::default());
+    let tracing_options = TracingSubscriberOptions::default();
+    init_tracing_subscriber(tracing_options.clone());
 
     if let Err(err) = run().await {
         println!();

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -8,8 +8,13 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+telemetry = ["dep:fuel-telemetry"]
+
 [dependencies]
 ansiterm.workspace = true
+fuel-telemetry = { workspace = true, optional = true }
 regex.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -1,5 +1,8 @@
 //! Utility items shared between forc crates.
 
+#[cfg(feature = "telemetry")]
+pub mod telemetry;
+
 use ansiterm::Colour;
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -7,19 +10,54 @@ use std::{env, io};
 use tracing::{Level, Metadata};
 pub use tracing_subscriber::{
     self,
-    filter::{filter_fn, EnvFilter, LevelFilter},
+    filter::{filter_fn, EnvFilter, FilterExt, LevelFilter},
     fmt::{format::FmtSpan, MakeWriter},
-    layer::SubscriberExt,
+    layer::{Layer, SubscriberExt},
+    registry,
+    util::SubscriberInitExt,
+    Layer as LayerTrait,
 };
 
+#[cfg(feature = "telemetry")]
+use fuel_telemetry::WorkerGuard;
+
 const ACTION_COLUMN_WIDTH: usize = 12;
+
+// Thread-local storage for telemetry WorkerGuard
+#[cfg(feature = "telemetry")]
+thread_local! {
+    static TELEMETRY_GUARD: std::cell::RefCell<Option<WorkerGuard>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Filter to hide telemetry spans from regular application logs
+#[derive(Clone)]
+pub struct HideTelemetryFilter;
+
+impl<S> tracing_subscriber::layer::Filter<S> for HideTelemetryFilter {
+    fn enabled(
+        &self,
+        meta: &Metadata<'_>,
+        _cx: &tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        // Hide spans that are created by telemetry macros
+        !meta.target().starts_with("fuel_telemetry")
+    }
+}
 
 // Global flag to track if JSON output mode is active
 static JSON_MODE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
+// Global flag to track if telemetry is disabled
+static TELEMETRY_DISABLED: AtomicBool = AtomicBool::new(false);
+
 /// Check if JSON mode is currently active
 fn is_json_mode_active() -> bool {
     JSON_MODE_ACTIVE.load(Ordering::SeqCst)
+}
+
+/// Check if telemetry is disabled
+pub fn is_telemetry_disabled() -> bool {
+    TELEMETRY_DISABLED.load(Ordering::SeqCst)
 }
 
 /// Returns the indentation for the action prefix relative to [ACTION_COLUMN_WIDTH].
@@ -181,7 +219,7 @@ pub fn println_red_err(txt: &str) {
 
 const LOG_FILTER: &str = "RUST_LOG";
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum TracingWriter {
     /// Write ERROR and WARN to stderr and everything else to stdout.
     Stdio,
@@ -193,13 +231,14 @@ pub enum TracingWriter {
     Json,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct TracingSubscriberOptions {
     pub verbosity: Option<u8>,
     pub silent: Option<bool>,
     pub log_level: Option<LevelFilter>,
     pub writer_mode: Option<TracingWriter>,
     pub regex_filter: Option<String>,
+    pub disable_telemetry: Option<bool>,
 }
 
 // This allows us to write ERROR and WARN level logs to stderr and everything else to stdout.
@@ -232,7 +271,7 @@ impl<'a> MakeWriter<'a> for TracingWriter {
     }
 }
 
-/// A subscriber built from default `tracing_subscriber::fmt::SubscriberBuilder` such that it would match directly using `println!` throughout the repo.
+/// A subscriber built using tracing_subscriber::registry with optional telemetry layer.
 ///
 /// `RUST_LOG` environment variable can be used to set different minimum level for the subscriber, default is `INFO`.
 pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
@@ -254,7 +293,8 @@ pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
             options
                 .silent
                 .and_then(|silent| silent.then_some(LevelFilter::OFF))
-        });
+        })
+        .unwrap_or(LevelFilter::INFO); // Default to INFO level when nothing else is specified
 
     let writer_mode = match options.writer_mode {
         Some(TracingWriter::Json) => {
@@ -265,19 +305,17 @@ pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
         _ => TracingWriter::Stdio,
     };
 
-    let builder = tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(env_filter)
-        .with_ansi(true)
-        .with_level(false)
-        .with_file(false)
-        .with_line_number(false)
-        .without_time()
-        .with_target(false)
-        .with_writer(writer_mode);
+    // Set the global telemetry disabled flag
+    let disabled = is_telemetry_disabled_from_options(&options);
+    TELEMETRY_DISABLED.store(disabled, Ordering::SeqCst);
+
+    // Build the fmt layer with proper filtering
+    let hide_telemetry_filter = HideTelemetryFilter;
 
     // Use regex to filter logs - if provided; otherwise allow all logs
-    let filter = filter_fn(move |metadata| {
-        if let Some(ref regex_filter) = options.regex_filter {
+    let regex_filter = options.regex_filter.clone();
+    let regex_filter_fn = filter_fn(move |metadata| {
+        if let Some(ref regex_filter) = regex_filter {
             let regex = regex::Regex::new(regex_filter).unwrap();
             regex.is_match(metadata.target())
         } else {
@@ -285,24 +323,98 @@ pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
         }
     });
 
-    match (is_json_mode_active(), level_filter) {
-        (true, Some(level)) => {
-            let subscriber = builder.json().with_max_level(level).finish().with(filter);
-            tracing::subscriber::set_global_default(subscriber).expect("setting subscriber failed");
-        }
-        (true, None) => {
-            let subscriber = builder.json().finish().with(filter);
-            tracing::subscriber::set_global_default(subscriber).expect("setting subscriber failed");
-        }
-        (false, Some(level)) => {
-            let subscriber = builder.with_max_level(level).finish().with(filter);
-            tracing::subscriber::set_global_default(subscriber).expect("setting subscriber failed");
-        }
-        (false, None) => {
-            let subscriber = builder.finish().with(filter);
-            tracing::subscriber::set_global_default(subscriber).expect("setting subscriber failed");
+    // Create filters for non-telemetry mode
+    let composite_filter = env_filter.and(hide_telemetry_filter).and(regex_filter_fn);
+
+    // Initialize registry with explicit layer handling
+    #[cfg(feature = "telemetry")]
+    {
+        if !disabled {
+            if let Ok((telemetry_layer, guard)) = fuel_telemetry::new_with_watchers!() {
+                // Store the WorkerGuard in thread-local storage
+                TELEMETRY_GUARD.with(|g| {
+                    *g.borrow_mut() = Some(guard);
+                });
+
+                // Use the HideTelemetryFilter to prevent telemetry spans from appearing in fmt output
+                let hide_filter = HideTelemetryFilter;
+
+                if is_json_mode_active() {
+                    registry()
+                        .with(telemetry_layer)
+                        .with(
+                            tracing_subscriber::fmt::layer()
+                                .json()
+                                .with_ansi(true)
+                                .with_level(false)
+                                .with_file(false)
+                                .with_line_number(false)
+                                .without_time()
+                                .with_target(false)
+                                .with_writer(writer_mode)
+                                .with_filter(hide_filter)
+                                .with_filter(level_filter),
+                        )
+                        .init();
+                } else {
+                    registry()
+                        .with(telemetry_layer)
+                        .with(
+                            tracing_subscriber::fmt::layer()
+                                .with_ansi(true)
+                                .with_level(false)
+                                .with_file(false)
+                                .with_line_number(false)
+                                .without_time()
+                                .with_target(false)
+                                .with_writer(writer_mode)
+                                .with_filter(hide_filter)
+                                .with_filter(level_filter),
+                        )
+                        .init();
+                }
+                return;
+            }
         }
     }
+
+    // Fallback: no telemetry layer
+    if is_json_mode_active() {
+        registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_ansi(true)
+                    .with_level(false)
+                    .with_file(false)
+                    .with_line_number(false)
+                    .without_time()
+                    .with_target(false)
+                    .with_writer(writer_mode)
+                    .with_filter(composite_filter)
+                    .with_filter(level_filter),
+            )
+            .init();
+    } else {
+        registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(true)
+                    .with_level(false)
+                    .with_file(false)
+                    .with_line_number(false)
+                    .without_time()
+                    .with_target(false)
+                    .with_writer(writer_mode)
+                    .with_filter(composite_filter)
+                    .with_filter(level_filter),
+            )
+            .init();
+    }
+}
+
+fn is_telemetry_disabled_from_options(options: &TracingSubscriberOptions) -> bool {
+    options.disable_telemetry.unwrap_or(false) || env::var("FORC_DISABLE_TELEMETRY").is_ok()
 }
 
 #[cfg(test)]

--- a/forc-tracing/src/telemetry.rs
+++ b/forc-tracing/src/telemetry.rs
@@ -1,0 +1,72 @@
+//! Telemetry utilities for logging to InfluxDB
+
+// When telemetry feature is enabled, re-export all fuel_telemetry macros
+#[cfg(feature = "telemetry")]
+pub use fuel_telemetry::{
+    debug_telemetry, error_telemetry, info_telemetry, span_telemetry, trace_telemetry,
+    warn_telemetry,
+};
+
+// When telemetry feature is disabled, provide stub macros that trigger compile-time errors
+#[cfg(not(feature = "telemetry"))]
+pub use self::disabled_telemetry::*;
+
+#[cfg(not(feature = "telemetry"))]
+mod disabled_telemetry {
+    /// Triggers a compile-time error when telemetry is not enabled
+    #[macro_export]
+    macro_rules! telemetry_disabled {
+        () => {
+            compile_error!(
+                "Telemetry is disabled. Enable the 'telemetry' feature to use telemetry macros."
+            )
+        };
+    }
+
+    #[macro_export]
+    macro_rules! error_telemetry {
+        ($($arg:tt)*) => {
+            telemetry_disabled!()
+        };
+    }
+
+    #[macro_export]
+    macro_rules! warn_telemetry {
+        ($($arg:tt)*) => {
+            telemetry_disabled!()
+        };
+    }
+
+    #[macro_export]
+    macro_rules! info_telemetry {
+        ($($arg:tt)*) => {
+            telemetry_disabled!()
+        };
+    }
+
+    #[macro_export]
+    macro_rules! debug_telemetry {
+        ($($arg:tt)*) => {
+            telemetry_disabled!()
+        };
+    }
+
+    #[macro_export]
+    macro_rules! trace_telemetry {
+        ($($arg:tt)*) => {
+            telemetry_disabled!()
+        };
+    }
+
+    #[macro_export]
+    macro_rules! span_telemetry {
+        ($($arg:tt)*) => {
+            telemetry_disabled!()
+        };
+    }
+
+    pub use {
+        debug_telemetry, error_telemetry, info_telemetry, span_telemetry, trace_telemetry,
+        warn_telemetry,
+    };
+}

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -31,7 +31,7 @@ clap_complete.workspace = true
 clap_complete_fig.workspace = true
 forc-pkg.workspace = true
 forc-test.workspace = true
-forc-tracing.workspace = true
+forc-tracing = { workspace = true, features = ["telemetry"] }
 forc-util = { workspace = true, features = ["tx"] }
 fs_extra.workspace = true
 fuel-abi-types.workspace = true

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -62,6 +62,10 @@ struct Opt {
     /// Set the log level
     #[clap(short='L', long, global = true, value_parser = LevelFilter::from_str)]
     log_level: Option<LevelFilter>,
+
+    /// Disable telemetry
+    #[clap(long, global = true)]
+    disable_telemetry: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -127,10 +131,11 @@ pub async fn run_cli() -> ForcResult<()> {
         verbosity: Some(opt.verbose),
         silent: Some(opt.silent),
         log_level: opt.log_level,
+        disable_telemetry: Some(opt.disable_telemetry),
         ..Default::default()
     };
 
-    init_tracing_subscriber(tracing_options);
+    init_tracing_subscriber(tracing_options.clone());
 
     match opt.command {
         Forc::Add(command) => add::exec(command),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat/stdout.snap
@@ -2994,9 +2994,6 @@ output:
    Compiling library std (test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-assert)
    Compiling script array_repeat (test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat)
     Finished debug [unoptimized + fuel] target(s) [7.064 KB] in ???
-    script array_repeat
-      Bytecode size: 7064 bytes (7.064 KB)
-      Bytecode hash: 0x69ce3ea2c40196fda9c534574731a978c37ff95d2eedacfed5f1c9c8c1611414
      Running 1 test, filtered 0 tests
 
 tested -- array_repeat


### PR DESCRIPTION
## Description

# Add telemetry opt-out support to forc-tracing

This adds `fuel-telemetry` to `forc-tracing` with **opt-out functionality** for upstream tools like fuelup.

## Usage

First, add it to the `forc-tracing` dependency:

```toml
[dependencies]
forc-tracing = { version = "0.47", features = ["telemetry"] }
```

Then use the `telemetry::*` glob, followed by the usual `tracing` macros, but with a `_telemetry` postfix:

```rust
use forc_tracing::{
    init_tracing_subscriber, println_green, println_red, println_yellow, telemetry::*,
};

fn main() {
    init_tracing_subscriber(Default::default());

    println_red("Stop");
    println_yellow("Slow down");
    println_green("Go");

    error_telemetry!("Error message for InfluxDB");
    warn_telemetry!("Warn message for InfluxDB");
    info_telemetry!("Info message for InfluxDB");
    debug_telemetry!("Debug message for InfluxDB");
    trace_telemetry!("Trace message for InfluxDB");
}
```

This will output the following (note `DEBUG` and `TRACE` messages are filtered out because of `RUST_LOG=info`):

```bash
> RUST_LOG=info ./target/debug/example
Stop
Slow down
Go
```

We can then peek into telemetry files like the following:

```bash
> cat ~/.fuelup/tmp/*.telemetry.* | while read line; do echo "$line" | base64 -d; echo; done
2025-03-06T19:53:24.923452000Z ERROR aarch64-apple-darwin:Darwin:23.6.0 forc-tracing:0.66.8:src/main.rs 0e3480f5-faab-48b8-a935-21ce90a6f028 auto: Error message for InfluxDB
2025-03-06T19:53:24.925348000Z  WARN aarch64-apple-darwin:Darwin:23.6.0 forc-tracing:0.66.8:src/main.rs 0e3480f5-faab-48b8-a935-21ce90a6f028 auto: Warn message for InfluxDB
2025-03-06T19:53:24.925434000Z  INFO aarch64-apple-darwin:Darwin:23.6.0 forc-tracing:0.66.8:src/main.rs 0e3480f5-faab-48b8-a935-21ce90a6f028 auto: Info message for InfluxDB
2025-03-06T19:53:31.335690000Z  INFO aarch64-apple-darwin:Darwin:23.6.0 systeminfo_watcher:0.1.0:src/systeminfo_watcher.rs ec63b355-7862-47db-9ae3-de0cfcc094c8 poll_systeminfo: cpu_arch="arm64" cpu_brand="Apple M2 Pro" cpu_count=10 global_cpu_usage=15.85 total_memory=34359738368 free_memory=23388143616 free_memory_percentage=0.68 os_long_name="macOS 14.6.1 Sonoma" kernel_version="23.6.0" uptime=2482559 vm="" ci="" load_average_1m=4.52 load_average_5m=4.17 load_average_15m=3.86
```

## New: Telemetry Opt-Out Support

This PR also adds opt-out functionality for telemetry, allowing upstream tools like fuelup to disable telemetry collection:

**Changes:**
- Added `--disable-telemetry` CLI flag to main forc binary
- Added `FORC_DISABLE_TELEMETRY` environment variable support
- Updated all telemetry macros to respect the disable flag
- Added `init_telemetry()` function for proper initialization

**Opt-out Usage:**

```bash
# Disable via CLI flag
forc --disable-telemetry build

# Disable via environment variable  
FORC_DISABLE_TELEMETRY=1 forc build

# For upstream tools like fuelup
export FORC_DISABLE_TELEMETRY=1
fuelup toolchain install latest
```

**Code example with opt-out:**

```rust
use forc_tracing::{init_telemetry, init_tracing_subscriber, TracingSubscriberOptions};

fn main() {
    let options = TracingSubscriberOptions {
        disable_telemetry: Some(true),
        ..Default::default()
    };
    
    init_tracing_subscriber(options.clone());
    init_telemetry(&options);
    
    // Telemetry macros will now be no-ops when disabled
    error_telemetry!("This won't be sent to telemetry if disabled");
}
```

The implementation ensures telemetry is opt-out by default but can be easily disabled through either CLI flags or environment variables, making it suitable for upstream tool integration.