### PR TITLE
Add wrapping operations to standard library

### DIFF
--- a/sway-lib-std/src/ops.sw
+++ b/sway-lib-std/src/ops.sw
@@ -2,7 +2,7 @@ library;
 
 use ::primitives::*;
 use ::registers::flags;
-use ::flags::panic_on_overflow_enabled;
+use ::flags::{disable_panic_on_overflow, panic_on_overflow_enabled, set_flags};
 
 const MAX_U32_U64: u64 = __transmute::<u32, u64>(u32::max());
 const MAX_U16_U64: u64 = __transmute::<u16, u64>(u16::max());
@@ -1570,6 +1570,28 @@ impl PartialEq for str {
 impl Eq for str {}
 
 impl u8 {
+    /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of the type.
+    pub fn wrapping_add(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self + other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary of the type.
+    pub fn wrapping_sub(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self - other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary of the type.
+    pub fn wrapping_mul(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self * other;
+        set_flags(f);
+        res
+    }
+
     /// Returns whether a `u8` is set to zero.
     ///
     /// # Returns
@@ -1590,6 +1612,28 @@ impl u8 {
 }
 
 impl u16 {
+    /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of the type.
+    pub fn wrapping_add(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self + other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary of the type.
+    pub fn wrapping_sub(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self - other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary of the type.
+    pub fn wrapping_mul(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self * other;
+        set_flags(f);
+        res
+    }
+
     /// Returns whether a `u16` is set to zero.
     ///
     /// # Returns
@@ -1610,6 +1654,28 @@ impl u16 {
 }
 
 impl u32 {
+    /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of the type.
+    pub fn wrapping_add(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self + other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary of the type.
+    pub fn wrapping_sub(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self - other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary of the type.
+    pub fn wrapping_mul(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self * other;
+        set_flags(f);
+        res
+    }
+
     /// Returns whether a `u32` is set to zero.
     ///
     /// # Returns
@@ -1630,6 +1696,28 @@ impl u32 {
 }
 
 impl u64 {
+    /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of the type.
+    pub fn wrapping_add(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self + other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary of the type.
+    pub fn wrapping_sub(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self - other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary of the type.
+    pub fn wrapping_mul(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self * other;
+        set_flags(f);
+        res
+    }
+
     /// Returns whether a `u64` is set to zero.
     ///
     /// # Returns
@@ -1650,6 +1738,28 @@ impl u64 {
 }
 
 impl u256 {
+    /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of the type.
+    pub fn wrapping_add(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self + other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary of the type.
+    pub fn wrapping_sub(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self - other;
+        set_flags(f);
+        res
+    }
+    /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary of the type.
+    pub fn wrapping_mul(self, other: Self) -> Self {
+        let f = disable_panic_on_overflow();
+        let res = self * other;
+        set_flags(f);
+        res
+    }
+
     /// Returns whether a `u256` is set to zero.
     ///
     /// # Returns

--- a/test/src/in_language_tests/test_programs/ops_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/ops_inline_tests/src/main.sw
@@ -9,3 +9,25 @@ pub fn str_eq_test() {
     assert("" != "a");
     assert("a" != "b");
 }
+
+#[test]
+pub fn wrapping_tests() {
+    assert_eq(0u8.wrapping_sub(1u8), u8::max());
+    assert_eq(0u16.wrapping_sub(1u16), u16::max());
+    assert_eq(0u32.wrapping_sub(1u32), u32::max());
+    assert_eq(0u64.wrapping_sub(1u64), u64::max());
+    assert_eq(u256::zero().wrapping_sub(u256::from(1u64)), u256::max());
+
+    assert_eq(u8::max().wrapping_add(1u8), 0);
+    assert_eq(u16::max().wrapping_add(1u16), 0);
+    assert_eq(u32::max().wrapping_add(1u32), 0);
+    assert_eq(u64::max().wrapping_add(1u64), 0);
+    assert_eq(u256::max().wrapping_add(u256::from(1u64)), u256::zero());
+
+    assert_eq(16u8.wrapping_mul(16u8), 0);
+    assert_eq(256u16.wrapping_mul(256u16), 0);
+    assert_eq(65_536u32.wrapping_mul(65_536u32), 0);
+    assert_eq(4_294_967_296u64.wrapping_mul(4_294_967_296u64), 0);
+    assert_eq(u256::from(0x0000000000000000000000000000000100000000000000000000000000000000).wrapping_mul(u256::from(0x0000000000000000000000000000000100000000000000000000000000000000)), 0);
+
+}


### PR DESCRIPTION

## Description

Add implementation for `wrapping_add()`, `wrapping_sub()` and `wrapping_mul()` to standard operations.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
