### PR TITLE
Add parallel processing to `forc-doc` using rayon to improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
  "include_dir",
  "minifier",
  "opener",
+ "rayon",
  "serde",
  "serde_json",
  "sway-ast",

--- a/forc-plugins/forc-doc/Cargo.toml
+++ b/forc-plugins/forc-doc/Cargo.toml
@@ -19,6 +19,7 @@ horrorshow.workspace = true
 include_dir.workspace = true
 minifier.workspace = true
 opener.workspace = true
+rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sway-ast.workspace = true

--- a/forc-plugins/forc-doc/src/doc/descriptor.rs
+++ b/forc-plugins/forc-doc/src/doc/descriptor.rs
@@ -27,7 +27,7 @@ trait RequiredMethods {
 impl RequiredMethods for Vec<DeclRefTraitFn> {
     fn to_methods(&self, decl_engine: &DeclEngine) -> Vec<TyTraitFn> {
         self.iter()
-            .map(|decl_ref| (*decl_engine.get_trait_fn(decl_ref)).clone())
+            .map(|decl_ref| decl_engine.get_trait_fn(decl_ref).as_ref().clone())
             .collect()
     }
 }
@@ -371,7 +371,7 @@ impl Descriptor {
                     module_info,
                     ty: DocumentableType::Primitive(type_info.clone()),
                     item_name: item_name.clone(),
-                    code_str: item_name.clone().to_string(),
+                    code_str: item_name.to_string(),
                     attrs_opt: attrs_opt.clone(),
                     item_context: Default::default(),
                 },

--- a/forc-plugins/forc-doc/src/doc/mod.rs
+++ b/forc-plugins/forc-doc/src/doc/mod.rs
@@ -94,7 +94,7 @@ impl Documentation {
                 }
             })
             .collect();
-        
+
         // Add unique primitive docs
         for doc in primitive_docs {
             if !docs.contains(&doc) {
@@ -168,7 +168,8 @@ impl Documentation {
         document_private_items: bool,
         experimental: ExperimentalFeatures,
     ) -> Result<()> {
-        let results: Result<Vec<_>, anyhow::Error> = ty_module.all_nodes
+        let results: Result<Vec<_>, anyhow::Error> = ty_module
+            .all_nodes
             .par_iter()
             .filter_map(|ast_node| {
                 if let TyAstNodeContent::Declaration(ref decl) = ast_node.content {

--- a/forc-plugins/forc-doc/src/render/item/components.rs
+++ b/forc-plugins/forc-doc/src/render/item/components.rs
@@ -40,11 +40,16 @@ impl Renderable for ItemHeader {
             item_name,
         } = self;
 
-        let favicon = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{SWAY_LOGO_FILE}"));
-        let normalize = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{NORMALIZE_CSS_FILE}"));
-        let swaydoc = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{SWAYDOC_CSS_FILE}"));
-        let ayu = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{AYU_CSS_FILE}"));
-        let ayu_hjs = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{AYU_MIN_CSS_FILE}"));
+        let favicon = module_info
+            .to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{SWAY_LOGO_FILE}"));
+        let normalize = module_info
+            .to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{NORMALIZE_CSS_FILE}"));
+        let swaydoc = module_info
+            .to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{SWAYDOC_CSS_FILE}"));
+        let ayu =
+            module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{AYU_CSS_FILE}"));
+        let ayu_hjs = module_info
+            .to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{AYU_MIN_CSS_FILE}"));
 
         Ok(box_html! {
             head {

--- a/forc-plugins/forc-doc/src/render/item/components.rs
+++ b/forc-plugins/forc-doc/src/render/item/components.rs
@@ -16,6 +16,13 @@ use sway_types::BaseIdent;
 
 use super::documentable_type::DocumentableType;
 
+// Asset file names to avoid repeated string formatting
+const SWAY_LOGO_FILE: &str = "sway-logo.svg";
+const NORMALIZE_CSS_FILE: &str = "normalize.css";
+const SWAYDOC_CSS_FILE: &str = "swaydoc.css";
+const AYU_CSS_FILE: &str = "ayu.css";
+const AYU_MIN_CSS_FILE: &str = "ayu.min.css";
+
 /// All necessary components to render the header portion of
 /// the item html doc.
 #[derive(Clone, Debug)]
@@ -33,15 +40,11 @@ impl Renderable for ItemHeader {
             item_name,
         } = self;
 
-        let favicon =
-            module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/sway-logo.svg"));
-        let normalize =
-            module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/normalize.css"));
-        let swaydoc =
-            module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/swaydoc.css"));
-        let ayu = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/ayu.css"));
-        let ayu_hjs =
-            module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/ayu.min.css"));
+        let favicon = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{SWAY_LOGO_FILE}"));
+        let normalize = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{NORMALIZE_CSS_FILE}"));
+        let swaydoc = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{SWAYDOC_CSS_FILE}"));
+        let ayu = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{AYU_CSS_FILE}"));
+        let ayu_hjs = module_info.to_html_shorthand_path_string(&format!("{ASSETS_DIR_NAME}/{AYU_MIN_CSS_FILE}"));
 
         Ok(box_html! {
             head {

--- a/forc-plugins/forc-doc/src/render/item/type_anchor.rs
+++ b/forc-plugins/forc-doc/src/render/item/type_anchor.rs
@@ -67,16 +67,16 @@ pub(crate) fn render_type_anchor(
             let enum_decl = render_plan.engines.de().get_enum(&decl_id);
             if !render_plan.document_private_items && enum_decl.visibility.is_private() {
                 Ok(box_html! {
-                    : enum_decl.name().clone().as_str();
+                    : enum_decl.name().as_str();
                 })
             } else {
                 let module_info = ModuleInfo::from_call_path(&enum_decl.call_path);
-                let file_name = format!("enum.{}.html", enum_decl.name().clone().as_str());
+                let file_name = format!("enum.{}.html", enum_decl.name().as_str());
                 let href =
                     module_info.file_path_from_location(&file_name, current_module_info, false)?;
                 Ok(box_html! {
                     a(class="enum", href=href) {
-                        : enum_decl.name().clone().as_str();
+                        : enum_decl.name().as_str();
                     }
                 })
             }
@@ -85,16 +85,16 @@ pub(crate) fn render_type_anchor(
             let struct_decl = render_plan.engines.de().get_struct(&decl_id);
             if !render_plan.document_private_items && struct_decl.visibility.is_private() {
                 Ok(box_html! {
-                    : struct_decl.name().clone().as_str();
+                    : struct_decl.name().as_str();
                 })
             } else {
                 let module_info = ModuleInfo::from_call_path(&struct_decl.call_path);
-                let file_name = format!("struct.{}.html", struct_decl.name().clone().as_str());
+                let file_name = format!("struct.{}.html", struct_decl.name().as_str());
                 let href =
                     module_info.file_path_from_location(&file_name, current_module_info, false)?;
                 Ok(box_html! {
                     a(class="struct", href=href) {
-                        : struct_decl.name().clone().as_str();
+                        : struct_decl.name().as_str();
                     }
                 })
             }

--- a/forc-plugins/forc-doc/src/render/mod.rs
+++ b/forc-plugins/forc-doc/src/render/mod.rs
@@ -96,7 +96,8 @@ impl RenderedDocumentation {
             links: BTreeMap::default(),
         };
         // Parallel document rendering
-        let rendered_results: Result<Vec<RenderResult>, anyhow::Error> = raw_docs.0
+        let rendered_results: Result<Vec<RenderResult>, anyhow::Error> = raw_docs
+            .0
             .par_iter()
             .map(|doc| {
                 let rendered_doc = RenderedDocument::from_doc(doc, render_plan.clone())?;
@@ -105,24 +106,24 @@ impl RenderedDocumentation {
                     style: DocStyle::AllDoc(program_kind.as_title_str().to_string()),
                     links: BTreeMap::default(),
                 };
-                
+
                 populate_decls(doc, &mut local_module_map);
                 populate_modules(doc, &mut local_module_map);
                 populate_doc_links(doc, &mut local_all_docs.links);
-                
+
                 Ok((rendered_doc, local_module_map, local_all_docs))
             })
             .collect();
-                
+
         // Merge results sequentially
         let mut module_map = ModuleMap::new();
         for (rendered_doc, local_module_map, local_all_docs) in rendered_results? {
             rendered_docs.0.push(rendered_doc);
-            
+
             for (key, value) in local_module_map {
                 module_map.entry(key).or_default().extend(value);
             }
-            
+
             all_docs.links.extend(local_all_docs.links);
         }
 


### PR DESCRIPTION
## Description
Key changes:
  - Parallelize document rendering and link generation
  - Add type aliases for complex nested types (`DocLinkMap`, `ModuleMap`, `RenderResult`)
  - Remove unnecessary wrapper functions and clones

The parallel processing maintains insertion order through sequential merging, ensuring identical documentation output.

Not sure why the codspeed report isn't showing this below but when I run `cargo bench` locally i'm seeing these results.

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| build_std_lib_docs | 70.069 ms | 43.227 ms | **43.2% faster** |

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
