### PR TITLE
refactor(u128): rename as_u64 to try_as_u64 for naming consistency

### DIFF
--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -303,7 +303,6 @@ impl U128 {
         }
     }
 
-    // TODO: Rename to `try_as_u64` to be consistent with all other downcasts
     /// Safely downcast to `u64` without loss of precision.
     ///
     /// # Additional Information
@@ -321,21 +320,37 @@ impl U128 {
     ///
     /// fn foo() {
     ///     let zero_u128 = U128::from(0, 0);
-    ///     let zero_u64 = zero_u128.as_u64().unwrap();
+    ///     let zero_u64 = zero_u128.try_as_u64().unwrap();
     ///
     ///     assert(zero_u64 == 0);
     ///
     ///     let max_u128 = U128::max();
-    ///     let result = max_u128.as_u64();
+    ///     let result = max_u128.try_as_u64();
     ///
     ///     assert(result.is_err()));
     /// }
     /// ```
-    pub fn as_u64(self) -> Result<u64, U128Error> {
+    pub fn try_as_u64(self) -> Result<u64, U128Error> {
         match self.upper {
             0 => Ok(self.lower),
             _ => Err(U128Error::LossOfPrecision),
         }
+    }
+
+    /// Safely downcast to `u64` without loss of precision.
+    ///
+    /// # Additional Information
+    ///
+    /// If the `U128` is larger than `u64::max()`, an error is returned.
+    /// 
+    /// **Deprecated:** Use `try_as_u64` instead for consistency with other downcast functions.
+    ///
+    /// # Returns
+    ///
+    /// * [Result<u64, U128Error>] - The result of the downcast.
+    #[deprecated(note = "Use `try_as_u64` instead for consistency with other downcast functions")]
+    pub fn as_u64(self) -> Result<u64, U128Error> {
+        self.try_as_u64()
     }
 
     /// Upcasts a `U128` to a `u256`.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/src/main.sw
@@ -88,12 +88,12 @@ fn main() -> bool {
     assert(not_3_0.upper() == u64::max() - 3);
     assert(not_3_0.lower() == u64::max());
 
-    // test as_u64()
+    // test try_as_u64()
     let eleven = U128::from((0, 11));
-    let unwrapped = eleven.as_u64().unwrap();
+    let unwrapped = eleven.try_as_u64().unwrap();
     assert(unwrapped == 11);
 
-    let err_1 = U128::from((42, 11)).as_u64();
+    let err_1 = U128::from((42, 11)).try_as_u64();
     assert(match err_1 {
         Err(U128Error::LossOfPrecision) => {
             true
@@ -103,7 +103,7 @@ fn main() -> bool {
         },
     });
 
-    let err_1 = U128::from((42, 0)).as_u64();
+    let err_1 = U128::from((42, 0)).try_as_u64();
     assert(match err_1 {
         Err(U128Error::LossOfPrecision) => {
             true

--- a/test/src/in_language_tests/test_programs/u128_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/u128_inline_tests/src/main.sw
@@ -20,9 +20,9 @@ fn u128_from_u8() {
     let u128_2 = <U128 as From<u8>>::from(u8_2);
     let u128_3 = <U128 as From<u8>>::from(u8_3);
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 255u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 255u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -35,9 +35,9 @@ fn u128_u8_into() {
     let u128_2: U128 = u8_2.into();
     let u128_3: U128 = u8_3.into();
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 255u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 255u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -50,9 +50,9 @@ fn u128_from_u16() {
     let u128_2 = <U128 as From<u16>>::from(u16_2);
     let u128_3 = <U128 as From<u16>>::from(u16_3);
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 65535u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 65535u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -65,9 +65,9 @@ fn u128_u16_into() {
     let u128_2: U128 = u16_2.into();
     let u128_3: U128 = u16_3.into();
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 65535u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 65535u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -80,9 +80,9 @@ fn u128_from_u32() {
     let u128_2 = <U128 as From<u32>>::from(u32_2);
     let u128_3 = <U128 as From<u32>>::from(u32_3);
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 4294967295u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 4294967295u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -95,9 +95,9 @@ fn u128_u32_into() {
     let u128_2: U128 = u32_2.into();
     let u128_3: U128 = u32_3.into();
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 4294967295u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 4294967295u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -110,9 +110,9 @@ fn u128_from_u64() {
     let u128_2 = <U128 as From<u64>>::from(u64_2);
     let u128_3 = <U128 as From<u64>>::from(u64_3);
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 18446744073709551615u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 18446744073709551615u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -125,9 +125,9 @@ fn u128_u64_into() {
     let u128_2: U128 = u64_2.into();
     let u128_3: U128 = u64_3.into();
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 18446744073709551615u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 18446744073709551615u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 }
 
 #[test]
@@ -328,17 +328,17 @@ fn u128_as_u64() {
     let u128_2 = <U128 as From<u64>>::from(u64_2);
     let u128_3 = <U128 as From<u64>>::from(u64_3);
 
-    assert(u128_1.as_u64().unwrap() == 0u64);
-    assert(u128_2.as_u64().unwrap() == 18446744073709551615u64);
-    assert(u128_3.as_u64().unwrap() == 1u64);
+    assert(u128_1.try_as_u64().unwrap() == 0u64);
+    assert(u128_2.try_as_u64().unwrap() == 18446744073709551615u64);
+    assert(u128_3.try_as_u64().unwrap() == 1u64);
 
     let u128_4 = <U128 as From<(u64, u64)>>::from((u64_3, u64_1));
     let u128_5 = <U128 as From<(u64, u64)>>::from((u64_2, u64_1));
     let u128_6 = <U128 as From<(u64, u64)>>::from((u64_2, u64_2));
 
-    assert(u128_4.as_u64().is_err());
-    assert(u128_5.as_u64().is_err());
-    assert(u128_6.as_u64().is_err());
+    assert(u128_4.try_as_u64().is_err());
+    assert(u128_5.try_as_u64().is_err());
+    assert(u128_6.try_as_u64().is_err());
 }
 
 #[test]
@@ -393,7 +393,7 @@ fn u128_lower() {
 #[test]
 fn u128_zero() {
     let zero_u128 = U128::zero();
-    assert(zero_u128.as_u64().unwrap() == 0u64);
+    assert(zero_u128.try_as_u64().unwrap() == 0u64);
 }
 
 #[test]


### PR DESCRIPTION
## Description

reopen #7294
Renamed the as_u64 method to try_as_u64 in u128.sw to maintain consistency with other fallible downcast methods. Deprecated the old as_u64 method with a note pointing to try_as_u64.

Fixes https://github.com/FuelLabs/sway/issues/6954