### PR TITLE
Enable `storage_vec_iter_tests` in-language test

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/test.toml
@@ -1,6 +1,4 @@
-# TODO Enable this test once https://github.com/FuelLabs/sway/issues/6899 is fixed.
-#      Compilation fails with error: No method "contains4(Data2<u64, u64>, Data2<numeric, numeric>) -> bool" found for type "Data2<T, K>".
-category = "disabled"
+category = "run"
 expected_result = { action = "return", value = 10 }
 expected_result_new_encoding = { action = "return_data", value = "000000000000000A" }
 validate_abi = true

--- a/test/src/in_language_tests/Forc.toml
+++ b/test/src/in_language_tests/Forc.toml
@@ -30,9 +30,7 @@ members = [
   "test_programs/result_inline_tests",
   "test_programs/revert_inline_tests",
   "test_programs/storage_key_inline_tests",
-# TODO: Enable this test once https://github.com/FuelLabs/sway/issues/6899 is fixed.
-#       Compilation fails with error: No method "eq(Self, Self) -> ()" found for type "Self".
-#  "test_programs/storage_vec_iter_tests",
+  "test_programs/storage_vec_iter_tests",
   "test_programs/string_inline_tests",
   "test_programs/time_inline_tests",
   "test_programs/tx_inline_tests",


### PR DESCRIPTION
## Description

This PR brings the `storage_vec_iter_tests` in-language test to the newest compiler version and enables it. The test was originally disabled because of #6899 which has been fixed. The test also had trait coherence violations that are fixed in this PR.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.