### PR TITLE
forc-run debugger integration

### DIFF
--- a/forc-plugins/forc-client/src/cmd/run.rs
+++ b/forc-plugins/forc-client/src/cmd/run.rs
@@ -55,6 +55,9 @@ pub struct Command {
     /// Arguments to pass into main function with forc run.
     #[clap(long)]
     pub args: Option<Vec<String>>,
+    /// Start interactive debugger after transaction execution
+    #[clap(long, help_heading = "DEBUG")]
+    pub debug: bool,
 
     #[clap(flatten)]
     pub experimental: sway_features::CliFields,


### PR DESCRIPTION
## Description

Added a `--debug` flag to `forc run` with the same behavior as `forc call`'s as implemented in #7323.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
