### PR TITLE
bugfix: forc-call list-functions and script output

### DIFF
--- a/forc-plugins/forc-client/src/op/call/list_functions.rs
+++ b/forc-plugins/forc-client/src/op/call/list_functions.rs
@@ -1,11 +1,6 @@
-use crate::{
-    cmd::call::AbiSource,
-    op::call::{
-        parser::{
-            get_default_value, param_to_function_arg, param_type_val_to_token, token_to_string,
-        },
-        Abi,
-    },
+use crate::op::call::{
+    parser::{get_default_value, param_to_function_arg, param_type_val_to_token, token_to_string},
+    Abi,
 };
 use anyhow::{anyhow, Result};
 use fuels_core::types::{param_types::ParamType, ContractId};
@@ -134,23 +129,11 @@ fn list_functions_for_single_contract<W: Write>(
             "{}({}) -> {}",
             painted_name, func_args_types, return_type
         )?;
-        match &abi.source {
-            AbiSource::String(s) => {
-                // json string in quotes for shell
-                writeln!(
-                    writer,
-                    "  forc call \\\n      --abi \"{}\" \\\n      {} \\\n      {} {}\n",
-                    s, contract_id, func.name, func_args_inputs,
-                )?;
-            }
-            _ => {
-                writeln!(
-                    writer,
-                    "  forc call \\\n      --abi {} \\\n      {} \\\n      {} {}\n",
-                    abi.source, contract_id, func.name, func_args_inputs,
-                )?;
-            }
-        }
+        writeln!(
+            writer,
+            "  forc call \\\n      --abi {} \\\n      {} \\\n      {} {}\n",
+            abi.source, contract_id, func.name, func_args_inputs,
+        )?;
     }
 
     Ok(())

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -44,7 +44,7 @@ pub struct CallResponse {
     pub receipts: Vec<Receipt>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub trace_events: Vec<trace::TraceEvent>,
-    #[serde(rename = "script", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "Script", skip_serializing_if = "Option::is_none")]
     pub script_json: Option<serde_json::Value>,
 }
 

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -207,6 +207,14 @@ pub struct Abi {
     type_lookup: HashMap<usize, UnifiedTypeDeclaration>,
 }
 
+impl Abi {
+    /// Set the source of the ABI after creation
+    pub fn with_source(mut self, source: AbiSource) -> Self {
+        self.source = source;
+        self
+    }
+}
+
 impl FromStr for Abi {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -326,8 +334,9 @@ pub async fn create_abi_map(
 ) -> anyhow::Result<HashMap<ContractId, Abi>> {
     // Load main ABI
     let main_abi_str = load_abi(main_abi).await?;
-    let main_abi =
-        Abi::from_str(&main_abi_str).map_err(|e| anyhow!("Failed to parse main ABI: {}", e))?;
+    let main_abi = Abi::from_str(&main_abi_str)
+        .map_err(|e| anyhow!("Failed to parse main ABI: {}", e))?
+        .with_source(main_abi.clone());
 
     // Start with main contract ABI
     let mut abi_map = HashMap::from([(main_contract_id, main_abi)]);
@@ -338,7 +347,7 @@ pub async fn create_abi_map(
             match load_abi(&abi_path).await {
                 Ok(abi_str) => match Abi::from_str(&abi_str) {
                     Ok(additional_abi) => {
-                        abi_map.insert(contract_id, additional_abi);
+                        abi_map.insert(contract_id, additional_abi.with_source(abi_path.clone()));
                         forc_tracing::println_action_green(
                             "Loaded additional ABI for contract",
                             &format!("0x{}", contract_id),


### PR DESCRIPTION
## Description

This pull request introduces improvements to ABI (Application Binary Interface) handling in the `forc-client` plugin, focusing on better tracking of ABI sources and minor output consistency fixes.
- The `--list-functions` inlined the full string ABI instead of what is provided in the call to the CLI; this results in very large outputs for `--list-functions` call
- A fix for the `CallResponse` so that the JSON is `Script` instead of `script` - the capital `Script` is required if we want to pass the response into `forc-debug`

Addresses: https://github.com/FuelLabs/sway/issues/7311

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
