### PR TITLE
feat: forc-call debugger integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,7 @@ dependencies = [
  "dialoguer",
  "either",
  "forc",
+ "forc-debug",
  "forc-pkg",
  "forc-tracing 0.69.1",
  "forc-tx",

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -62,6 +62,7 @@
 - [Debugging](./debugging/index.md)
   - [Debugging with CLI](./debugging/debugging_with_cli.md)
   - [Debugging with IDE](./debugging/debugging_with_ide.md)
+  - [Debugging with Forc Call](./debugging/debugging_with_forc_call.md)
 - [Sway LSP](./lsp/index.md)
   - [Installation](./lsp/installation.md)
   - [Features](./lsp/features.md)

--- a/docs/book/src/debugging/debugging_with_forc_call.md
+++ b/docs/book/src/debugging/debugging_with_forc_call.md
@@ -1,0 +1,75 @@
+# Debugging with Forc Call
+
+The `forc call` command includes interactive debugging capabilities through the `--debug` flag, enabling developers to debug contract function calls step-by-step after transaction execution.
+
+## Overview
+
+When you add the `--debug` flag to any `forc call` command, it will:
+
+1. Execute the contract function call as normal
+2. Automatically launch an interactive debugging session
+3. Allow you to step through the execution, inspect values, and set breakpoints
+4. Provide full access to the `forc-debug` interface
+
+This integration seamlessly combines contract interaction with debugging, making it easy to understand what happens during contract execution.
+
+## Basic Usage
+
+Simply add the `--debug` flag to any existing `forc call` command:
+
+```bash
+forc call <CONTRACT_ID> \
+    --abi <ABI_PATH> \
+    <FUNCTION_NAME> [ARGS...] \
+    --debug
+```
+
+## Example: Debugging a Contract Call
+
+Let's say you have a contract with a function that performs some calculations:
+
+```sway
+contract;
+
+abi Calculator {
+    fn factorial(n: u64) -> u64;
+}
+
+impl Calculator for Contract {
+    fn factorial(n: u64) -> u64 {
+        let mut result = 1;
+        let mut counter = 0;
+        while counter < n {
+            counter = counter + 1;
+            result = result * counter;
+        }
+        result
+    }
+}
+```
+
+### Debugging the Factorial Function
+
+```bash
+forc call 0x1234567890abcdef1234567890abcdef12345678 \
+    --abi ./out/debug/calculator-abi.json \
+    factorial 5 \
+    --debug
+```
+
+This command will:
+
+1. Execute `factorial(5)` on the deployed contract
+2. Show the transaction result (return value: 120)
+3. Launch the interactive debugger with the transaction data pre-loaded
+
+### Interactive Debugging Session
+
+Once the debugger launches, you'll see the pre-buffered debugger prompt to start the transaction:
+
+```text
+Welcome to the Sway Debugger! Type "help" for a list of commands.
+>> start_tx /var/folders/xz/5djvk4596k5c1fj2prcd0d880000gn/T/.tmpexrnFE.json /var/folders/xz/5djvk4596k5c1fj2prcd0d880000gn/T/.tmpuaPRtF.json
+```
+
+You can now use all the [standard debugging commands](./debugging_with_cli.md#using-the-debugger).

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -39,6 +39,7 @@ devault.workspace = true
 dialoguer.workspace = true
 either.workspace = true
 forc.workspace = true
+forc-debug.workspace = true
 forc-pkg.workspace = true
 forc-tracing.workspace = true
 forc-tx.workspace = true

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -326,6 +326,14 @@ forc call 0x0dcba78d7b09a1f77353f51367afd8b8ab94b5b2bb6c9437d9ba9eea47dede97 \
     --amount 100 \
     --mode live
 ```
+
+### Call a contract with interactive debugger after transaction
+```sh
+forc call 0x0dcba78d7b09a1f77353f51367afd8b8ab94b5b2bb6c9437d9ba9eea47dede97 \
+    --abi ./contract-abi.json \
+    get_balance 0x0087675439e10a8351b1d5e4cf9d0ea6da77675623ff6b16470b5e3c58998423 \
+    --debug
+```
 "#)]
 pub struct Command {
     /// The contract ID to call
@@ -409,6 +417,10 @@ pub struct Command {
     /// - `-v=2`: Additionally print receipts and script json
     #[clap(short = 'v', action = clap::ArgAction::Count, help_heading = "OUTPUT")]
     pub verbosity: u8,
+
+    /// Start interactive debugger after transaction execution
+    #[clap(long, help_heading = "DEBUG")]
+    pub debug: bool,
 }
 
 impl Command {

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -419,7 +419,7 @@ pub struct Command {
     pub verbosity: u8,
 
     /// Start interactive debugger after transaction execution
-    #[clap(long, help_heading = "DEBUG")]
+    #[clap(long, short = 'd', help_heading = "DEBUG")]
     pub debug: bool,
 }
 

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -436,7 +436,7 @@ async fn start_debug_session(
     );
 
     // Start the interactive CLI session with the prepared command
-    let mut cli = forc_debug::cli::Cli::new().map_err(|e| anyhow!("Failed to create CLI: {e}"))?;
+    let mut cli = forc_debug::cli::Cli::new().map_err(|e| anyhow!("Failed to create debug CLI interface: {e}"))?;
     cli.run(&mut debugger, Some(tx_cmd))
         .await
         .map_err(|e| anyhow!("Interactive CLI failed: {e}"))?;

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -439,7 +439,7 @@ async fn start_debug_session(
     let mut cli = forc_debug::cli::Cli::new().map_err(|e| anyhow!("Failed to create debug CLI interface: {e}"))?;
     cli.run(&mut debugger, Some(tx_cmd))
         .await
-        .map_err(|e| anyhow!("Interactive CLI failed: {e}"))?;
+        .map_err(|e| anyhow!("Interactive debugging session failed: {e}"))?;
 
     Ok(())
 }

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -257,11 +257,11 @@ pub async fn call_function(
         }
     };
 
-    let fuel_tx::Transaction::Script(script) = tx.into() else {
+    let tx: fuel_tx::Transaction = tx.into();
+    let fuel_tx::Transaction::Script(script) = &tx else {
         bail!("Transaction is not a script");
     };
-
-    let script_json = serde_json::to_value(&script)
+    let script_json = serde_json::to_value(script)
         .map_err(|e| anyhow!("Failed to convert script to JSON: {e}"))?;
 
     // Parse the result based on output format
@@ -293,7 +293,7 @@ pub async fn call_function(
             wallet.provider(),
             &mode,
             &consensus_params,
-            &script,
+            script,
             tx_execution.result.receipts(),
             storage_reads,
             &abi_map,
@@ -332,6 +332,11 @@ pub async fn call_function(
         &mode,
         &node,
     );
+
+    // Start interactive debugger if requested
+    if cmd.debug {
+        start_debug_session(&client, &tx, abi).await?;
+    }
 
     Ok(CallResponse {
         tx_hash: tx_execution.id.to_string(),
@@ -397,6 +402,48 @@ fn prepare_contract_call_data(
     Ok((encoded_data, output_param))
 }
 
+/// Starts an interactive debugging session with the given transaction and ABI
+async fn start_debug_session(
+    fuel_client: &FuelClient,
+    tx: &fuel_tx::Transaction,
+    abi: &super::Abi,
+) -> Result<()> {
+    // Create debugger instance from the existing fuel client
+    let mut debugger = forc_debug::debugger::Debugger::from_client(fuel_client.clone())
+        .await
+        .map_err(|e| anyhow!("Failed to create debugger: {e}"))?;
+
+    // Create temporary files for transaction and ABI (auto-cleaned when dropped)
+    let mut tx_file = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .map_err(|e| anyhow!("Failed to create temp transaction file: {e}"))?;
+    serde_json::to_writer_pretty(&mut tx_file, tx)
+        .map_err(|e| anyhow!("Failed to write transaction to temp file: {e}"))?;
+
+    let mut abi_file = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .map_err(|e| anyhow!("Failed to create temp ABI file: {e}"))?;
+    serde_json::to_writer_pretty(&mut abi_file, &abi.program)
+        .map_err(|e| anyhow!("Failed to write ABI to temp file: {e}"))?;
+
+    // Prepare the start_tx command string for the CLI
+    let tx_cmd = format!(
+        "start_tx {} {}",
+        tx_file.path().to_string_lossy(),
+        abi_file.path().to_string_lossy()
+    );
+
+    // Start the interactive CLI session with the prepared command
+    let mut cli = forc_debug::cli::Cli::new().map_err(|e| anyhow!("Failed to create CLI: {e}"))?;
+    cli.run(&mut debugger, Some(tx_cmd))
+        .await
+        .map_err(|e| anyhow!("Interactive CLI failed: {e}"))?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -432,6 +479,7 @@ pub mod tests {
             output: cmd::call::OutputFormat::Raw,
             list_functions: false,
             verbosity: 0,
+            debug: false,
         }
     }
 

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -436,7 +436,8 @@ async fn start_debug_session(
     );
 
     // Start the interactive CLI session with the prepared command
-    let mut cli = forc_debug::cli::Cli::new().map_err(|e| anyhow!("Failed to create debug CLI interface: {e}"))?;
+    let mut cli = forc_debug::cli::Cli::new()
+        .map_err(|e| anyhow!("Failed to create debug CLI interface: {e}"))?;
     cli.run(&mut debugger, Some(tx_cmd))
         .await
         .map_err(|e| anyhow!("Interactive debugging session failed: {e}"))?;

--- a/forc-plugins/forc-mcp/src/forc_call/mod.rs
+++ b/forc-plugins/forc-mcp/src/forc_call/mod.rs
@@ -558,6 +558,7 @@ fn build_call_command(
         external_contracts: None,
         output: OutputFormat::Json,
         verbosity,
+        debug: false,
     })
 }
 
@@ -599,6 +600,7 @@ fn build_list_command(contract_id: &str, abi: &str) -> anyhow::Result<forc_clien
         external_contracts: None,
         output: OutputFormat::Default,
         verbosity: 0,
+        debug: false,
     })
 }
 
@@ -657,6 +659,7 @@ fn build_transfer_command(
         external_contracts: None,
         output: OutputFormat::Json,
         verbosity,
+        debug: false,
     })
 }
 


### PR DESCRIPTION
## Description

This PR adds interactive debugging capabilities to the `forc call` command, enabling developers to debug contract function calls step-by-step after transaction execution.
The `--debug` flag is added to the `forc call` command that launches an interactive debugging session after transaction execution.
The integration automatically handles transaction/ABI data and launches `forc-debug` for step-by-step debugging.

### Implementation

- New `--debug` flag in `forc call` command
- `start_debug_session()` function that creates temporary transaction/ABI files and launches the debugger
- Integration with existing `forc-debug` functionality via the `start_tx` command

### Usage

```bash
forc call 0x0dcba78d7b09a1f77353f51367afd8b8ab94b5b2bb6c9437d9ba9eea47dede97 \
    --abi ./contract-abi.json \
    get_balance 0x0087675439e10a8351b1d5e4cf9d0ea6da77675623ff6b16470b5e3c58998423 \
    --debug
```

This drops users into an interactive debugging session to step through execution, inspect values, and set breakpoints.

### Notes

- No breaking changes - feature is additive with optional flag
- Temporary files are automatically cleaned up using `tempfile` crate
- Zero overhead when `--debug` flag is not used

<img width="1070" height="298" alt="image" src="https://github.com/user-attachments/assets/f48e8c7f-063b-4869-b690-810ddb7143cd" />

Addresses https://github.com/FuelLabs/sway/issues/7321.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
