### PR TITLE
[WIP] feat: support multi environment for proxy deployment

### DIFF
--- a/docs/book/src/forc/plugins/forc_client/index.md
+++ b/docs/book/src/forc/plugins/forc_client/index.md
@@ -183,6 +183,37 @@ address = "0xd8c4b07a0d1be57b228f4c18ba7bca0c8655eb6e9d695f14080f2cf4fc7cd946" #
 
 If an `address` is present, `forc` calls into that contract to update its `target` instead of deploying a new contract. Since a new proxy deployment adds its own `address` into the `Forc.toml` automatically, you can simply enable the proxy once and after the initial deployment, `forc` will keep updating the target accordingly for each new deployment of the same contract.
 
+### Multi-Network Proxy Support
+
+For projects that need to deploy across multiple networks (testnet, mainnet, devnet, local), you can configure network-specific proxy addresses using the `addresses` table instead of a single `address` field:
+
+```TOML
+[project]
+name = "test_contract"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false
+
+[proxy]
+enabled = true
+
+[proxy.addresses]
+testnet = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+mainnet = "0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"
+devnet = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+local = "0x567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456"
+```
+
+When using network-specific proxy addresses:
+- `forc-deploy` automatically determines the current network and uses the appropriate proxy address
+- If no proxy address is configured for the current network, a new proxy contract will be deployed
+- The proxy address for the current network is automatically updated in `Forc.toml` after deployment
+
+**Note:** The `address` and `addresses` fields are mutually exclusive. Use `address` for single-network deployments or `addresses` for multi-network setups.
+
+This approach eliminates the need to manually update proxy addresses when switching between networks, making multi-network deployment workflows much more robust.
+
 ## Large Contracts
 
 For contracts over the maximum contract size limit (currently `100kB`) defined by the network, `forc-deploy` will split the contract into chunks and deploy the contract with multiple transactions using the Rust SDK's [loader contract](https://github.com/FuelLabs/fuels-rs/blob/master/docs/src/deploying/large_contracts.md) functionality. Chunks that have already been deployed will be reused on subsequent deployments.

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -3,7 +3,7 @@ use crate::{
     constants::TX_SUBMIT_TIMEOUT_MS,
     util::{
         account::ForcClientAccount,
-        pkg::{built_pkgs, create_proxy_contract, update_proxy_address_in_manifest},
+        pkg::{built_pkgs, create_proxy_contract, update_proxy_address_in_manifest_for_network},
         target::Target,
         tx::{
             check_and_create_wallet_at_default_path, prompt_forc_wallet_password, select_account,
@@ -44,6 +44,34 @@ use std::{
     time::Duration,
 };
 use sway_core::{asm_generation::ProgramABI, language::parsed::TreeType, BuildTarget};
+
+/// Resolves the proxy address for the current network context.
+/// 
+/// Uses the network name from chain info to look up network-specific proxy addresses,
+/// falling back to the single address field for backward compatibility.
+fn resolve_proxy_address_for_network(
+    proxy: &forc_pkg::manifest::Proxy,
+    chain_info: &fuels::types::chain_info::ChainInfo,
+) -> Option<String> {
+    if !proxy.enabled {
+        return None;
+    }
+
+    let target = Target::from_str(&chain_info.name).unwrap_or_default();
+    let network_name = match target {
+        Target::Testnet => "testnet",
+        Target::Mainnet => "mainnet", 
+        Target::Devnet => "devnet",
+        Target::Local => "local",
+    };
+
+    // First try network-specific addresses
+    if let Some(address) = proxy.address_for_network(network_name) {
+        Some(address.clone())
+    } else {
+        None
+    }
+}
 
 /// Default maximum contract size allowed for a single contract. If the target
 /// contract size is bigger than this amount, forc-deploy will automatically
@@ -553,45 +581,45 @@ pub async fn deploy_contracts(
             deploy_pkg(command, pkg, salt, &provider, &account).await?
         };
 
+        // Get chain info to resolve network-specific proxy addresses
+        let chain_info = provider.chain_info().await?;
         let proxy_id = match &pkg.descriptor.manifest_file.proxy {
-            Some(forc_pkg::manifest::Proxy {
-                enabled: true,
-                address: Some(proxy_addr),
-            }) => {
-                // Make a call into the contract to update impl contract address to 'deployed_contract'.
+            Some(proxy) if proxy.enabled => {
+                if let Some(proxy_addr) = resolve_proxy_address_for_network(proxy, &chain_info) {
+                    // Make a call into the contract to update impl contract address to 'deployed_contract'.
 
-                // Create a contract instance for the proxy contract using default proxy contract abi and
-                // specified address.
-                let proxy_contract =
-                    ContractId::from_str(proxy_addr).map_err(|e| anyhow::anyhow!(e))?;
+                    // Create a contract instance for the proxy contract using default proxy contract abi and
+                    // specified address.
+                    let proxy_contract =
+                        ContractId::from_str(&proxy_addr).map_err(|e| anyhow::anyhow!(e))?;
 
-                update_proxy_contract_target(&account, proxy_contract, deployed_contract_id)
+                    update_proxy_contract_target(&account, proxy_contract, deployed_contract_id)
+                        .await?;
+                    Some(proxy_contract)
+                } else {
+                    // No proxy address configured for this network, deploy a new one
+                    let pkg_name = &pkg.descriptor.name;
+                    let pkg_storage_slots = &pkg.storage_slots;
+                    // Deploy a new proxy contract.
+                    let deployed_proxy_contract = deploy_new_proxy(
+                        command,
+                        pkg_name,
+                        pkg_storage_slots,
+                        &deployed_contract_id,
+                        &provider,
+                        &account,
+                    )
                     .await?;
-                Some(proxy_contract)
-            }
-            Some(forc_pkg::manifest::Proxy {
-                enabled: true,
-                address: None,
-            }) => {
-                let pkg_name = &pkg.descriptor.name;
-                let pkg_storage_slots = &pkg.storage_slots;
-                // Deploy a new proxy contract.
-                let deployed_proxy_contract = deploy_new_proxy(
-                    command,
-                    pkg_name,
-                    pkg_storage_slots,
-                    &deployed_contract_id,
-                    &provider,
-                    &account,
-                )
-                .await?;
 
-                // Update manifest file such that the proxy address field points to the new proxy contract.
-                update_proxy_address_in_manifest(
-                    &format!("0x{}", deployed_proxy_contract),
-                    &pkg.descriptor.manifest_file,
-                )?;
-                Some(deployed_proxy_contract)
+                    // Update manifest file such that the proxy address field points to the new proxy contract.
+                    // This will now use network-aware updating logic
+                    update_proxy_address_in_manifest_for_network(
+                        &format!("0x{}", deployed_proxy_contract),
+                        &pkg.descriptor.manifest_file,
+                        &chain_info,
+                    )?;
+                    Some(deployed_proxy_contract)
+                }
             }
             // Proxy not enabled.
             _ => None,
@@ -621,12 +649,9 @@ async fn confirm_transaction_details(
         .map(|pkg| {
             tx_count += 1;
             let proxy_text = match &pkg.descriptor.manifest_file.proxy {
-                Some(forc_pkg::manifest::Proxy {
-                    enabled: true,
-                    address,
-                }) => {
+                Some(proxy) if proxy.enabled => {
                     tx_count += 1;
-                    if address.is_some() {
+                    if proxy.has_address() {
                         " + update proxy"
                     } else {
                         " + deploy proxy"


### PR DESCRIPTION
Related to #7346

## Summary
- Adds support for network-specific proxy addresses to solve multi-network deployment fragility
- Enables robust deployment workflows across testnet, mainnet, devnet, and local networks
- Maintains full backward compatibility with existing single proxy address configuration

## Changes
- **Proxy Configuration**: Added `addresses` table for network-specific proxy addresses
- **Network Resolution**: Automatic network detection and proxy address resolution during deployment
- **Manifest Updates**: Network-aware proxy address writing and migration from single to multi-network format
- **Validation**: Mutual exclusivity validation between `address` and `addresses` fields
- **Documentation**: Updated with examples and migration guidance

## Configuration Examples
**Before (single network)**:
```toml
[proxy]
enabled = true
address = "0x1234..."
```

**After (multi-network)**:
```toml
[proxy]
enabled = true

[proxy.addresses]
testnet = "0x1234..."
mainnet = "0x5678..."
```

## Testing
- Comprehensive unit tests for network resolution and validation
- Integration tests for deployment workflows
- Backward compatibility verification

