### PR TITLE
[WIP] Fuzzing-1: parsing support for `#[fuzz]` and `#[fuzz_param]` attributes**

### DIFF
--- a/sway-ast/src/attribute.rs
+++ b/sway-ast/src/attribute.rs
@@ -33,6 +33,14 @@ pub const DOC_COMMENT_ATTRIBUTE_NAME: &str = "doc-comment";
 pub const TEST_ATTRIBUTE_NAME: &str = "test";
 pub const TEST_SHOULD_REVERT_ARG_NAME: &str = "should_revert";
 
+// In-language fuzz testing.
+pub const FUZZ_ATTRIBUTE_NAME: &str = "fuzz";
+pub const FUZZ_PARAM_ATTRIBUTE_NAME: &str = "fuzz_param";
+pub const FUZZ_PARAM_NAME_ARG_NAME: &str = "name";
+pub const FUZZ_PARAM_ITERATION_ARG_NAME: &str = "iteration";
+pub const FUZZ_PARAM_MIN_VAL_ARG_NAME: &str = "min_val";
+pub const FUZZ_PARAM_MAX_VAL_ARG_NAME: &str = "max_val";
+
 // Allow warnings.
 pub const ALLOW_ATTRIBUTE_NAME: &str = "allow";
 pub const ALLOW_DEAD_CODE_ARG_NAME: &str = "dead_code";
@@ -72,6 +80,8 @@ pub const KNOWN_ATTRIBUTE_NAMES: &[&str] = &[
     DEPRECATED_ATTRIBUTE_NAME,
     FALLBACK_ATTRIBUTE_NAME,
     ABI_NAME_ATTRIBUTE_NAME,
+    FUZZ_ATTRIBUTE_NAME,
+    FUZZ_PARAM_ATTRIBUTE_NAME,
 ];
 
 /// An attribute declaration. Attribute declaration

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -220,7 +220,7 @@ impl TyAstNode {
             } => {
                 let fn_decl = decl_engine.get_function(decl_id);
                 let TyFunctionDecl { attributes, .. } = &*fn_decl;
-                attributes.has_any_of_kind(AttributeKind::Test)
+                attributes.has_any_of_kind(AttributeKind::Test) || attributes.has_any_of_kind(AttributeKind::Fuzz)
             }
             _ => false,
         }

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -543,4 +543,225 @@ mod tests {
         )
         "#);
     }
+
+    #[test]
+    fn parse_fuzz_attribute() {
+        assert_ron_snapshot!(parse::<Attribute>(r#"
+            fuzz
+        "#,), @r#"
+        Attribute(
+          name: BaseIdent(
+            name_override_opt: None,
+            span: Span(
+              src: "\n            fuzz\n        ",
+              start: 13,
+              end: 17,
+              source_id: None,
+            ),
+            is_raw_ident: false,
+          ),
+          args: None,
+        )
+        "#);
+    }
+
+    #[test]
+    fn parse_fuzz_param_attribute() {
+        assert_ron_snapshot!(parse::<Attribute>(r#"
+            fuzz_param(name = "input1", iteration = 100)
+        "#,), @r#"
+        Attribute(
+          name: BaseIdent(
+            name_override_opt: None,
+            span: Span(
+              src: "\n            fuzz_param(name = \"input1\", iteration = 100)\n        ",
+              start: 13,
+              end: 23,
+              source_id: None,
+            ),
+            is_raw_ident: false,
+          ),
+          args: Some(Parens(
+            inner: Punctuated(
+              value_separator_pairs: [
+                (AttributeArg(
+                  name: BaseIdent(
+                    name_override_opt: None,
+                    span: Span(
+                      src: "\n            fuzz_param(name = \"input1\", iteration = 100)\n        ",
+                      start: 24,
+                      end: 28,
+                      source_id: None,
+                    ),
+                    is_raw_ident: false,
+                  ),
+                  value: Some(String(LitString(
+                    span: Span(
+                      src: "\n            fuzz_param(name = \"input1\", iteration = 100)\n        ",
+                      start: 31,
+                      end: 39,
+                      source_id: None,
+                    ),
+                    parsed: "input1",
+                  ))),
+                ), CommaToken(
+                  span: Span(
+                    src: "\n            fuzz_param(name = \"input1\", iteration = 100)\n        ",
+                    start: 39,
+                    end: 40,
+                    source_id: None,
+                  ),
+                )),
+              ],
+              final_value_opt: Some(AttributeArg(
+                name: BaseIdent(
+                  name_override_opt: None,
+                  span: Span(
+                    src: "\n            fuzz_param(name = \"input1\", iteration = 100)\n        ",
+                    start: 41,
+                    end: 50,
+                    source_id: None,
+                  ),
+                  is_raw_ident: false,
+                ),
+                value: Some(Int(LitInt(
+                  span: Span(
+                    src: "\n            fuzz_param(name = \"input1\", iteration = 100)\n        ",
+                    start: 53,
+                    end: 56,
+                    source_id: None,
+                  ),
+                  parsed: [
+                    100,
+                  ],
+                  ty_opt: None,
+                  is_generated_b256: false,
+                ))),
+              )),
+            ),
+            span: Span(
+              src: "\n            fuzz_param(name = \"input1\", iteration = 100)\n        ",
+              start: 23,
+              end: 57,
+              source_id: None,
+            ),
+          )),
+        )
+        "#);
+    }
+
+    #[test]
+    fn parse_fuzz_param_min_max_attribute() {
+        assert_ron_snapshot!(parse::<Attribute>(r#"
+            fuzz_param(name = "input2", min_val = 0, max_val = 255)
+        "#,), @r#"
+        Attribute(
+          name: BaseIdent(
+            name_override_opt: None,
+            span: Span(
+              src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+              start: 13,
+              end: 23,
+              source_id: None,
+            ),
+            is_raw_ident: false,
+          ),
+          args: Some(Parens(
+            inner: Punctuated(
+              value_separator_pairs: [
+                (AttributeArg(
+                  name: BaseIdent(
+                    name_override_opt: None,
+                    span: Span(
+                      src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                      start: 24,
+                      end: 28,
+                      source_id: None,
+                    ),
+                    is_raw_ident: false,
+                  ),
+                  value: Some(String(LitString(
+                    span: Span(
+                      src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                      start: 31,
+                      end: 39,
+                      source_id: None,
+                    ),
+                    parsed: "input2",
+                  ))),
+                ), CommaToken(
+                  span: Span(
+                    src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                    start: 39,
+                    end: 40,
+                    source_id: None,
+                  ),
+                )),
+                (AttributeArg(
+                  name: BaseIdent(
+                    name_override_opt: None,
+                    span: Span(
+                      src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                      start: 41,
+                      end: 48,
+                      source_id: None,
+                    ),
+                    is_raw_ident: false,
+                  ),
+                  value: Some(Int(LitInt(
+                    span: Span(
+                      src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                      start: 51,
+                      end: 52,
+                      source_id: None,
+                    ),
+                    parsed: [],
+                    ty_opt: None,
+                    is_generated_b256: false,
+                  ))),
+                ), CommaToken(
+                  span: Span(
+                    src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                    start: 52,
+                    end: 53,
+                    source_id: None,
+                  ),
+                )),
+              ],
+              final_value_opt: Some(AttributeArg(
+                name: BaseIdent(
+                  name_override_opt: None,
+                  span: Span(
+                    src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                    start: 54,
+                    end: 61,
+                    source_id: None,
+                  ),
+                  is_raw_ident: false,
+                ),
+                value: Some(Int(LitInt(
+                  span: Span(
+                    src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+                    start: 64,
+                    end: 67,
+                    source_id: None,
+                  ),
+                  parsed: [
+                    255,
+                  ],
+                  ty_opt: None,
+                  is_generated_b256: false,
+                ))),
+              )),
+            ),
+            span: Span(
+              src: "\n            fuzz_param(name = \"input2\", min_val = 0, max_val = 255)\n        ",
+              start: 23,
+              end: 68,
+              source_id: None,
+            ),
+          )),
+        )
+        "#);
+    }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "attributes_fuzz_invalid_args"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/Forc.toml
@@ -3,5 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "attributes_fuzz_invalid_args"
-
-[dependencies]
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "attributes_fuzz_invalid_args"
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/src/main.sw
@@ -1,0 +1,15 @@
+library;
+
+#[fuzz(invalid_arg)]
+fn invalid_fuzz_with_args() {
+}
+
+#[fuzz]
+#[fuzz_param]
+fn invalid_fuzz_param_no_args() {
+}
+
+#[fuzz]
+#[fuzz_param(unknown_arg = "value")]
+fn invalid_fuzz_param_unknown_arg() {
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_args/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "attributes_fuzz_invalid_multiplicity"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "attributes_fuzz_invalid_multiplicity"
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/Forc.toml
@@ -3,5 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "attributes_fuzz_invalid_multiplicity"
-
-[dependencies]
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/src/main.sw
@@ -1,0 +1,11 @@
+library;
+
+#[fuzz]
+#[fuzz]
+fn multiple_fuzz_attributes() {
+}
+
+#[test]
+#[fuzz]
+fn both_test_and_fuzz_attributes() {
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_multiplicity/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "attributes_fuzz_invalid_target"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/Forc.toml
@@ -3,5 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "attributes_fuzz_invalid_target"
-
-[dependencies]
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "attributes_fuzz_invalid_target"
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/src/main.sw
@@ -1,0 +1,9 @@
+library;
+
+#[fuzz]
+struct InvalidStruct {
+    field: u64,
+}
+
+#[fuzz_param(name = "input", iteration = 100)]
+const INVALID_CONST: u64 = 42;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/attributes_fuzz_invalid_target/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: $()
+# check: $()

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "attributes_fuzz_valid"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/Forc.toml
@@ -3,5 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "attributes_fuzz_valid"
-
-[dependencies]
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "attributes_fuzz_valid"
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/src/main.sw
@@ -1,0 +1,22 @@
+library;
+
+#[fuzz]
+fn fuzz_simple() {
+}
+
+#[fuzz]
+#[fuzz_param(name = "input1", iteration = 100)]
+fn fuzz_with_single_param(input1: u64) {
+}
+
+#[fuzz]
+#[fuzz_param(name = "input1", iteration = 50)]
+#[fuzz_param(name = "input2", min_val = 0, max_val = 255)]
+fn fuzz_with_multiple_params(input1: u64, input2: u8) {
+}
+
+#[fuzz]
+#[fuzz_param(name = "x", min_val = 1, max_val = 100)]
+#[fuzz_param(name = "y", iteration = 25)]
+fn fuzz_with_mixed_params(x: u32, y: u64) {
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/attributes_fuzz_valid/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# check: $()


### PR DESCRIPTION
### DISCLAIMER
Currently still experimenting, will come up with the RFC once the I have a more robust mindset around how to expose this to the user

----

This PR adds parsing infrastructure for fuzz testing attributes in preparation for future fuzzing capabilities. The implementation follows the same patterns as existing `#[test]` attributes.

## Changes

- **Attribute constants**: Added `FUZZ_ATTRIBUTE_NAME`, `FUZZ_PARAM_ATTRIBUTE_NAME` and parameter names
- **AttributeKind variants**: New `Fuzz` and `FuzzParam` enum variants with proper validation
- **Function detection**: Updated `is_test_function()` to include fuzz functions
- **Test entry processing**: Modified to handle fuzz functions alongside test functions

## Usage Examples

Basic fuzz function:
```rust
#[fuzz]
fn fuzz_my_function(input: u64) {
    // fuzz test logic
}
```

With parameters:
```rust
#[fuzz]
#[fuzz_param(name = "input", iteration = 1000)]
#[fuzz_param(name = "seed", min_val = 0, max_val = 100)]
fn fuzz_with_params(input: u64, seed: u32) {
    // parameterized fuzz test
}
```

## Implementation Notes

- Functions cannot have both `#[test]` and `#[fuzz]` attributes
- `#[fuzz]` attribute expects no arguments (similar to `#[test]`)
- `#[fuzz_param]` supports `name`, `iteration`, `min_val`, `max_val` arguments
- Multiple `#[fuzz_param]` attributes allowed per function
- Only one `#[fuzz]` attribute per function

## Testing

Added comprehensive test coverage:
- Unit tests for attribute parsing
- E2E tests for valid usage patterns
- Error cases for invalid targets, arguments, and multiplicity