### PR TITLE
Fix incorrect comment reference to `SourcePinned::from_str`

### DIFF
--- a/forc-pkg/src/source/mod.rs
+++ b/forc-pkg/src/source/mod.rs
@@ -156,7 +156,7 @@ pub struct DisplayCompiling<'a, T> {
     manifest_dir: &'a Path,
 }
 
-/// Error returned upon failed parsing of `SourcePinned::from_str`.
+/// Error returned upon failed parsing of `Pinned::from_str`.
 #[derive(Clone, Debug)]
 pub struct PinnedParseError;
 


### PR DESCRIPTION
## Description

This PR fixes a minor documentation issue:

- Corrected the comment above the `PinnedParseError` struct to reference the correct function `Pinned::from_str` instead of the non-existent `SourcePinned::from_str`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
