### PR TITLE
docs: fix broken sway-libs GitHub link to use official documentation URL

### DIFF
--- a/docs/book/src/sway-program-types/libraries.md
+++ b/docs/book/src/sway-program-types/libraries.md
@@ -192,11 +192,11 @@ Some Sway Libraries to try out:
 
 - [Binary Merkle Proof](https://docs.fuel.network/docs/sway-libs/merkle/)
 - [Signed Integers](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/signed_integers)
-- [Ownership](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/ownership)
+- [Ownership](https://fuellabs.github.io/sway-libs/book/ownership/index.html)
 
 ### Example
 
-You can import and use a Sway Library such as the [Ownership](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/ownership) library just like any other external library.
+You can import and use a Sway Library such as the [Ownership](https://fuellabs.github.io/sway-libs/book/ownership/index.html) library just like any other external library.
 
 ```sway
 use ownership::Ownership;


### PR DESCRIPTION
- Replace https://github.com/FuelLabs/sway-libs/tree/master/libs/src/ownership 
  with https://fuellabs.github.io/sway-libs/book/ownership/index.html