### PR TITLE
Replace asm type conversion with __transmute

### DIFF
--- a/forc-plugins/forc-client/test/data/big_contract/src/main.sw
+++ b/forc-plugins/forc-client/test/data/big_contract/src/main.sw
@@ -198,12 +198,8 @@ impl MyContract for Contract {
         assert(sha256_str_array(STR_4) == sha256("abcd"));
 
         // Assert address do not change
-        let addr_1 = asm(addr: &BOOL) {
-            addr: u64
-        };
-        let addr_2 = asm(addr: &BOOL) {
-            addr: u64
-        };
+        let addr_1 = __transmute::<&bool, u64>(&BOOL);
+        let addr_2 = __transmute::<&bool, u64>(&BOOL);
         assert(addr_1 == addr_2);
         true
     }

--- a/sway-lib-std/src/ops.sw
+++ b/sway-lib-std/src/ops.sw
@@ -102,9 +102,9 @@ impl Add for u16 {
 
 impl Add for u8 {
     fn add(self, other: Self) -> Self {
-        let res_u64 = __add(u8_as_u64(self), u8_as_u64(other));
+        let res_u64 = __add(__transmute::<u8, u64>(self), __transmute::<u8, u64>(other));
 
-        let max_u8_u64 = u8_as_u64(Self::max());
+        let max_u8_u64 = __transmute::<u8, u64>(Self::max());
 
         if __gt(res_u64, max_u8_u64) {
             if panic_on_overflow_enabled() {
@@ -112,10 +112,10 @@ impl Add for u8 {
             } else {
                 // overflow enabled
                 // res % (Self::max() + 1)
-                u64_as_u8(__mod(res_u64, __add(max_u8_u64, 1)))
+                __transmute::<u64, u8>(__mod(res_u64, __add(max_u8_u64, 1)))
             }
         } else {
-            u64_as_u8(res_u64)
+            __transmute::<u64, u8>(res_u64)
         }
     }
 }
@@ -214,9 +214,9 @@ impl Subtract for u16 {
 
 impl Subtract for u8 {
     fn subtract(self, other: Self) -> Self {
-        let res_u64 = __sub(u8_as_u64(self), u8_as_u64(other));
+        let res_u64 = __sub(__transmute::<u8, u64>(self), __transmute::<u8, u64>(other));
 
-        let max_u8_u64 = u8_as_u64(Self::max());
+        let max_u8_u64 = __transmute::<u8, u64>(Self::max());
 
         if __gt(res_u64, max_u8_u64) {
             if panic_on_overflow_enabled() {
@@ -224,10 +224,10 @@ impl Subtract for u8 {
             } else {
                 // overflow enabled
                 // res % (Self::max() + 1)
-                u64_as_u8(__mod(res_u64, __add(max_u8_u64, 1)))
+                __transmute::<u64, u8>(__mod(res_u64, __add(max_u8_u64, 1)))
             }
         } else {
-            u64_as_u8(res_u64)
+            __transmute::<u64, u8>(res_u64)
         }
     }
 }
@@ -327,9 +327,9 @@ impl Multiply for u16 {
 
 impl Multiply for u8 {
     fn multiply(self, other: Self) -> Self {
-        let res_u64 = __mul(u8_as_u64(self), u8_as_u64(other));
+        let res_u64 = __mul(__transmute::<u8, u64>(self), __transmute::<u8, u64>(other));
 
-        let max_u8_u64 = u8_as_u64(Self::max());
+        let max_u8_u64 = __transmute::<u8, u64>(Self::max());
 
         if __gt(res_u64, max_u8_u64) {
             if panic_on_overflow_enabled() {
@@ -337,10 +337,10 @@ impl Multiply for u8 {
             } else {
                 // overflow enabled
                 // res % (Self::max() + 1)
-                u64_as_u8(__mod(res_u64, __add(max_u8_u64, 1)))
+                __transmute::<u64, u8>(__mod(res_u64, __add(max_u8_u64, 1)))
             }
         } else {
-            u64_as_u8(res_u64)
+            __transmute::<u64, u8>(res_u64)
         }
     }
 }
@@ -1686,18 +1686,6 @@ impl b256 {
     /// ```
     pub fn is_zero(self) -> bool {
         self == 0x0000000000000000000000000000000000000000000000000000000000000000
-    }
-}
-
-fn u8_as_u64(val: u8) -> u64 {
-    asm(input: val) {
-        input: u64
-    }
-}
-
-fn u64_as_u8(val: u64) -> u8 {
-    asm(input: val) {
-        input: u8
     }
 }
 

--- a/test/src/in_language_tests/test_programs/bytes_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/bytes_inline_tests/src/main.sw
@@ -1067,7 +1067,7 @@ fn bytes_b256_into() {
 #[test()]
 fn bytes_from_raw_slice() {
     let val = 0x3497297632836282349729763283628234972976328362823497297632836282;
-    let slice = asm(ptr: (__addr_of(val), 32)) {
+    let slice = __transmute::<(raw_ptr, u64), raw_slice>(ptr: (__addr_of(val), 32)) {
         ptr: raw_slice
     };
 
@@ -1099,9 +1099,7 @@ fn bytes_raw_slice_from() {
 #[test()]
 fn bytes_raw_slice_into() {
     let val = 0x3497297632836282349729763283628234972976328362823497297632836282;
-    let slice = asm(ptr: (__addr_of(val), 32)) {
-        ptr: raw_slice
-    };
+    let slice = __transmute::<(raw_ptr, u64), raw_slice>((__addr_of(val), 32));
 
     let bytes: Bytes = slice.into();
 

--- a/test/src/in_language_tests/test_programs/storage_vec_iter_tests/src/impls.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_iter_tests/src/impls.sw
@@ -290,9 +290,7 @@ impl TestInstance for b256 {
 
 impl AbiEncode for raw_ptr {
     fn abi_encode(self, buffer: Buffer) -> Buffer {
-        let ptr_as_u64 = asm(p: self) {
-            p: u64
-        };
+        let ptr_as_u64 = __transmute::<raw_ptr, u64>(self);
         ptr_as_u64.abi_encode(buffer)
     }
 }
@@ -303,9 +301,7 @@ impl TestInstance for raw_ptr {
         let mut res = Vec::new();
         let mut i = 0;
         while i < len {
-            let null_ptr = asm() {
-                zero: raw_ptr
-            };
+            let null_ptr = __transmute::<u64, raw_ptr>(0);
             res.push(null_ptr.add::<u64>(values.get(i).unwrap().as_u64()));
             i += 1;
         }

--- a/test/src/in_language_tests/test_programs/u128_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/u128_inline_tests/src/main.sw
@@ -1427,11 +1427,9 @@ fn u128_as_u256() {
         let u256_val = u128_val.as_u256();
         assert(u256_val == u256::from(val));
 
-        // Ensure parity with asm u256 conversion
-        let asm_val = asm(nums: (0, 0, 0, val)) {
-            nums: u256
-        };
-        assert(u256_val == asm_val);
+        // Ensure parity with transmute u256 conversion
+        let trm_val = __transmute::<(u64, u64, u64, u64), u256>((0, 0, 0, val));
+        assert(u256_val == trm_val);
 
         for val2 in vals.iter() {
             // Ensure parity with u256::from(0, 0, val, val2)
@@ -1439,11 +1437,9 @@ fn u128_as_u256() {
             let u256_val = u128_val.as_u256();
             assert(u256_val == u256::from((0, 0, val, val2)));
 
-            // Ensure parity with asm u256 conversion
-            let asm_val = asm(nums: (0, 0, val, val2)) {
-                nums: u256
-            };
-            assert(u256_val == asm_val);
+            // Ensure parity with transmute u256 conversion
+            let trm_val = __transmute::<(u64, u64, u64, u64)>((0, 0, val, val2));
+            assert(u256_val == trm_val);
         }
     }
 }

--- a/test/src/in_language_tests/test_programs/vec_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/vec_inline_tests/src/main.sw
@@ -636,9 +636,7 @@ fn vec_as_raw_slice() {
 #[test()]
 fn vec_from_raw_slice() {
     let val = 0x3497297632836282349729763283628234972976328362823497297632836282;
-    let slice = asm(ptr: (__addr_of(val), 32)) {
-        ptr: raw_slice
-    };
+    let slice = __transmute::<(raw_ptr, u64), raw_slice>((__addr_of(val), 32));
 
     let mut vec: Vec<u64> = Vec::from(slice);
     assert(vec.ptr() != slice.ptr()); // Vec should own its buffer
@@ -677,9 +675,7 @@ fn vec_from_raw_slice() {
 #[test()]
 fn vec_raw_slice_into() {
     let val = 0x3497297632836282349729763283628234972976328362823497297632836282;
-    let slice = asm(ptr: (__addr_of(val), 32)) {
-        ptr: raw_slice
-    };
+    let slice = __transmute::<(raw_ptr, u64), raw_slice>((__addr_of(val), 32));
 
     let vec: Vec<u64> = slice.into();
 

--- a/test/src/ir_generation/tests/ptr_add.sw
+++ b/test/src/ir_generation/tests/ptr_add.sw
@@ -1,7 +1,7 @@
 script;
 
 fn main() {
-    let null = asm(output) { zero: raw_ptr };
+    let null = __transmute::<u64, raw_ptr>(0);
     let _ = __ptr_add::<u64>(null, 1);
 }
 // check: $VAL = get_local __ptr ptr, null, $MD

--- a/test/src/ir_generation/tests/ptr_sub.sw
+++ b/test/src/ir_generation/tests/ptr_sub.sw
@@ -1,7 +1,7 @@
 script;
 
 fn main() {
-    let null = asm(output) { zero: raw_ptr };
+    let null = __transmute::<u64, raw_ptr>(0);
     let _ = __ptr_sub::<u64>(null, 1);
 }
 // check: $VAL = get_local __ptr ptr, null, $MD

--- a/test/src/ir_generation/tests/state_load_quad.sw
+++ b/test/src/ir_generation/tests/state_load_quad.sw
@@ -1,6 +1,6 @@
 script;
 fn main() {
-    let null = asm(output) { zero: raw_ptr };
+    let null = __transmute::<u64, raw_ptr>(0);
     let res = __state_load_quad(
       0x0000000000000000000000000000000000000000000000000000000000000001,
       null,

--- a/test/src/ir_generation/tests/state_store_quad.sw
+++ b/test/src/ir_generation/tests/state_store_quad.sw
@@ -1,7 +1,7 @@
 script;
 
 fn main() {
-    let null = asm(output) { zero: raw_ptr };
+    let null = __transmute::<u64, raw_ptr>(0);
     let _ = __state_store_quad(
       0x0000000000000000000000000000000000000000000000000000000000000001,
       null,

--- a/test/src/sdk-harness/test_projects/registers/src/main.sw
+++ b/test/src/sdk-harness/test_projects/registers/src/main.sw
@@ -25,33 +25,23 @@ impl Registers for Contract {
     }
 
     fn get_program_counter() -> u64 {
-        asm(ptr: program_counter()) {
-            ptr: u64
-        }
+        __transmute::<raw_ptr, u64>(program_counter())
     }
 
     fn get_stack_start_ptr() -> u64 {
-        asm(ptr: stack_start_ptr()) {
-            ptr: u64
-        }
+        __transmute::<raw_ptr, u64>(stack_start_ptr())
     }
 
     fn get_stack_ptr() -> u64 {
-        asm(ptr: stack_ptr()) {
-            ptr: u64
-        }
+        __transmute::<raw_ptr, u64>(stack_ptr())
     }
 
     fn get_frame_ptr() -> u64 {
-        asm(ptr: frame_ptr()) {
-            ptr: u64
-        }
+        __transmute::<raw_ptr, u64>(frame_ptr())
     }
 
     fn get_heap_ptr() -> u64 {
-        asm(ptr: heap_ptr()) {
-            ptr: u64
-        }
+        __transmute::<raw_ptr, u64>(heap_ptr())
     }
 
     fn get_error() -> u64 {
@@ -71,9 +61,7 @@ impl Registers for Contract {
     }
 
     fn get_instrs_start() -> u64 {
-        asm(ptr: instrs_start()) {
-            ptr: u64
-        }
+        __transmute::<raw_ptr, u64>(instrs_start())
     }
 
     fn get_return_value() -> u64 {


### PR DESCRIPTION
## Description

Replace library uses of asm blocks for unsafe type conversion with the __transmute intrinsic.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
