### PR TITLE
Eliminate `mem_copy_val`s when accessing global constants

### DIFF
--- a/sway-ir/src/analysis/memory_utils.rs
+++ b/sway-ir/src/analysis/memory_utils.rs
@@ -283,6 +283,12 @@ fn get_symbols(context: &Context, val: Value, gep_only: bool) -> ReferredSymbols
                 op: InstOp::GetConfig(_, _),
                 ..
             }) if !gep_only => (),
+            // We've reached a global at the top of the chain.
+            // There cannot be a symbol behind it, and so the returned set is complete.
+            ValueDatum::Instruction(Instruction {
+                op: InstOp::GetGlobal(_),
+                ..
+            }) if !gep_only => (),
             // Note that in this case, the pointer itself is coming from a `Load`,
             // and not an address. So, we just continue following the pointer.
             ValueDatum::Instruction(Instruction {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat/stdout.snap
@@ -1,5 +1,6 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
 > forc build  --path test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat --experimental const_generics --ir final --asm final --bytecode
 exit status: 0
@@ -1235,7 +1236,7 @@ output:
     Finished debug [unoptimized + fuel] target(s) [6.648 KB] in ???
     script array_repeat
       Bytecode size: 6648 bytes (6.648 KB)
-      Bytecode hash: 0x0ae596de91be50b99f5af33b3ffdf03b48086eef74ff481547652feb85078b94
+      Bytecode hash: 0x556fd20a12eccbbba1405bdda2eb527e6da68804f20c081c92bd630a22877ead
      Running 1 test, filtered 0 tests
 
 tested -- array_repeat

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/stdout.snap
@@ -444,12 +444,12 @@ warning
 ____
 
   Compiled script "const_generics" with 2 warnings.
-    Finished debug [unoptimized + fuel] target(s) [9.56 KB] in ???
+    Finished debug [unoptimized + fuel] target(s) [9.536 KB] in ???
      Running 1 test, filtered 0 tests
 
 tested -- const_generics
 
-      test run_main ... ok (???, 17574 gas)
+      test run_main ... ok (???, 17350 gas)
            debug output:
 [src/main.sw:105:13] a = [1, 2]
 [src/main.sw:109:13] [C {}].len() = 1

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg/stdout.snap
@@ -72,12 +72,12 @@ output:
     Building test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg
    Compiling library std (sway-lib-std)
    Compiling script dbg (test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/dbg)
-    Finished debug [unoptimized + fuel] target(s) [42.296 KB] in ???
+    Finished debug [unoptimized + fuel] target(s) [42.456 KB] in ???
      Running 1 test, filtered 0 tests
 
 tested -- dbg
 
-      test call_main ... ok (???, 125935 gas)
+      test call_main ... ok (???, 122721 gas)
            debug output:
 [src/main.sw:13:13] () = ()
 [src/main.sw:15:13] true = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/stdout.snap
@@ -1,5 +1,6 @@
 ---
 source: test/src/snapshot/mod.rs
+assertion_line: 162
 ---
 > forc test --path test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests --logs --raw-logs --dbgs --reverts passing_
 exit status: 0
@@ -18,12 +19,12 @@ warning: Error message is empty
 ____
 
   Compiled script "panic_handling_in_unit_tests" with 1 warning.
-    Finished debug [unoptimized + fuel] target(s) [9.552 KB] in ???
+    Finished debug [unoptimized + fuel] target(s) [9.392 KB] in ???
      Running 2 tests, filtered 18 tests
 
 tested -- panic_handling_in_unit_tests
 
-      test passing_dbgs_and_logs ... ok (???, 2219 gas)
+      test passing_dbgs_and_logs ... ok (???, 2175 gas)
            debug output:
 [src/main.sw:23:13] "This is a passing test containing `__dbg` outputs." = "This is a passing test containing `__dbg` outputs."
 [src/main.sw:25:13] x = 42
@@ -31,7 +32,7 @@ tested -- panic_handling_in_unit_tests
 AsciiString { data: "This is a log from the passing test." }, log rb: 10098701174489624218
 42, log rb: 1515152261580153489
            raw logs:
-[{"LogData":{"data":"0000000000000024546869732069732061206c6f672066726f6d207468652070617373696e6720746573742e","digest":"29d742ad9093cdf81404ff756467a44448729b85ab3c0d65197829fb61d2dd29","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":44,"pc":15824,"ptr":67107840,"ra":0,"rb":10098701174489624218}},{"LogData":{"data":"000000000000002a","digest":"a6bb133cb1e3638ad7b8a3ff0539668e9e56f9b850ef1b2a810f5422eaa6c323","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":16456,"ptr":67106816,"ra":0,"rb":1515152261580153489}}]
+[{"LogData":{"data":"0000000000000024546869732069732061206c6f672066726f6d207468652070617373696e6720746573742e","digest":"29d742ad9093cdf81404ff756467a44448729b85ab3c0d65197829fb61d2dd29","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":44,"pc":15664,"ptr":67107840,"ra":0,"rb":10098701174489624218}},{"LogData":{"data":"000000000000002a","digest":"a6bb133cb1e3638ad7b8a3ff0539668e9e56f9b850ef1b2a810f5422eaa6c323","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":16296,"ptr":67106816,"ra":0,"rb":1515152261580153489}}]
       test passing_no_dbgs_or_logs ... ok (???, 18 gas)
 
 test result: OK. 2 passed; 0 failed; finished in ???
@@ -55,20 +56,20 @@ warning: Error message is empty
 ____
 
   Compiled script "panic_handling_in_unit_tests" with 1 warning.
-    Finished debug [unoptimized + fuel] target(s) [9.552 KB] in ???
+    Finished debug [unoptimized + fuel] target(s) [9.392 KB] in ???
      Running 20 tests, filtered 0 tests
 
 tested -- panic_handling_in_unit_tests
 
-      test passing_dbgs_and_logs ... ok (???, 2219 gas)
+      test passing_dbgs_and_logs ... ok (???, 2175 gas)
       test passing_no_dbgs_or_logs ... ok (???, 18 gas)
       test failing_revert_intrinsic ... FAILED (???, 19 gas)
-      test failing_revert_function_with_dbgs_and_logs ... FAILED (???, 2346 gas)
-      test failing_error_signal_assert ... FAILED (???, 497 gas)
-      test failing_error_signal_assert_eq ... FAILED (???, 1394 gas)
-      test failing_error_signal_assert_ne ... FAILED (???, 1389 gas)
-      test failing_error_signal_require_str_error ... FAILED (???, 318 gas)
-      test failing_error_signal_require_enum_error ... FAILED (???, 414 gas)
+      test failing_revert_function_with_dbgs_and_logs ... FAILED (???, 2297 gas)
+      test failing_error_signal_assert ... FAILED (???, 475 gas)
+      test failing_error_signal_assert_eq ... FAILED (???, 1371 gas)
+      test failing_error_signal_assert_ne ... FAILED (???, 1366 gas)
+      test failing_error_signal_require_str_error ... FAILED (???, 320 gas)
+      test failing_error_signal_require_enum_error ... FAILED (???, 416 gas)
       test failing_panic_no_arg ... FAILED (???, 197 gas)
       test failing_panic_unit_arg ... FAILED (???, 197 gas)
       test failing_panic_const_eval_str_arg ... FAILED (???, 19 gas)
@@ -102,7 +103,7 @@ AsciiString { data: "This is a log from the reverting test." }, log rb: 10098701
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 46,
-      "pc": 15824,
+      "pc": 15664,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -136,7 +137,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 64,
-      "pc": 15824,
+      "pc": 15664,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -149,7 +150,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 16456,
+      "pc": 16296,
       "ptr": 67106816,
       "ra": 0,
       "rb": 1515152261580153489
@@ -162,7 +163,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 16456,
+      "pc": 16296,
       "ptr": 67105792,
       "ra": 0,
       "rb": 1515152261580153489
@@ -189,7 +190,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 64,
-      "pc": 15824,
+      "pc": 15664,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -202,7 +203,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 16456,
+      "pc": 16296,
       "ptr": 67106816,
       "ra": 0,
       "rb": 1515152261580153489
@@ -215,7 +216,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 16456,
+      "pc": 16296,
       "ptr": 67105792,
       "ra": 0,
       "rb": 1515152261580153489
@@ -238,7 +239,7 @@ AsciiString { data: "This is an error message in a `require` call." }, log rb: 1
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 53,
-      "pc": 15824,
+      "pc": 15664,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -261,7 +262,7 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 9,
-      "pc": 13696,
+      "pc": 13552,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016
@@ -285,7 +286,7 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 0,
-      "pc": 13772,
+      "pc": 13628,
       "ptr": 67107840,
       "ra": 0,
       "rb": 3330666440490685604
@@ -309,7 +310,7 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 0,
-      "pc": 13832,
+      "pc": 13688,
       "ptr": 67107840,
       "ra": 0,
       "rb": 3330666440490685604
@@ -351,7 +352,7 @@ AsciiString { data: "Panicked with a non-const evaluated string argument." }, lo
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 60,
-      "pc": 18436,
+      "pc": 18276,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -375,7 +376,7 @@ AsciiString { data: "" }, log rb: 10098701174489624218
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 18436,
+      "pc": 18276,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -399,7 +400,7 @@ AsciiString { data: "    " }, log rb: 10098701174489624218
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 12,
-      "pc": 18436,
+      "pc": 18276,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -424,7 +425,7 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 9,
-      "pc": 14284,
+      "pc": 14140,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016
@@ -449,7 +450,7 @@ C(AsciiString { data: "This is an error with an empty error message." }), log rb
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 61,
-      "pc": 14412,
+      "pc": 14268,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016
@@ -474,7 +475,7 @@ D(AsciiString { data: "This is an error with a whitespace error message." }), lo
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 65,
-      "pc": 14540,
+      "pc": 14396,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract/stdout.snap
@@ -9,78 +9,78 @@ output:
    Compiling library std (test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-core)
    Compiling library panicking_lib (test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_lib)
    Compiling contract panicking_contract (test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panicking_contract)
-    Finished release [optimized + fuel] target(s) [8.136 KB] in ???
+    Finished release [optimized + fuel] target(s) [8.048 KB] in ???
      Running 11 tests, filtered 0 tests
 
 tested -- panicking_contract
 
-      test test_directly_panicking_method ... ok (???, 1595 gas)
+      test test_directly_panicking_method ... ok (???, 1591 gas)
            revert code: ffffffff00000000
             ├─ panic message: Error C.
             ├─ panic value:   C(true)
             └─ panicked in:   panicking_contract@1.2.3, src/main.sw:22:9
            decoded log values:
 C(true), log rb: 5503570629422409978
-      test test_nested_panic_inlined ... ok (???, 2921 gas)
+      test test_nested_panic_inlined ... ok (???, 2917 gas)
            revert code: ffffffff00000005
             ├─ panic message: Error E.
             ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
             └─ panicked in:   panicking_lib, src/lib.sw:41:9
            decoded log values:
 E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
-      test test_nested_panic_inlined_same_revert_code ... ok (???, 2921 gas)
+      test test_nested_panic_inlined_same_revert_code ... ok (???, 2917 gas)
            revert code: ffffffff00000005
             ├─ panic message: Error E.
             ├─ panic value:   E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }])
             └─ panicked in:   panicking_lib, src/lib.sw:41:9
            decoded log values:
 E([AsciiString { data: "this" }, AsciiString { data: "is not" }, AsciiString { data: "the best practice" }]), log rb: 5503570629422409978
-      test test_nested_panic_not_inlined ... ok (???, 3120 gas)
+      test test_nested_panic_not_inlined ... ok (???, 3116 gas)
            revert code: ffffffff00000006
             ├─ panic message: Error E.
             ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
             └─ panicked in:   panicking_lib, src/lib.sw:35:5
            decoded log values:
 E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
-      test test_nested_panic_not_inlined_same_revert_code ... ok (???, 3120 gas)
+      test test_nested_panic_not_inlined_same_revert_code ... ok (???, 3116 gas)
            revert code: ffffffff00000006
             ├─ panic message: Error E.
             ├─ panic value:   E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }])
             └─ panicked in:   panicking_lib, src/lib.sw:35:5
            decoded log values:
 E([AsciiString { data: "to have" }, AsciiString { data: "strings" }, AsciiString { data: "in error enum variants" }]), log rb: 5503570629422409978
-      test test_generic_panic_with_unit ... ok (???, 2052 gas)
+      test test_generic_panic_with_unit ... ok (???, 2048 gas)
            revert code: ffffffff00000004
             ├─ panic value:   ()
             └─ panicked in:   panicking_lib, src/lib.sw:74:5
            decoded log values:
 (), log rb: 3330666440490685604
-      test test_generic_panic_with_unit_same_revert_code ... ok (???, 2052 gas)
+      test test_generic_panic_with_unit_same_revert_code ... ok (???, 2048 gas)
            revert code: ffffffff00000004
             ├─ panic value:   ()
             └─ panicked in:   panicking_lib, src/lib.sw:74:5
            decoded log values:
 (), log rb: 3330666440490685604
-      test test_generic_panic_with_str ... ok (???, 2062 gas)
+      test test_generic_panic_with_str ... ok (???, 2058 gas)
            revert code: ffffffff00000002
             ├─ panic message: generic panic with string
             └─ panicked in:   panicking_lib, src/lib.sw:74:5
            decoded log values:
 AsciiString { data: "generic panic with string" }, log rb: 10098701174489624218
-      test test_generic_panic_with_different_str_same_revert_code ... ok (???, 1732 gas)
+      test test_generic_panic_with_different_str_same_revert_code ... ok (???, 1728 gas)
            revert code: ffffffff00000002
             ├─ panic message: generic panic with different string
             └─ panicked in:   panicking_lib, src/lib.sw:74:5
            decoded log values:
 AsciiString { data: "generic panic with different string" }, log rb: 10098701174489624218
-      test test_generic_panic_with_error_type_enum ... ok (???, 1862 gas)
+      test test_generic_panic_with_error_type_enum ... ok (???, 1858 gas)
            revert code: ffffffff00000003
             ├─ panic message: Error A.
             ├─ panic value:   A
             └─ panicked in:   panicking_lib, src/lib.sw:74:5
            decoded log values:
 A, log rb: 5503570629422409978
-      test test_generic_panic_with_error_type_enum_different_variant_same_revert_code ... ok (???, 2031 gas)
+      test test_generic_panic_with_error_type_enum_different_variant_same_revert_code ... ok (???, 2026 gas)
            revert code: ffffffff00000003
             ├─ panic message: Error B.
             ├─ panic value:   B(42)

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x94db39f409a31b9f2ebcadeea44378e419208c20de90f5d8e1e33dc1523754cb;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xbd57a0138d242c9386c3689c1280d5cbccdf3c6a7db820c5934e2e87682be1a4; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
+const CONTRACT_ID = 0xdc8809151850786831a09319d9f4d556287b31a656001252dbdbd1c463b9cba9; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/ir_generation/tests/global_constants_usage.sw
+++ b/test/src/ir_generation/tests/global_constants_usage.sw
@@ -1,0 +1,23 @@
+// target-fuelvm
+script;
+
+const ADDRESS: b256 = 0x9999999999999999999999999999999999999999999999999999999999999999;
+
+fn main() {
+    poke(ADDRESS);
+}
+
+#[inline(never)]
+fn poke<T>(_t: T) { }
+
+// ::check-ir::
+
+// check: fn main() -> ()
+
+// ::check-ir-optimized::
+// pass: o1
+
+// check: v0 = get_global __ptr b256, test_lib::ADDRESS
+// nextln: v1 = get_local __ptr b256, __tmp_arg
+// nextln: mem_copy_val v1, v0
+// nextln: v2 = call poke_0(v1)


### PR DESCRIPTION
## Description

This PR properly treats `InstOp::GetGlobal` in the `memory_utils::get_symbols`. Before, when analysis hit `GetGlobal` as a pointer source, it didn't know that there cannot be a symbol behind that pointer. That's why it was treated the resulting `ReferredSymbols` as incomplete. This harmed `memcpyopt` optimizations.

E.g., in this example:

```sway
script;

const ADDRESS: b256 = 0x9999999999999999999999999999999999999999999999999999999999999999;

fn main() {
    poke(ADDRESS);
}

#[inline(never)]
fn poke<T>(_t: T) { }
```
the resulting final IR in `release` build was:

```
entry_orig fn main_0() -> (), !13 {
    local mut b256 __aggr_memcpy_0            <<<--- Additional local.
    local b256 __tmp_arg

    entry():
    v0 = get_global __ptr b256, storage_all_layouts::ADDRESS, !14
    v1 = get_local __ptr b256, __aggr_memcpy_0
    mem_copy_val v1, v0                       <<<--- Additional `mem_cpy_val`.
    v2 = get_local __ptr b256, __tmp_arg
    mem_copy_val v2, v1
    v3 = call poke_1(v2)
    v12 = const unit ()
    ret () v12
}
```
After this change, the resulting IR becomes:

```
entry_orig fn main_0() -> (), !13 {
    local b256 __tmp_arg

    entry():
    v0 = get_global __ptr b256, storage_all_layouts::ADDRESS, !14
    v1 = get_local __ptr b256, __tmp_arg
    mem_copy_val v1, v0
    v3 = call poke_1(v1)
    v12 = const unit ()
    ret () v12
}
```
The change didn't affect the bytecode or gas usage of most of the `should_pass` tests.
Only the following `should_pass/language` snapshot tests decreased in bytecode size and gas usage:

| Test | Bytecode before | Bytecode after |
| ---- | --------------- | -------------- |
| const_generics | 9.560 | 9.536 |
| panic_expression/panicking_contract | 8.136 | 8.048 |
| panic_expression/panic_handling_in_unit_tests | 9.552 | 9.392 |

The only test in which the bytecode size and gas usage went up was `should_pass/language/intrinsics/dbg` test run in `debug` mode. When run in `release` mode, the usage of `_dbg` intrinsic didn't cause any increases (the `dbg_release` test).

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.