### PR TITLE
Remove `cargo-run-e2e-test-evm` job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       - build-forc-test-project
       - cargo-build-workspace
       - cargo-clippy
-      - cargo-run-e2e-test-evm
       - cargo-test-lib-std
       - forc-run-benchmarks
       - forc-unit-tests
@@ -441,21 +440,6 @@ jobs:
           sleep 5 &&
           cargo run --locked --release --bin test -- --locked --release
 
-  cargo-run-e2e-test-evm:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-      - name: Cargo Run E2E Tests (EVM)
-        run: cargo run --locked --release --bin test -- --target evm --locked --no-experimental new_encoding
-
   # TODO: Remove this upon merging std tests with the rest of the E2E tests.
   cargo-test-lib-std:
     runs-on: buildjet-8vcpu-ubuntu-2204
@@ -779,7 +763,6 @@ jobs:
         cargo-clippy,
         cargo-fmt-check,
         cargo-run-e2e-test,
-        cargo-run-e2e-test-evm,
         cargo-test-lib-std,
         cargo-test-workspace,
         cargo-test-sway-lsp,
@@ -843,7 +826,6 @@ jobs:
         cargo-clippy,
         cargo-fmt-check,
         cargo-run-e2e-test,
-        cargo-run-e2e-test-evm,
         cargo-test-lib-std,
         cargo-test-workspace,
         cargo-test-sway-lsp,


### PR DESCRIPTION
## Description

This PR removes the `cargo-run-e2e-test-evm` from the CI. We currently do not support EVM and running the tests only slows the CI down by re-running the tests that are not EVM dependent like, e.g., language tests that fail compiling programs, or snapshot tests that anyhow do not run with the EVM target. All those tests are already tested for FuelVM in both `debug` and `release` mode.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.