### PR TITLE
chore: fix typos

### DIFF
--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -272,7 +272,7 @@ pub(crate) fn attr_decls_to_attributes(
         if attributes_of_kind.len() > 1 {
             let (last_attribute, previous_attributes) = attributes_of_kind
                 .split_last()
-                .expect("`attributes_of_kind` has more then one element");
+                .expect("`attributes_of_kind` has more than one element");
             handler.emit_err(
                 ConvertParseTreeError::InvalidAttributeMultiplicity {
                     last_occurrence: (&last_attribute.name).into(),

--- a/sway-core/src/metadata.rs
+++ b/sway-core/src/metadata.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 #[derive(Default)]
 pub(crate) struct MetadataManager {
-    // We want to be able to store more then one `Span` per `MetadataIndex`.
+    // We want to be able to store more than one `Span` per `MetadataIndex`.
     // E.g., storing the span of the function name, and the whole function declaration.
     // The spans differ then by the tag property of their `Metadatum::Struct`.
     // We could cache all such spans in a single `HashMap` where the key would be `(Span, tag)`.

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -111,14 +111,14 @@ pub(super) enum ReqDeclNode {
     /// E.g., a literal `123` will have a requirement on the scrutinee e.g. `struct.x == 123`.
     ReqOrVarDecl(ReqOrVarDecl),
     /// Represent the requirements and declarations connected with the lazy AND operator,
-    /// if there are more then two of them.
+    /// if there are more than two of them.
     /// Notice that the vector of contained nodes can be empty or have only one element.
     /// AND semantics is applied if there are two or more elements.
     /// E.g., requirements coming from the struct and tuple patterns
     /// must all be fulfilled in order for the whole pattern to match.
     And(Vec<ReqDeclNode>),
     /// Represent the requirements and declarations connected with the lazy OR operator,
-    /// if there are more then two of them.
+    /// if there are more than two of them.
     /// Notice that the vector of contained nodes can be empty or have only one element.
     /// OR semantics is applied if there are two or more elements.
     /// Only the requirements coming from the individual variants of an OR match arm

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -412,7 +412,7 @@ fn instantiate_branch_condition_result_var_declarations_and_matched_or_variant_i
                         // return the calculated condition and no carry overs.
                         // `vars` and `tuples` will be empty after appending.
 
-                        // Note that if we have more then one tuple in carry over, this means they
+                        // Note that if we have more than one tuple in carry over, this means they
                         // are coming from an AND node (because an OR node always produces a single tuple).
                         // In that case the `vars` redefined in tuples are never the same and we can
                         // safely declare them in any order after the tuples.

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -959,7 +959,7 @@ impl ty::TyExpression {
                 &arms_reachability[..catch_all_arm_position],
             );
         }
-        // if there are no interior catch-all arms and there is more then one arm
+        // if there are no interior catch-all arms and there is more than one arm
         else if let Some((last_arm_report, other_arms_reachability)) =
             arms_reachability.split_last()
         {

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -710,7 +710,7 @@ fn check_is_valid_error_type_enum(
     {
         let (last_occurrence, previous_occurrences) = duplicated_error_messages
             .split_last()
-            .expect("`duplicated_error_messages` has more then one element");
+            .expect("`duplicated_error_messages` has more than one element");
         handler.emit_warn(CompileWarning {
             span: last_occurrence.clone(),
             warning_content: Warning::ErrorDuplicatedErrorMessage {

--- a/sway-ir/src/analysis/memory_utils.rs
+++ b/sway-ir/src/analysis/memory_utils.rs
@@ -360,7 +360,7 @@ pub fn get_gep_symbol(context: &Context, val: Value) -> Option<Symbol> {
 }
 
 /// Return [Symbol] referred by `val` if there is _exactly one_ symbol referred,
-/// or `None` if there are no [Symbol]s referred or if there is more then one
+/// or `None` if there are no [Symbol]s referred or if there is more than one
 /// referred.
 pub fn get_referred_symbol(context: &Context, val: Value) -> Option<Symbol> {
     let syms = get_referred_symbols(context, val);


### PR DESCRIPTION
## Description

Corrected misspellings:
- `more then` → `more than`