### PR TITLE
Apply Clippy's `uninlined_format_args` lint

### DIFF
--- a/forc-pkg/src/manifest/dep_modifier.rs
+++ b/forc-pkg/src/manifest/dep_modifier.rs
@@ -287,7 +287,7 @@ impl fmt::Display for Section {
             Section::Deps => "dependencies",
             Section::ContractDeps => "contract-dependencies",
         };
-        write!(f, "{}", section)
+        write!(f, "{section}")
     }
 }
 
@@ -335,12 +335,12 @@ impl Section {
                     Dependency::Simple(ver) => {
                         let mut inline = InlineTable::default();
                         inline.insert("version", Value::from(ver.to_string()));
-                        inline.insert("salt", Value::from(format!("0x{}", salt)));
+                        inline.insert("salt", Value::from(format!("0x{salt}")));
                         Item::Value(toml_edit::Value::InlineTable(inline))
                     }
                     Dependency::Detailed(details) => {
                         let mut inline = generate_table(details);
-                        inline.insert("salt", Value::from(format!("0x{}", salt)));
+                        inline.insert("salt", Value::from(format!("0x{salt}")));
                         Item::Value(toml_edit::Value::InlineTable(inline))
                     }
                 };
@@ -445,11 +445,10 @@ mod tests {
             authors = ["Test"]
             entry = "main.sw"
             license = "MIT"
-            name = "{}"
+            name = "{name}"
             
             [dependencies]
-        "#,
-            name
+        "#
         );
         fs::write(base_path.join("Forc.toml"), forc_toml)?;
 
@@ -500,11 +499,10 @@ mod tests {
                 authors = ["Test"]
                 entry = "main.sw"
                 license = "MIT"
-                name = "{}"
+                name = "{name}"
                 
                 [dependencies]
-            "#,
-                name
+            "#
             );
             fs::write(member_path.join("Forc.toml"), forc_toml)?;
 
@@ -942,7 +940,7 @@ mod tests {
         let base_path = temp_dir.path();
         let package_dir = base_path.join("pkg1");
         let dep = "pkg1";
-        let resp = format!("cannot add `{}` as a dependency to itself", dep);
+        let resp = format!("cannot add `{dep}` as a dependency to itself");
 
         let manifest_file = ManifestFile::from_dir(base_path).unwrap();
         let members = manifest_file.member_manifests().unwrap();
@@ -1062,7 +1060,7 @@ mod tests {
         );
         assert_eq!(
             contract_table.get("salt").unwrap().as_str(),
-            Some(format!("0x{}", hex_salt).as_str())
+            Some(format!("0x{hex_salt}").as_str())
         );
     }
 

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -277,7 +277,7 @@ impl FromStr for HexSalt {
 impl Display for HexSalt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let salt = self.0;
-        write!(f, "{}", salt)
+        write!(f, "{salt}")
     }
 }
 

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -700,10 +700,7 @@ impl BuildPlan {
         // longer exists at its specified location, etc. We must first remove all invalid nodes
         // before we can determine what we need to fetch.
         let invalid_deps = validate_graph(&graph, manifests)?;
-        let members: HashSet<String> = manifests
-            .iter()
-            .map(|(member_name, _)| member_name.clone())
-            .collect();
+        let members: HashSet<String> = manifests.keys().cloned().collect();
         remove_deps(&mut graph, &members, &invalid_deps);
 
         // We know that the remaining nodes have valid paths, otherwise they would have been
@@ -741,11 +738,11 @@ impl BuildPlan {
             }
             println_action_green(
                 "Creating",
-                &format!("a new `Forc.lock` file. (Cause: {})", cause),
+                &format!("a new `Forc.lock` file. (Cause: {cause})"),
             );
             let member_names = manifests
-                .iter()
-                .map(|(_, manifest)| manifest.project.name.to_string())
+                .values()
+                .map(|manifest| manifest.project.name.to_string())
                 .collect();
             crate::lock::print_diff(&member_names, &lock_diff);
             let string = toml::ser::to_string_pretty(&new_lock)

--- a/forc-pkg/src/source/ipfs.rs
+++ b/forc-pkg/src/source/ipfs.rs
@@ -93,8 +93,7 @@ impl source::Fetch for Pinned {
                             println_action_green(
                                 "Fetching",
                                 &format!(
-                                    "from {}. Note: This can take several minutes.",
-                                    ipfs_node_gateway_url
+                                    "from {ipfs_node_gateway_url}. Note: This can take several minutes."
                                 ),
                             );
                             cid.fetch_with_gateway_url(&ipfs_node_gateway_url, &dest)
@@ -274,7 +273,7 @@ mod tests {
 
         // Add files
         for (path, content) in files {
-            let full_path = format!("test-project/{}", path);
+            let full_path = format!("test-project/{path}");
             let header = create_header(&full_path, content.len() as u64);
             ar.append(&header, content.as_bytes()).unwrap();
         }

--- a/forc-pkg/src/source/reg/index_file.rs
+++ b/forc-pkg/src/source/reg/index_file.rs
@@ -354,7 +354,7 @@ mod tests {
 
         // Test round-trip serialization
         let serialized = serde_json::to_string_pretty(&deserialized).unwrap();
-        println!("Re-serialized JSON: {}", serialized);
+        println!("Re-serialized JSON: {serialized}");
 
         // Deserialize again to ensure it's valid
         let re_deserialized: IndexFile = serde_json::from_str(&serialized).unwrap();

--- a/forc-pkg/src/source/reg/mod.rs
+++ b/forc-pkg/src/source/reg/mod.rs
@@ -469,7 +469,7 @@ async fn fetch(fetch_id: u64, pinned: &Pinned, ipfs_node: &IPFSNode) -> anyhow::
                 IPFSNode::WithUrl(gateway_url) => {
                     println_action_green(
                         "Fetching",
-                        &format!("from {}. Note: This can take several minutes.", gateway_url),
+                        &format!("from {gateway_url}. Note: This can take several minutes."),
                     );
                     cid.fetch_with_gateway_url(gateway_url, &path).await
                 }
@@ -477,12 +477,9 @@ async fn fetch(fetch_id: u64, pinned: &Pinned, ipfs_node: &IPFSNode) -> anyhow::
 
             // If IPFS fails, try CDN fallback
             if let Err(ipfs_error) = ipfs_result {
-                println_action_green("Warning", &format!("IPFS fetch failed: {}", ipfs_error));
+                println_action_green("Warning", &format!("IPFS fetch failed: {ipfs_error}"));
                 fetch_from_s3(pinned, &path).await.with_context(|| {
-                    format!(
-                        "Both IPFS and CDN fallback failed. IPFS error: {}",
-                        ipfs_error
-                    )
+                    format!("Both IPFS and CDN fallback failed. IPFS error: {ipfs_error}")
                 })?;
             }
 
@@ -600,10 +597,7 @@ where
 
     let contents = index_response.text().await?;
     let index_file: IndexFile = serde_json::from_str(&contents).with_context(|| {
-        format!(
-            "Unable to deserialize a github registry lookup response. Body was: \"{}\"",
-            contents
-        )
+        format!("Unable to deserialize a github registry lookup response. Body was: \"{contents}\"")
     })?;
 
     let res = f(index_file).await?;

--- a/forc-plugins/forc-client/build.rs
+++ b/forc-plugins/forc-client/build.rs
@@ -33,10 +33,8 @@ fn update_proxy_abi_decl_with_file(source_file_path: &Path, minified_json: &str)
 
     // Prepare the replacement string for the `abigen!` macro
     let escaped_json = minified_json.replace('\\', "\\\\").replace('"', "\\\"");
-    let new_abigen = format!(
-        "abigen!(Contract(name = \"ProxyContract\", abi = \"{}\",));",
-        escaped_json
-    );
+    let new_abigen =
+        format!("abigen!(Contract(name = \"ProxyContract\", abi = \"{escaped_json}\",));");
 
     // Use a regular expression to find and replace the `abigen!` macro
     let re = regex::Regex::new(r#"abigen!\(Contract\(name = "ProxyContract", abi = ".*?",\)\);"#)

--- a/forc-plugins/forc-client/src/bin/call.rs
+++ b/forc-plugins/forc-client/src/bin/call.rs
@@ -21,7 +21,7 @@ async fn main() {
         }
     };
     if let Err(err) = forc_client::op::call(operation, command).await {
-        println_error(&format!("{}", err));
+        println_error(&format!("{err}"));
         std::process::exit(1);
     }
 }

--- a/forc-plugins/forc-client/src/bin/deploy.rs
+++ b/forc-plugins/forc-client/src/bin/deploy.rs
@@ -6,7 +6,7 @@ async fn main() {
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Deploy::parse();
     if let Err(err) = forc_client::op::deploy(command).await {
-        println_error(&format!("{}", err));
+        println_error(&format!("{err}"));
         std::process::exit(1);
     }
 }

--- a/forc-plugins/forc-client/src/bin/run.rs
+++ b/forc-plugins/forc-client/src/bin/run.rs
@@ -6,7 +6,7 @@ async fn main() {
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Run::parse();
     if let Err(err) = forc_client::op::run(command).await {
-        println_error(&format!("{}", err));
+        println_error(&format!("{err}"));
         std::process::exit(1);
     }
 }

--- a/forc-plugins/forc-client/src/bin/submit.rs
+++ b/forc-plugins/forc-client/src/bin/submit.rs
@@ -6,7 +6,7 @@ async fn main() {
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Submit::parse();
     if let Err(err) = forc_client::op::submit(command).await {
-        println_error(&format!("{}", err));
+        println_error(&format!("{err}"));
         std::process::exit(1);
     }
 }

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -151,8 +151,8 @@ impl std::fmt::Display for AbiSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AbiSource::File(path) => write!(f, "{}", path.display()),
-            AbiSource::Url(url) => write!(f, "{}", url),
-            AbiSource::String(s) => write!(f, "{}", s),
+            AbiSource::Url(url) => write!(f, "{url}"),
+            AbiSource::String(s) => write!(f, "{s}"),
         }
     }
 }
@@ -471,34 +471,28 @@ impl Command {
 fn parse_contract_abi(s: &str) -> Result<(ContractId, AbiSource), String> {
     let parts: Vec<&str> = s.trim().split(':').collect();
     let [contract_id_str, abi_path_str] = parts.try_into().map_err(|_| {
-        format!(
-            "Invalid contract ABI format: '{}'. Expected format: contract_id:abi_path",
-            s
-        )
+        format!("Invalid contract ABI format: '{s}'. Expected format: contract_id:abi_path")
     })?;
 
     let contract_id =
         ContractId::from_str(&format!("0x{}", contract_id_str.trim_start_matches("0x")))
-            .map_err(|e| format!("Invalid contract ID '{}': {}", contract_id_str, e))?;
+            .map_err(|e| format!("Invalid contract ID '{contract_id_str}': {e}"))?;
 
     let abi_path = AbiSource::try_from(abi_path_str.to_string())
-        .map_err(|e| format!("Invalid ABI path '{}': {}", abi_path_str, e))?;
+        .map_err(|e| format!("Invalid ABI path '{abi_path_str}': {e}"))?;
 
     Ok((contract_id, abi_path))
 }
 
 fn parse_label(s: &str) -> Result<(ContractId, String), String> {
     let parts: Vec<&str> = s.trim().split(':').collect();
-    let [contract_id_str, label] = parts.try_into().map_err(|_| {
-        format!(
-            "Invalid label format: '{}'. Expected format: contract_id:label",
-            s
-        )
-    })?;
+    let [contract_id_str, label] = parts
+        .try_into()
+        .map_err(|_| format!("Invalid label format: '{s}'. Expected format: contract_id:label"))?;
 
     let contract_id =
         ContractId::from_str(&format!("0x{}", contract_id_str.trim_start_matches("0x")))
-            .map_err(|e| format!("Invalid contract ID '{}': {}", contract_id_str, e))?;
+            .map_err(|e| format!("Invalid contract ID '{contract_id_str}': {e}"))?;
 
     Ok((contract_id, label.to_string()))
 }

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -132,7 +132,7 @@ pub async fn call_function(
                     "Automatically provided external contract addresses with call (max 10):",
                 );
                 external_contracts.iter().for_each(|addr| {
-                    forc_tracing::println_warning(&format!("- 0x{}", addr));
+                    forc_tracing::println_warning(&format!("- 0x{addr}"));
                 });
             }
             external_contracts
@@ -917,8 +917,8 @@ pub mod tests {
         let (_, id_2, _, _) = get_contract_instance().await;
         let (amount, asset_id, recipient) = (
             "1",
-            &format!("{{0x{}}}", base_asset_id),
-            &format!("(ContractId:{{0x{}}})", id_2),
+            &format!("{{0x{base_asset_id}}}"),
+            &format!("(ContractId:{{0x{id_2}}})"),
         );
         let mut cmd = get_contract_call_cmd(
             id,
@@ -952,7 +952,7 @@ pub mod tests {
         let random_wallet = Wallet::random(&mut rand::thread_rng(), provider.clone());
         let (amount, asset_id, recipient) = (
             "2",
-            &format!("{{0x{}}}", base_asset_id),
+            &format!("{{0x{base_asset_id}}}"),
             &format!("(Address:{{0x{}}})", random_wallet.address()),
         );
         let mut cmd = get_contract_call_cmd(
@@ -982,7 +982,7 @@ pub mod tests {
         let random_wallet = Wallet::random(&mut rand::thread_rng(), provider.clone());
         let (amount, asset_id, recipient) = (
             "5",
-            &format!("{{0x{}}}", base_asset_id),
+            &format!("{{0x{base_asset_id}}}"),
             &format!("(Address:{{0x{}}})", random_wallet.address()),
         );
         let mut cmd = get_contract_call_cmd(
@@ -1010,7 +1010,7 @@ pub mod tests {
         let random_wallet = Wallet::random(&mut rand::thread_rng(), provider.clone());
         let (amount, asset_id, recipient) = (
             "3",
-            &format!("{{0x{}}}", base_asset_id),
+            &format!("{{0x{base_asset_id}}}"),
             &format!("(Address:{{0x{}}})", random_wallet.address()),
         );
         let mut cmd = get_contract_call_cmd(

--- a/forc-plugins/forc-client/src/op/call/list_functions.rs
+++ b/forc-plugins/forc-client/src/op/call/list_functions.rs
@@ -48,12 +48,12 @@ fn list_functions_for_single_contract<W: Write>(
     writer: &mut W,
 ) -> Result<()> {
     let header = if is_main_contract {
-        format!("Callable functions for contract: {}\n", contract_id)
+        format!("Callable functions for contract: {contract_id}\n")
     } else {
-        format!("Functions for additional contract: {}\n", contract_id)
+        format!("Functions for additional contract: {contract_id}\n")
     };
 
-    writeln!(writer, "{}", header)?;
+    writeln!(writer, "{header}")?;
 
     if abi.unified.functions.is_empty() {
         writeln!(writer, "No functions found in the contract ABI.\n")?;
@@ -107,7 +107,7 @@ fn list_functions_for_single_contract<W: Write>(
                 | ParamType::Struct { .. }
                 | ParamType::Enum { .. }
                 | ParamType::RawSlice
-                | ParamType::Vector(_) => format!("\"{}\"", func_args_input),
+                | ParamType::Vector(_) => format!("\"{func_args_input}\""),
                 _ => func_args_input.to_owned(),
             })
             .collect::<Vec<String>>()
@@ -124,11 +124,7 @@ fn list_functions_for_single_contract<W: Write>(
             })?;
 
         let painted_name = forc_util::ansiterm::Colour::Blue.paint(func.name.clone());
-        writeln!(
-            writer,
-            "{}({}) -> {}",
-            painted_name, func_args_types, return_type
-        )?;
+        writeln!(writer, "{painted_name}({func_args_types}) -> {return_type}")?;
         writeln!(
             writer,
             "  forc call \\\n      --abi {} \\\n      {} \\\n      {} {}\n",
@@ -189,10 +185,7 @@ mod tests {
             // Verify the ABI source is preserved exactly as provided
             assert!(
                 output_string.contains(expected_abi_arg),
-                "Test '{}' failed: expected '{}' in output, but got:\n{}",
-                test_name,
-                expected_abi_arg,
-                output_string
+                "Test '{test_name}' failed: expected '{expected_abi_arg}' in output, but got:\n{output_string}"
             );
         }
     }

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -219,10 +219,10 @@ impl FromStr for Abi {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let program: ProgramABI =
-            serde_json::from_str(s).map_err(|err| format!("failed to parse ABI: {}", err))?;
+            serde_json::from_str(s).map_err(|err| format!("failed to parse ABI: {err}"))?;
 
         let unified = UnifiedProgramABI::from_counterpart(&program)
-            .map_err(|err| format!("conversion to unified ABI format failed: {}", err))?;
+            .map_err(|err| format!("conversion to unified ABI format failed: {err}"))?;
 
         let type_lookup = unified
             .types
@@ -257,7 +257,7 @@ pub(crate) fn display_tx_info(
         if let Some(explorer_url) = node.get_explorer_url() {
             forc_tracing::println_label_green(
                 "\nView transaction:",
-                &format!("{}/tx/0x{}\n", explorer_url, tx_hash),
+                &format!("{explorer_url}/tx/0x{tx_hash}\n"),
             );
         }
     }
@@ -318,7 +318,7 @@ pub(crate) fn display_detailed_call_info(
         if !logs.is_empty() {
             forc_tracing::println_green_bold("logs:");
             for log in logs.iter() {
-                writeln!(writer, "  {:#}", log)?;
+                writeln!(writer, "  {log:#}")?;
             }
         }
     }
@@ -350,20 +350,18 @@ pub async fn create_abi_map(
                         abi_map.insert(contract_id, additional_abi.with_source(abi_path.clone()));
                         forc_tracing::println_action_green(
                             "Loaded additional ABI for contract",
-                            &format!("0x{}", contract_id),
+                            &format!("0x{contract_id}"),
                         );
                     }
                     Err(e) => {
                         forc_tracing::println_warning(&format!(
-                            "Failed to parse ABI for contract 0x{}: {}",
-                            contract_id, e
+                            "Failed to parse ABI for contract 0x{contract_id}: {e}"
                         ));
                     }
                 },
                 Err(e) => {
                     forc_tracing::println_warning(&format!(
-                        "Failed to load ABI for contract 0x{}: {}",
-                        contract_id, e
+                        "Failed to load ABI for contract 0x{contract_id}: {e}"
                     ));
                 }
             }

--- a/forc-plugins/forc-client/src/op/call/parser.rs
+++ b/forc-plugins/forc-client/src/op/call/parser.rs
@@ -256,24 +256,24 @@ pub fn token_to_string(token: &Token) -> Result<String> {
         Token::B256(bytes) => {
             let mut hex = String::with_capacity(bytes.len() * 2);
             for byte in bytes {
-                write!(hex, "{:02x}", byte).unwrap();
+                write!(hex, "{byte:02x}").unwrap();
             }
-            Ok(format!("0x{}", hex))
+            Ok(format!("0x{hex}"))
         }
         Token::Bytes(bytes) => {
             let mut hex = String::with_capacity(bytes.len() * 2);
             for byte in bytes {
-                write!(hex, "{:02x}", byte).unwrap();
+                write!(hex, "{byte:02x}").unwrap();
             }
-            Ok(format!("0x{}", hex))
+            Ok(format!("0x{hex}"))
         }
         Token::String(s) => Ok(s.clone()),
         Token::RawSlice(bytes) => {
             let mut hex = String::with_capacity(bytes.len() * 2);
             for byte in bytes {
-                write!(hex, "{:02x}", byte).unwrap();
+                write!(hex, "{byte:02x}").unwrap();
             }
-            Ok(format!("0x{}", hex))
+            Ok(format!("0x{hex}"))
         }
         Token::StringArray(token) => Ok(token.get_encodable_str().map(|s| s.to_string())?),
         Token::StringSlice(token) => token
@@ -448,7 +448,7 @@ pub fn param_to_function_arg(param_type: &ParamType) -> String {
         ParamType::Bytes => "Bytes".to_string(),
         ParamType::String => "str".to_string(),
         ParamType::RawSlice => "RawSlice".to_string(),
-        ParamType::StringArray(size) => format!("str[{}]", size),
+        ParamType::StringArray(size) => format!("str[{size}]"),
         ParamType::StringSlice => "str".to_string(),
         ParamType::Tuple(types) => {
             let inner = types

--- a/forc-plugins/forc-client/src/op/call/transfer.rs
+++ b/forc-plugins/forc-client/src/op/call/transfer.rs
@@ -17,8 +17,7 @@ pub async fn transfer(
     let tx_response = if provider.is_user_account(*recipient).await? {
         writeln!(
             writer,
-            "\nTransferring {} 0x{} to recipient address 0x{}...\n",
-            amount, asset_id, recipient
+            "\nTransferring {amount} 0x{asset_id} to recipient address 0x{recipient}...\n"
         )?;
         wallet
             .transfer(recipient, amount, asset_id, tx_policies)
@@ -27,8 +26,7 @@ pub async fn transfer(
     } else {
         writeln!(
             writer,
-            "\nTransferring {} 0x{} to contract address 0x{}...\n",
-            amount, asset_id, recipient
+            "\nTransferring {amount} 0x{asset_id} to contract address 0x{recipient}...\n"
         )?;
         let contract_id = (*recipient).into();
         wallet

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -588,7 +588,7 @@ pub async fn deploy_contracts(
 
                 // Update manifest file such that the proxy address field points to the new proxy contract.
                 update_proxy_address_in_manifest(
-                    &format!("0x{}", deployed_proxy_contract),
+                    &format!("0x{deployed_proxy_contract}"),
                     &pkg.descriptor.manifest_file,
                 )?;
                 Some(deployed_proxy_contract)
@@ -709,11 +709,11 @@ pub async fn deploy_pkg(
                 // Create a deployment artifact.
                 create_deployment_artifact(
                     DeploymentArtifact {
-                        transaction_id: format!("0x{}", transaction_id),
-                        salt: format!("0x{}", salt),
+                        transaction_id: format!("0x{transaction_id}"),
+                        salt: format!("0x{salt}"),
                         network_endpoint: node_url.to_string(),
                         chain_id,
-                        contract_id: format!("0x{}", contract_id),
+                        contract_id: format!("0x{contract_id}"),
                         deployment_size: bytecode.len(),
                         deployed_block_height: None,
                     },
@@ -743,10 +743,10 @@ pub async fn deploy_pkg(
                     create_deployment_artifact(
                         DeploymentArtifact {
                             transaction_id: format!("0x{}", tx.id(&chain_id)),
-                            salt: format!("0x{}", salt),
+                            salt: format!("0x{salt}"),
                             network_endpoint: node_url.to_string(),
                             chain_id,
-                            contract_id: format!("0x{}", contract_id),
+                            contract_id: format!("0x{contract_id}"),
                             deployment_size: bytecode.len(),
                             deployed_block_height: Some(*block_height),
                         },

--- a/forc-plugins/forc-client/src/op/run/mod.rs
+++ b/forc-plugins/forc-client/src/op/run/mod.rs
@@ -198,7 +198,7 @@ async fn try_send_tx(
             send_tx(&client, tx, pretty_print, simulate, debug, abi),
         )
         .await
-        .with_context(|| format!("timeout waiting for {:?} to be included in a block", tx))?,
+        .with_context(|| format!("timeout waiting for {tx:?} to be included in a block"))?,
         Err(_) => Err(fuel_core_not_running(node_url)),
     }
 }

--- a/forc-plugins/forc-client/src/util/pkg.rs
+++ b/forc-plugins/forc-client/src/util/pkg.rs
@@ -43,7 +43,7 @@ pub(crate) fn create_proxy_contract(pkg_name: &str) -> Result<PathBuf> {
     // Create the proxy contract folder.
     let proxy_contract_dir = user_forc_directory()
         .join(GENERATED_CONTRACT_FOLDER_NAME)
-        .join(format!("{}-proxy", pkg_name));
+        .join(format!("{pkg_name}-proxy"));
     std::fs::create_dir_all(&proxy_contract_dir)?;
     std::fs::write(
         proxy_contract_dir.join(PROXY_BIN_FILE_NAME),

--- a/forc-plugins/forc-client/src/util/target.rs
+++ b/forc-plugins/forc-client/src/util/target.rs
@@ -105,6 +105,6 @@ impl std::fmt::Display for Target {
             Target::Devnet => "Devnet",
             Target::Local => "local",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -213,9 +213,8 @@ pub(crate) async fn select_account(
                     format!(
                         "Your wallet does not have any funds to pay for the transaction.\
                         \n\nIf you are interacting with a testnet, consider using the faucet.\
-                        \n-> {target} network faucet: {}/?address={first_account}\
-                        \nIf you are interacting with a local node, consider providing a chainConfig which funds your account.",
-                        faucet_url
+                        \n-> {target} network faucet: {faucet_url}/?address={first_account}\
+                        \nIf you are interacting with a local node, consider providing a chainConfig which funds your account."
                     )
                 } else {
                     "Your wallet does not have any funds to pay for the transaction.".to_string()

--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -358,7 +358,7 @@ async fn test_simple_deploy() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url),
         target: None,
@@ -400,7 +400,7 @@ async fn test_deploy_submit_only() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
 
     let target = NodeTarget {
         node_url: Some(node_url),
@@ -449,7 +449,7 @@ async fn test_deploy_fresh_proxy() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url),
         target: None,
@@ -502,7 +502,7 @@ async fn test_proxy_contract_re_routes_call() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -638,7 +638,7 @@ async fn test_non_owner_fails_to_set_target() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -706,7 +706,7 @@ async fn test_non_owner_fails_to_set_target() {
 #[test]
 fn test_deploy_interactive_missing_wallet() -> Result<(), rexpect::error::Error> {
     let (mut node, port) = run_node();
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
 
     // Spawn the forc-deploy binary using cargo run
     let project_dir = test_data_path().join("standalone_contract");
@@ -743,7 +743,7 @@ async fn chunked_deploy() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url),
         target: None,
@@ -777,7 +777,7 @@ async fn chunked_deploy_re_routes_calls() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -822,7 +822,7 @@ async fn chunked_deploy_with_proxy_re_routes_call() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -857,7 +857,7 @@ async fn can_deploy_script() {
     copy_dir(&project_dir, tmp_dir.path()).unwrap();
     patch_manifest_file_with_path_std(tmp_dir.path()).unwrap();
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -889,7 +889,7 @@ async fn deploy_script_calls() {
     copy_dir(&project_dir, tmp_dir.path()).unwrap();
     patch_manifest_file_with_path_std(tmp_dir.path()).unwrap();
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -922,7 +922,7 @@ async fn deploy_script_calls() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -1015,7 +1015,7 @@ async fn can_deploy_predicates() {
     copy_dir(&project_dir, tmp_dir.path()).unwrap();
     patch_manifest_file_with_path_std(tmp_dir.path()).unwrap();
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -1047,7 +1047,7 @@ async fn deployed_predicate_call() {
     copy_dir(&project_dir, tmp_dir.path()).unwrap();
     patch_manifest_file_with_path_std(tmp_dir.path()).unwrap();
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,
@@ -1309,7 +1309,7 @@ async fn offset_shifted_abi_works() {
         ..Default::default()
     };
 
-    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let node_url = format!("http://127.0.0.1:{port}/v1/graphql");
     let target = NodeTarget {
         node_url: Some(node_url.clone()),
         target: None,

--- a/forc-plugins/forc-crypto/src/keys/vanity.rs
+++ b/forc-plugins/forc-crypto/src/keys/vanity.rs
@@ -33,8 +33,8 @@ fn validate_regex_pattern(s: &str) -> Result<String, String> {
         return Err("Regex pattern too long: max 128 characters".to_string());
     }
 
-    if let Err(e) = Regex::new(&format!("(?i){}", s)) {
-        return Err(format!("Invalid regex pattern: {}", e));
+    if let Err(e) = Regex::new(&format!("(?i){s}")) {
+        return Err(format!("Invalid regex pattern: {e}"));
     }
 
     Ok(s.to_string())
@@ -176,7 +176,7 @@ pub struct RegexMatcher {
 
 impl RegexMatcher {
     pub fn new(pattern: &str) -> anyhow::Result<Self> {
-        let re = Regex::new(&format!("(?i){}", pattern))?;
+        let re = Regex::new(&format!("(?i){pattern}"))?;
         Ok(Self { re })
     }
 }
@@ -215,10 +215,7 @@ pub fn find_vanity_address_with_timeout(
                 if current != 0 && current % breakpoint == 0 {
                     let elapsed = start.elapsed().as_secs_f64();
                     let rate = current as f64 / elapsed;
-                    println!(
-                        "└─ tried {} addresses ({:.2} addresses/sec)...",
-                        current, rate
-                    );
+                    println!("└─ tried {current} addresses ({rate:.2} addresses/sec)...");
                 }
 
                 if let Ok((addr, _, _)) = result {

--- a/forc-plugins/forc-crypto/src/main.rs
+++ b/forc-plugins/forc-crypto/src/main.rs
@@ -13,7 +13,7 @@ use termion::screen::IntoAlternateScreen;
 fn main() {
     init_tracing_subscriber(Default::default());
     if let Err(err) = run() {
-        println_error(&format!("{}", err));
+        println_error(&format!("{err}"));
         std::process::exit(1);
     }
 }

--- a/forc-plugins/forc-debug/examples/client_usage.rs
+++ b/forc-plugins/forc-debug/examples/client_usage.rs
@@ -20,10 +20,10 @@ async fn run_example() -> Result<(), anyhow::Error> {
     assert!(status.breakpoint.is_some());
 
     let value = client.register(&session_id, 12).await?;
-    println!("reg[12] = {}", value);
+    println!("reg[12] = {value}");
 
     let mem = client.memory(&session_id, 0x10, 0x20).await?;
-    println!("mem[0x10..0x30] = {:?}", mem);
+    println!("mem[0x10..0x30] = {mem:?}");
 
     client.set_single_stepping(&session_id, true).await?;
 

--- a/forc-plugins/forc-debug/src/cli/mod.rs
+++ b/forc-plugins/forc-debug/src/cli/mod.rs
@@ -84,7 +84,7 @@ impl Cli {
                         match args[0].as_str() {
                             cmd if helper.commands.is_help_command(cmd) => {
                                 if let Err(e) = commands::cmd_help(helper, &args).await {
-                                    println!("Error: {}", e);
+                                    println!("Error: {e}");
                                 }
                             }
                             cmd if helper.commands.is_quit_command(cmd) => {
@@ -108,10 +108,10 @@ impl Cli {
                                                 cmd, suggestion.name
                                             );
                                         } else {
-                                            println!("Error: {}", e);
+                                            println!("Error: {e}");
                                         }
                                     } else {
-                                        println!("Error: {}", e);
+                                        println!("Error: {e}");
                                     }
                                 }
                             }
@@ -127,7 +127,7 @@ impl Cli {
                     break Ok(());
                 }
                 Err(err) => {
-                    println!("Error: {}", err);
+                    println!("Error: {err}");
                     break Ok(());
                 }
             }

--- a/forc-plugins/forc-debug/src/debugger/commands.rs
+++ b/forc-plugins/forc-debug/src/debugger/commands.rs
@@ -159,13 +159,13 @@ impl DebugCommand {
                 if let Some((contract_id, abi_path)) = abi_arg.split_once(':') {
                     let contract_id = contract_id
                         .parse::<ContractId>()
-                        .map_err(|_| format!("Invalid contract ID: {}", contract_id))?;
+                        .map_err(|_| format!("Invalid contract ID: {contract_id}"))?;
                     abi_mappings.push(AbiMapping::Contract {
                         contract_id,
                         abi_path: abi_path.to_string(),
                     });
                 } else {
-                    return Err(format!("Invalid --abi argument: {}", abi_arg));
+                    return Err(format!("Invalid --abi argument: {abi_arg}"));
                 }
                 i += 2;
             } else if args[i].ends_with(".json") {
@@ -210,7 +210,7 @@ impl DebugCommand {
         };
 
         let offset = crate::cli::parse_int(offset_str)
-            .ok_or_else(|| format!("Invalid offset: {}", offset_str))? as u64;
+            .ok_or_else(|| format!("Invalid offset: {offset_str}"))? as u64;
 
         Ok(DebugCommand::SetBreakpoint {
             contract_id,
@@ -226,7 +226,7 @@ impl DebugCommand {
             } else if let Some(index) = crate::names::register_index(arg) {
                 indices.push(index as u32);
             } else {
-                return Err(format!("Unknown register: {}", arg));
+                return Err(format!("Unknown register: {arg}"));
             }
         }
         Ok(DebugCommand::GetRegisters { indices })
@@ -237,13 +237,13 @@ impl DebugCommand {
 
         let offset = args
             .first()
-            .map(|a| crate::cli::parse_int(a).ok_or_else(|| format!("Invalid offset: {}", a)))
+            .map(|a| crate::cli::parse_int(a).ok_or_else(|| format!("Invalid offset: {a}")))
             .transpose()?
             .unwrap_or(0) as u32;
 
         let limit = args
             .get(1)
-            .map(|a| crate::cli::parse_int(a).ok_or_else(|| format!("Invalid limit: {}", a)))
+            .map(|a| crate::cli::parse_int(a).ok_or_else(|| format!("Invalid limit: {a}")))
             .transpose()?
             .unwrap_or(WORD_SIZE * (VM_MAX_RAM as usize)) as u32;
 

--- a/forc-plugins/forc-debug/src/debugger/mod.rs
+++ b/forc-plugins/forc-debug/src/debugger/mod.rs
@@ -57,19 +57,18 @@ impl Debugger {
                 for decoded in decoded_receipts {
                     match decoded {
                         DecodedReceipt::Regular(receipt) => {
-                            writeln!(writer, "Receipt: {:?}", receipt)?;
+                            writeln!(writer, "Receipt: {receipt:?}")?;
                         }
                         DecodedReceipt::LogData {
                             receipt,
                             decoded_value,
                             contract_id,
                         } => {
-                            writeln!(writer, "Receipt: {:?}", receipt)?;
+                            writeln!(writer, "Receipt: {receipt:?}")?;
                             if let Some(value) = decoded_value {
                                 writeln!(
                                     writer,
-                                    "Decoded log value: {}, from contract: {}",
-                                    value, contract_id
+                                    "Decoded log value: {value}, from contract: {contract_id}"
                                 )?;
                             }
                         }
@@ -108,7 +107,7 @@ impl Debugger {
                 }
             }
             DebugResponse::Error(err) => {
-                writeln!(writer, "Error: {}", err)?;
+                writeln!(writer, "Error: {err}")?;
             }
         }
         Ok(())
@@ -225,7 +224,7 @@ impl Debugger {
         for index in indices {
             if index >= VM_REGISTER_COUNT as u32 {
                 return Err(Error::ArgumentError(crate::error::ArgumentError::Invalid(
-                    format!("Register index too large: {}", index),
+                    format!("Register index too large: {index}"),
                 )));
             }
             let value = self

--- a/forc-plugins/forc-debug/tests/cli_integration.rs
+++ b/forc-plugins/forc-debug/tests/cli_integration.rs
@@ -27,7 +27,7 @@ fn test_cli() {
 
     dbg!(&run_cmd);
 
-    run_cmd.arg(format!("http://127.0.0.1:{}/graphql", port));
+    run_cmd.arg(format!("http://127.0.0.1:{port}/graphql"));
 
     // Increased timeout to account for rustyline initialization
     let mut cmd = spawn_command(run_cmd, Some(5000)).unwrap();

--- a/forc-plugins/forc-debug/tests/server_integration.rs
+++ b/forc-plugins/forc-debug/tests/server_integration.rs
@@ -141,7 +141,7 @@ fn test_server_launch_mode() {
         ResponseBody::SetBreakpoints(res) => {
             assert!(res.breakpoints.len() == 3);
         }
-        other => panic!("Expected SetBreakpoints response, got {:?}", other),
+        other => panic!("Expected SetBreakpoints response, got {other:?}"),
     }
     assert!(exit_code.is_none());
 
@@ -163,7 +163,7 @@ fn test_server_launch_mode() {
         ResponseBody::Threads(res) => {
             assert_eq!(res.threads.len(), 1);
         }
-        other => panic!("Expected Threads response, got {:?}", other),
+        other => panic!("Expected Threads response, got {other:?}"),
     }
     assert!(exit_code.is_none());
 
@@ -175,7 +175,7 @@ fn test_server_launch_mode() {
         ResponseBody::StackTrace(res) => {
             assert_eq!(res.stack_frames.len(), 1);
         }
-        other => panic!("Expected StackTrace response, got {:?}", other),
+        other => panic!("Expected StackTrace response, got {other:?}"),
     }
     assert!(exit_code.is_none());
 
@@ -187,7 +187,7 @@ fn test_server_launch_mode() {
         ResponseBody::Scopes(res) => {
             assert_eq!(res.scopes.len(), 2);
         }
-        other => panic!("Expected Scopes response, got {:?}", other),
+        other => panic!("Expected Scopes response, got {other:?}"),
     }
     assert!(exit_code.is_none());
 
@@ -202,7 +202,7 @@ fn test_server_launch_mode() {
         ResponseBody::Variables(res) => {
             assert_eq!(res.variables.len(), 64);
         }
-        other => panic!("Expected Variables response, got {:?}", other),
+        other => panic!("Expected Variables response, got {other:?}"),
     }
     assert!(exit_code.is_none());
 
@@ -223,7 +223,7 @@ fn test_server_launch_mode() {
             ];
             assert_variables_eq(expected, res.variables);
         }
-        other => panic!("Expected Variables response, got {:?}", other),
+        other => panic!("Expected Variables response, got {other:?}"),
     }
     assert!(exit_code.is_none());
 
@@ -330,15 +330,11 @@ fn test_sourcemap_build() {
     for (line, expected_count, description) in key_locations {
         let instructions = line_to_instructions
             .get(&line)
-            .unwrap_or_else(|| panic!("Missing mapping for line {}: {}", line, description));
+            .unwrap_or_else(|| panic!("Missing mapping for line {line}: {description}"));
         assert_eq!(
             instructions.len(),
             expected_count,
-            "Line {} ({}): Expected {} instructions, found {:?}",
-            line,
-            description,
-            expected_count,
-            instructions
+            "Line {line} ({description}): Expected {expected_count} instructions, found {instructions:?}"
         );
     }
 }
@@ -350,7 +346,7 @@ fn assert_stopped_breakpoint_event(event: Option<Event>, breakpoint_id: i64) {
             assert!(matches!(body.reason, StoppedEventReason::Breakpoint));
             assert_eq!(body.hit_breakpoint_ids, Some(vec![breakpoint_id]));
         }
-        other => panic!("Expected Stopped event, got {:?}", other),
+        other => panic!("Expected Stopped event, got {other:?}"),
     };
 }
 
@@ -361,14 +357,14 @@ fn assert_stopped_next_event(event: Option<Event>) {
             assert!(matches!(body.reason, StoppedEventReason::Step));
             assert_eq!(body.hit_breakpoint_ids, None);
         }
-        other => panic!("Expected Stopped event, got {:?}", other),
+        other => panic!("Expected Stopped event, got {other:?}"),
     };
 }
 
 fn assert_output_event_body(event: Option<Event>) -> OutputEventBody {
     match event.expect("received event") {
         Event::Output(body) => body,
-        other => panic!("Expected Output event, got {:?}", other),
+        other => panic!("Expected Output event, got {other:?}"),
     }
 }
 

--- a/forc-plugins/forc-doc/src/render/item/context.rs
+++ b/forc-plugins/forc-doc/src/render/item/context.rs
@@ -397,7 +397,7 @@ impl ItemContext {
                         doc_links.push(DocLink {
                             name: method_name.clone(),
                             module_info: inherent_impl.impl_for_module.clone(),
-                            html_filename: format!("{}method.{}", IDENTITY, method_name),
+                            html_filename: format!("{IDENTITY}method.{method_name}"),
                             preview_opt: None,
                         })
                     }
@@ -522,13 +522,13 @@ impl Renderable for DocImplTrait {
 
         let trait_link = if let Some(module_prefixes) = &self.module_info_override {
             ModuleInfo::from_vec_str(module_prefixes).file_path_from_location(
-                &format!("trait.{}.html", short_name),
+                &format!("trait.{short_name}.html"),
                 impl_for_module,
                 is_external_item,
             )?
         } else {
             ModuleInfo::from_call_path(trait_name).file_path_from_location(
-                &format!("trait.{}.html", short_name),
+                &format!("trait.{short_name}.html"),
                 impl_for_module,
                 is_external_item,
             )?

--- a/forc-plugins/forc-doc/src/render/search.rs
+++ b/forc-plugins/forc-doc/src/render/search.rs
@@ -50,7 +50,7 @@ pub(crate) fn generate_searchbar(module_info: &ModuleInfo) -> Box<dyn RenderBox>
                             const name = item.type_name === "module"
                                 ? [...item.module_info.slice(0, -1), formattedName].join("::")
                                 : [...item.module_info, formattedName].join("::");
-                            const path = ["{}", ...item.module_info, item.html_filename].join("/");
+                            const path = ["{path_to_root}", ...item.module_info, item.html_filename].join("/");
                             const left = `<td><span>${{name}}</span></td>`;
                             const right = `<td><p>${{item.preview}}</p></td>`;
                             return `<tr onclick="window.location='${{path}}';">${{left}}${{right}}</tr>`;
@@ -71,7 +71,7 @@ pub(crate) fn generate_searchbar(module_info: &ModuleInfo) -> Box<dyn RenderBox>
             // Check for any query parameters initially
             onQueryParamsChange();
         }}
-    );"#, path_to_root)).to_string();
+    );"#)).to_string();
     box_html! {
         script(src=format!("{}/search.js", path_to_root), type="text/javascript");
         script {

--- a/forc-plugins/forc-doc/tests/lib.rs
+++ b/forc-plugins/forc-doc/tests/lib.rs
@@ -28,7 +28,7 @@ fn test_impl_traits_default() {
     let doc_dir_name: &str = "impl_traits_default";
     let project_name = "impl_traits";
     let command = Command {
-        path: Some(format!("{}/{}", DATA_DIR, project_name)),
+        path: Some(format!("{DATA_DIR}/{project_name}")),
         doc_path: Some(doc_dir_name.into()),
         ..Default::default()
     };
@@ -72,7 +72,7 @@ fn test_workspace_docs() {
     let doc_dir_name: &str = "workspace_docs";
     let workspace_name = "sample_workspace";
     let command = Command {
-        path: Some(format!("{}/{}", DATA_DIR, workspace_name)),
+        path: Some(format!("{DATA_DIR}/{workspace_name}")),
         doc_path: Some(doc_dir_name.into()),
         ..Default::default()
     };
@@ -133,7 +133,7 @@ fn test_impl_traits_no_deps() {
     let doc_dir_name: &str = "impl_traits_no_deps";
     let project_name: &str = "impl_traits_generic";
     let command = Command {
-        path: Some(format!("{}/{}", DATA_DIR, project_name)),
+        path: Some(format!("{DATA_DIR}/{project_name}")),
         doc_path: Some(doc_dir_name.into()),
         no_deps: true,
         ..Default::default()
@@ -170,7 +170,7 @@ fn test_impl_traits_no_deps() {
 }
 
 fn assert_index_html(doc_path: &Path, project_name: &str, expect: &Expect) {
-    let path_to_file = PathBuf::from(format!("{}/{}", project_name, IMPL_FOR));
+    let path_to_file = PathBuf::from(format!("{project_name}/{IMPL_FOR}"));
     check_file(doc_path, &path_to_file, expect);
 }
 
@@ -182,12 +182,12 @@ fn assert_search_js(doc_path: &Path, expect: &Expect) {
 fn check_file(doc_path: &Path, path_to_file: &PathBuf, expect: &Expect) {
     let path = doc_path.join(path_to_file);
     let actual = std::fs::read_to_string(path.clone())
-        .unwrap_or_else(|_| panic!("failed to read file: {:?}", path));
+        .unwrap_or_else(|_| panic!("failed to read file: {path:?}"));
     expect.assert_eq(&actual)
 }
 
 fn assert_file_tree(doc_dir_name: &str, project_name: &str, expected_files: Vec<&str>) {
-    let doc_root: PathBuf = format!("{}/{}/out/{}", DATA_DIR, project_name, doc_dir_name).into();
+    let doc_root: PathBuf = format!("{DATA_DIR}/{project_name}/out/{doc_dir_name}").into();
     let expected = expected_files
         .iter()
         .map(PathBuf::from)

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
     init_tracing_subscriber(Default::default());
     if let Err(err) = run() {
         println_error("Formatting skipped due to error.");
-        println_error(&format!("{}", err));
+        println_error(&format!("{err}"));
         std::process::exit(1);
     }
 }

--- a/forc-plugins/forc-mcp/src/auth/service.rs
+++ b/forc-plugins/forc-mcp/src/auth/service.rs
@@ -184,7 +184,7 @@ pub async fn create_api_key(
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Failed to create API key: {}", e),
+                error: format!("Failed to create API key: {e}"),
             }),
         )),
     }
@@ -210,7 +210,7 @@ pub async fn list_api_keys(
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Failed to list API keys: {}", e),
+                error: format!("Failed to list API keys: {e}"),
             }),
         )),
     }
@@ -238,7 +238,7 @@ pub async fn get_api_key(
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Failed to get API key: {}", e),
+                error: format!("Failed to get API key: {e}"),
             }),
         )),
     }
@@ -272,7 +272,7 @@ pub async fn delete_api_key(
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
-                    error: format!("Failed to check API key: {}", e),
+                    error: format!("Failed to check API key: {e}"),
                 }),
             ));
         }
@@ -283,7 +283,7 @@ pub async fn delete_api_key(
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Failed to delete API key: {}", e),
+                error: format!("Failed to delete API key: {e}"),
             }),
         )),
     }
@@ -316,7 +316,7 @@ pub async fn import_api_keys(
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Failed to import API keys: {}", e),
+                error: format!("Failed to import API keys: {e}"),
             }),
         )),
     }

--- a/forc-plugins/forc-mcp/src/forc_call/mod.rs
+++ b/forc-plugins/forc-mcp/src/forc_call/mod.rs
@@ -101,8 +101,7 @@ impl ForcCallTools {
             Ok(cmd) => cmd,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Invalid arguments: {}",
-                    e
+                    "Error: Invalid arguments: {e}"
                 ))]))
             }
         };
@@ -111,8 +110,7 @@ impl ForcCallTools {
             Ok(op) => op,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Failed to validate command: {}",
-                    e
+                    "Error: Failed to validate command: {e}"
                 ))]))
             }
         };
@@ -121,8 +119,7 @@ impl ForcCallTools {
             Ok(resp) => resp,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Contract call failed: {}",
-                    e
+                    "Error: Contract call failed: {e}"
                 ))]))
             }
         };
@@ -131,8 +128,7 @@ impl ForcCallTools {
             Ok(content) => content,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Failed to convert response to JSON: {}",
-                    e
+                    "Failed to convert response to JSON: {e}"
                 ))]))
             }
         };
@@ -149,8 +145,7 @@ impl ForcCallTools {
             Ok(cmd) => cmd,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Invalid arguments: {}",
-                    e
+                    "Error: Invalid arguments: {e}"
                 ))]))
             }
         };
@@ -159,8 +154,7 @@ impl ForcCallTools {
             Ok(op) => op,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Failed to validate command: {}",
-                    e
+                    "Error: Failed to validate command: {e}"
                 ))]))
             }
         };
@@ -173,8 +167,7 @@ impl ForcCallTools {
                     Ok(abi_map) => (contract_id, abi_map),
                     Err(e) => {
                         return Ok(CallToolResult::error(vec![Content::text(format!(
-                            "Failed to create ABI map: {}",
-                            e
+                            "Failed to create ABI map: {e}"
                         ))]))
                     }
                 }
@@ -194,8 +187,7 @@ impl ForcCallTools {
             &mut output_buffer,
         ) {
             return Ok(CallToolResult::error(vec![Content::text(format!(
-                "Failed to list contract functions: {}",
-                e
+                "Failed to list contract functions: {e}"
             ))]));
         }
 
@@ -204,8 +196,7 @@ impl ForcCallTools {
             Ok(s) => s,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Output was not valid UTF-8: {}",
-                    e
+                    "Output was not valid UTF-8: {e}"
                 ))]))
             }
         };
@@ -232,8 +223,7 @@ impl ForcCallTools {
             Ok(cmd) => cmd,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Invalid arguments: {}",
-                    e
+                    "Error: Invalid arguments: {e}"
                 ))]))
             }
         };
@@ -242,8 +232,7 @@ impl ForcCallTools {
             Ok(op) => op,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Failed to validate command: {}",
-                    e
+                    "Error: Failed to validate command: {e}"
                 ))]))
             }
         };
@@ -252,8 +241,7 @@ impl ForcCallTools {
             Ok(resp) => resp,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Transfer failed: {}",
-                    e
+                    "Error: Transfer failed: {e}"
                 ))]))
             }
         };
@@ -262,8 +250,7 @@ impl ForcCallTools {
             Ok(content) => content,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Failed to convert response to JSON: {}",
-                    e
+                    "Failed to convert response to JSON: {e}"
                 ))]))
             }
         };
@@ -287,8 +274,7 @@ impl ForcCallTools {
                 Ok(event) => trace_events.push(event),
                 Err(e) => {
                     return Ok(CallToolResult::error(vec![Content::text(format!(
-                        "Error: Failed to parse trace_event: {}",
-                        e
+                        "Error: Failed to parse trace_event: {e}"
                     ))]))
                 }
             }
@@ -305,8 +291,7 @@ impl ForcCallTools {
                         }
                         Err(e) => {
                             return Ok(CallToolResult::error(vec![Content::text(format!(
-                                "Error: Failed to parse contract ID '{}': {}",
-                                contract_id_str, e
+                                "Error: Failed to parse contract ID '{contract_id_str}': {e}"
                             ))]))
                         }
                     }
@@ -327,8 +312,7 @@ impl ForcCallTools {
             &mut trace_buffer,
         ) {
             return Ok(CallToolResult::error(vec![Content::text(format!(
-                "Error: Failed to generate trace: {}",
-                e
+                "Error: Failed to generate trace: {e}"
             ))]));
         }
 
@@ -336,8 +320,7 @@ impl ForcCallTools {
             Ok(output) => output,
             Err(e) => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: Failed to convert trace output to string: {}",
-                    e
+                    "Error: Failed to convert trace output to string: {e}"
                 ))]))
             }
         };
@@ -791,10 +774,10 @@ mod tests {
             let abi_path = "../../forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json";
 
             Ok(E2ETestFixture {
-                contract_id: format!("0x{}", contract_id),
+                contract_id: format!("0x{contract_id}"),
                 abi_path: abi_path.to_string(),
                 node_url: provider.url().to_string(),
-                secret_key: format!("0x{}", secret_key),
+                secret_key: format!("0x{secret_key}"),
                 provider,
             })
         }
@@ -898,7 +881,7 @@ mod tests {
                 // Convert HashMap<ContractId, String> to HashMap<String, String>
                 let labels_map: HashMap<String, String> = labels
                     .iter()
-                    .map(|(contract_id, label)| (format!("0x{}", contract_id), label.clone()))
+                    .map(|(contract_id, label)| (format!("0x{contract_id}"), label.clone()))
                     .collect();
                 args.insert(
                     "labels".to_string(),
@@ -1326,7 +1309,7 @@ mod tests {
         // Convert HashMap<ContractId, String> to HashMap<String, String>
         let labels_map: HashMap<String, String> = labels
             .iter()
-            .map(|(contract_id, label)| (format!("0x{}", contract_id), label.clone()))
+            .map(|(contract_id, label)| (format!("0x{contract_id}"), label.clone()))
             .collect();
 
         // Convert trace_events to array of JSON objects

--- a/forc-plugins/forc-mcp/src/lib.rs
+++ b/forc-plugins/forc-mcp/src/lib.rs
@@ -448,7 +448,7 @@ async fn admin_auth_middleware(
             Err(e) => Err((
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 axum::Json(auth::ErrorResponse {
-                    error: format!("Internal server error: {}", e),
+                    error: format!("Internal server error: {e}"),
                 }),
             )
                 .into_response()),
@@ -504,10 +504,10 @@ pub mod tests {
                 return Err(anyhow!("Server task completed before test could run"));
             }
 
-            let base_url = format!("http://127.0.0.1:{}", port);
+            let base_url = format!("http://127.0.0.1:{port}");
 
             // Create MCP client using SSE transport
-            let transport = SseClientTransport::start(format!("{}/sse", base_url)).await?;
+            let transport = SseClientTransport::start(format!("{base_url}/sse")).await?;
             let client_info = ClientInfo {
                 protocol_version: Default::default(),
                 capabilities: ClientCapabilities::default(),
@@ -544,7 +544,7 @@ pub mod tests {
                 return Err(anyhow!("Server task completed before test could run"));
             }
 
-            let base_url = format!("http://127.0.0.1:{}/mcp", port);
+            let base_url = format!("http://127.0.0.1:{port}/mcp");
 
             // Create MCP client using HTTP streamable transport
             let transport = StreamableHttpClientTransport::from_uri(base_url);

--- a/forc-plugins/forc-migrate/src/cli/commands/run.rs
+++ b/forc-plugins/forc-migrate/src/cli/commands/run.rs
@@ -491,10 +491,7 @@ fn print_migration_finished_action(num_of_postponed_steps: usize) {
 fn print_continue_migration_action(txt: &str) {
     println_action_yellow(
         "Continue",
-        &format!(
-            "{} and re-run `forc migrate` to finish the migration process",
-            txt
-        ),
+        &format!("{txt} and re-run `forc migrate` to finish the migration process"),
     );
 }
 

--- a/forc-plugins/forc-migrate/src/modifying/attribute.rs
+++ b/forc-plugins/forc-migrate/src/modifying/attribute.rs
@@ -96,7 +96,7 @@ impl New {
                     final_value_opt: Some(Box::new(New::attribute_with_arg(
                         insert_span.clone(),
                         CFG_ATTRIBUTE_NAME,
-                        &format!("experimental_{}", feature_name),
+                        &format!("experimental_{feature_name}"),
                         Some(New::literal_bool(insert_span.clone(), value)),
                     ))),
                 },

--- a/forc-plugins/forc-node/src/chain_config.rs
+++ b/forc-plugins/forc-node/src/chain_config.rs
@@ -234,8 +234,7 @@ impl ConfigFetcher {
         };
 
         let api_endpoint = format!(
-            "https://api.github.com/repos/FuelLabs/{}/contents/{}",
-            CHAIN_CONFIG_REPO_NAME, folder_name,
+            "https://api.github.com/repos/FuelLabs/{CHAIN_CONFIG_REPO_NAME}/contents/{folder_name}",
         );
 
         let contents = self.fetch_folder_contents(&api_endpoint).await?;
@@ -323,8 +322,7 @@ async fn validate_remote_chainconfig(
 
     if fetcher.check_fetch_required(conf).await? {
         println_warning(&format!(
-            "A network configuration update detected for {}, this might create problems while syncing with rest of the network",
-            conf
+            "A network configuration update detected for {conf}, this might create problems while syncing with rest of the network"
         ));
         // Ask user if they want to update the chain config.
         let update = ask_user_yes_no_question("Would you like to update network configuration?")?;
@@ -378,7 +376,7 @@ mod tests {
                 GithubContentDetails {
                     name: name.to_string(),
                     sha,
-                    download_url: Some(format!("https://raw.githubusercontent.com/test/{}", name)),
+                    download_url: Some(format!("https://raw.githubusercontent.com/test/{name}")),
                     content_type: "file".to_string(),
                 }
             })
@@ -407,8 +405,7 @@ mod tests {
         let github_response = create_github_response(&test_files);
         Mock::given(method("GET"))
             .and(path(format!(
-                "/repos/FuelLabs/{}/contents/{}",
-                CHAIN_CONFIG_REPO_NAME, TESTNET_CONFIG_FOLDER_NAME
+                "/repos/FuelLabs/{CHAIN_CONFIG_REPO_NAME}/contents/{TESTNET_CONFIG_FOLDER_NAME}"
             )))
             .respond_with(ResponseTemplate::new(200).set_body_json(&github_response))
             .mount(&mock_server)
@@ -455,8 +452,7 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path(format!(
-                "/repos/FuelLabs/{}/contents/{}",
-                CHAIN_CONFIG_REPO_NAME, TESTNET_CONFIG_FOLDER_NAME
+                "/repos/FuelLabs/{CHAIN_CONFIG_REPO_NAME}/contents/{TESTNET_CONFIG_FOLDER_NAME}"
             )))
             .respond_with(ResponseTemplate::new(200).set_body_json(&github_response))
             .mount(&mock_server)
@@ -497,8 +493,7 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path(format!(
-                "/repos/FuelLabs/{}/contents/{}",
-                CHAIN_CONFIG_REPO_NAME, TESTNET_CONFIG_FOLDER_NAME
+                "/repos/FuelLabs/{CHAIN_CONFIG_REPO_NAME}/contents/{TESTNET_CONFIG_FOLDER_NAME}"
             )))
             .respond_with(ResponseTemplate::new(200).set_body_json(&github_response))
             .mount(&mock_server)
@@ -557,8 +552,7 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path(format!(
-                "/repos/FuelLabs/{}/contents/{}",
-                CHAIN_CONFIG_REPO_NAME, TESTNET_CONFIG_FOLDER_NAME
+                "/repos/FuelLabs/{CHAIN_CONFIG_REPO_NAME}/contents/{TESTNET_CONFIG_FOLDER_NAME}"
             )))
             .respond_with(ResponseTemplate::new(200).set_body_json(&github_response))
             .mount(&mock_server)

--- a/forc-plugins/forc-node/src/run_opts.rs
+++ b/forc-plugins/forc-node/src/run_opts.rs
@@ -127,8 +127,7 @@ impl RunOpts {
         }
         if let Some(relayer_listener) = self.relayer_listener {
             params.push(format!(
-                "--relayer-v2-listening-contracts {}",
-                relayer_listener
+                "--relayer-v2-listening-contracts {relayer_listener}"
             ));
         }
         if let Some(da_deploy_height) = self.relayer_da_deploy_height {

--- a/forc-plugins/forc-node/src/util.rs
+++ b/forc-plugins/forc-node/src/util.rs
@@ -206,8 +206,7 @@ pub fn check_open_fds_limit(max_files: u64) -> Result<(), Box<dyn std::error::Er
         }
         Err(format!(
             "the maximum number of open file descriptors is too \
-             small, got {}, expect greater or equal to {}",
-            prev_limit, max_files
+             small, got {prev_limit}, expect greater or equal to {max_files}"
         )
         .into())
     }

--- a/forc-plugins/forc-publish/src/error.rs
+++ b/forc-plugins/forc-publish/src/error.rs
@@ -64,7 +64,7 @@ impl Error {
             },
             Err(err) => Error::ApiResponseError {
                 status,
-                error: format!("Unexpected API error: {}", err),
+                error: format!("Unexpected API error: {err}"),
             },
         }
     }

--- a/forc-plugins/forc-publish/src/forc_pub_client.rs
+++ b/forc-plugins/forc-publish/src/forc_pub_client.rs
@@ -44,7 +44,7 @@ impl ForcPubClient {
         use std::io::{stdout, Write};
         let url = self
             .uri
-            .join(&format!("upload_project?forc_version={}", forc_version))?;
+            .join(&format!("upload_project?forc_version={forc_version}"))?;
         let file_bytes = fs::read(file_path)?;
 
         let response = self
@@ -83,7 +83,7 @@ impl ForcPubClient {
                                     });
                                 } else {
                                     // Print the event data, replacing the previous message.
-                                    print!("\r\x1b[2K  =>  {}", data);
+                                    print!("\r\x1b[2K  =>  {data}");
                                     stdout().flush().unwrap();
                                 }
                             }
@@ -100,7 +100,7 @@ impl ForcPubClient {
             }
             Err(Error::ServerError)
         } else {
-            eprintln!("Error during upload initiation: {:?}", response);
+            eprintln!("Error during upload initiation: {response:?}");
             Err(Error::ServerError)
         }
     }
@@ -114,7 +114,7 @@ impl ForcPubClient {
             .client
             .post(url)
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", auth_token))
+            .header("Authorization", format!("Bearer {auth_token}"))
             .json(&publish_request)
             .send()
             .await?;
@@ -156,8 +156,7 @@ mod test {
         // Simulate SSE response with a progress event and a final upload_id event
         let sse_body = format!(
             "data: uploading...\n\n\
-             data: {{\"upload_id\":\"{}\"}}\n\n",
-            upload_id
+             data: {{\"upload_id\":\"{upload_id}\"}}\n\n"
         );
 
         Mock::given(method("POST"))

--- a/forc-plugins/forc-publish/src/tarball.rs
+++ b/forc-plugins/forc-publish/src/tarball.rs
@@ -48,7 +48,7 @@ fn process_readme(temp_project_dir: &Path) -> Result<()> {
             }
             Err(e) => {
                 // Log warning but don't fail the publish
-                println_warning(&format!("Failed to flatten README.md includes: {}", e));
+                println_warning(&format!("Failed to flatten README.md includes: {e}"));
             }
         }
     }

--- a/forc-test/src/ecal.rs
+++ b/forc-test/src/ecal.rs
@@ -23,7 +23,7 @@ impl Syscall {
                 let s = std::str::from_utf8(bytes.as_slice()).unwrap();
 
                 let mut f = unsafe { std::fs::File::from_raw_fd(*fd as i32) };
-                write!(&mut f, "{}", s).unwrap();
+                write!(&mut f, "{s}").unwrap();
 
                 // Don't close the fd
                 std::mem::forget(f);
@@ -36,7 +36,7 @@ impl Syscall {
                 std::mem::forget(f);
             }
             Syscall::Unknown { ra, rb, rc, rd } => {
-                println!("Unknown ecal: {} {} {} {}", ra, rb, rc, rd);
+                println!("Unknown ecal: {ra} {rb} {rc} {rd}");
             }
         }
     }

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -52,10 +52,10 @@ fn print_message(text: &str, color: Colour, style: TextStyle, level: LogLevel) {
     let log_msg = match (is_json_mode_active(), style) {
         // JSON mode formatting (no colors)
         (true, TextStyle::Plain | TextStyle::Bold) => text.to_string(),
-        (true, TextStyle::Label(label)) => format!("{}: {}", label, text),
+        (true, TextStyle::Label(label)) => format!("{label}: {text}"),
         (true, TextStyle::Action(action)) => {
             let indent = get_action_indentation(&action);
-            format!("{}{} {}", indent, action, text)
+            format!("{indent}{action} {text}")
         }
 
         // Normal mode formatting (with colors)
@@ -324,7 +324,7 @@ mod tests {
         println_label_green("Compiling", txt);
 
         let expected_action = "\x1b[1;32mCompiling\x1b[0m";
-        assert!(logs_contain(&format!("{} {}", expected_action, txt)));
+        assert!(logs_contain(&format!("{expected_action} {txt}")));
     }
 
     #[traced_test]
@@ -336,7 +336,7 @@ mod tests {
         println_label_red("Error", txt);
 
         let expected_action = "\x1b[1;31mError\x1b[0m";
-        assert!(logs_contain(&format!("{} {}", expected_action, txt)));
+        assert!(logs_contain(&format!("{expected_action} {txt}")));
     }
 
     #[traced_test]
@@ -348,7 +348,7 @@ mod tests {
         println_action_green("Compiling", txt);
 
         let expected_action = "\x1b[1;32mCompiling\x1b[0m";
-        assert!(logs_contain(&format!("    {} {}", expected_action, txt)));
+        assert!(logs_contain(&format!("    {expected_action} {txt}")));
     }
 
     #[traced_test]
@@ -360,7 +360,7 @@ mod tests {
         println_action_green("Supercalifragilistic", txt);
 
         let expected_action = "\x1b[1;32mSupercalifragilistic\x1b[0m";
-        assert!(logs_contain(&format!("{} {}", expected_action, txt)));
+        assert!(logs_contain(&format!("{expected_action} {txt}")));
     }
 
     #[traced_test]
@@ -372,7 +372,7 @@ mod tests {
         println_action_red("Removing", txt);
 
         let expected_action = "\x1b[1;31mRemoving\x1b[0m";
-        assert!(logs_contain(&format!("     {} {}", expected_action, txt)));
+        assert!(logs_contain(&format!("     {expected_action} {txt}")));
     }
 
     #[traced_test]

--- a/forc-util/src/bytecode.rs
+++ b/forc-util/src/bytecode.rs
@@ -103,7 +103,7 @@ where
                 });
 
             let hash_result = hasher.finalize();
-            let bytecode_id = format!("{:x}", hash_result);
+            let bytecode_id = format!("{hash_result:x}");
             return Ok(bytecode_id);
         }
     }

--- a/forc-util/src/fs_locking.rs
+++ b/forc-util/src/fs_locking.rs
@@ -50,7 +50,7 @@ impl PidFileLocking {
             .expect("Failed to execute ps command");
 
         let output_str = String::from_utf8_lossy(&output.stdout);
-        output_str.contains(&format!("{} ", pid))
+        output_str.contains(&format!("{pid} "))
     }
 
     #[cfg(target_os = "windows")]
@@ -72,13 +72,10 @@ impl PidFileLocking {
     /// Removes the lock file if it is not locked or the process that locked it is no longer active
     pub fn release(&self) -> io::Result<()> {
         if self.is_locked() {
-            Err(io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "Cannot remove a dirty lock file, it is locked by another process (PID: {:#?})",
-                    self.get_locker_pid()
-                ),
-            ))
+            Err(io::Error::other(format!(
+                "Cannot remove a dirty lock file, it is locked by another process (PID: {:#?})",
+                self.get_locker_pid()
+            )))
         } else {
             self.remove_file()?;
             Ok(())

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -117,7 +117,7 @@ impl<T> Termination for ForcCliResult<T> {
         match self.result {
             Ok(_) => DEFAULT_SUCCESS_EXIT_CODE.into(),
             Err(e) => {
-                println_error(&format!("{}", e));
+                println_error(&format!("{e}"));
                 e.exit_code.into()
             }
         }

--- a/forc-util/src/restricted.rs
+++ b/forc-util/src/restricted.rs
@@ -159,9 +159,8 @@ fn test_is_valid_project_name_format() {
 
     let format_error_message = |name: &str| -> String {
         format!(
-            "'{}' is not a valid name for a project. \n\
-            The name may use letters, numbers, hyphens, and underscores, and must start with a letter.",
-            name
+            "'{name}' is not a valid name for a project. \n\
+            The name may use letters, numbers, hyphens, and underscores, and must start with a letter."
         )
     };
 

--- a/forc/src/cli/commands/add.rs
+++ b/forc/src/cli/commands/add.rs
@@ -53,7 +53,7 @@ pub struct Command {
 
 pub(crate) fn exec(command: Command) -> ForcResult<()> {
     dep_modifier::modify_dependencies(command.into())
-        .map_err(|e| format!("failed to add dependencies: {}", e))
+        .map_err(|e| format!("failed to add dependencies: {e}"))
         .map_err(|msg| msg.as_str().into())
 }
 

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -115,19 +115,17 @@ mod test {
             .expect("register completion script");
 
         let output =
-            if let Ok(output) = runtime.complete(&format!("{} \t\t", command_to_complete), &term) {
+            if let Ok(output) = runtime.complete(&format!("{command_to_complete} \t\t"), &term) {
                 output
             } else {
-                println!("Skipping {}", shell);
+                println!("Skipping {shell}");
                 return;
             };
 
         for expectation in expectations {
             assert!(
                 output.contains(expectation),
-                "Failed find {} in {}",
-                expectation,
-                output
+                "Failed find {expectation} in {output}"
             );
         }
     }

--- a/forc/src/cli/commands/remove.rs
+++ b/forc/src/cli/commands/remove.rs
@@ -50,7 +50,7 @@ pub struct Command {
 
 pub(crate) fn exec(command: Command) -> ForcResult<()> {
     dep_modifier::modify_dependencies(command.into())
-        .map_err(|e| format!("failed to remove dependencies: {}", e))
+        .map_err(|e| format!("failed to remove dependencies: {e}"))
         .map_err(|msg| msg.as_str().into())
 }
 

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -119,7 +119,7 @@ pub(crate) fn exec(cmd: Command) -> ForcResult<()> {
                 print_tested_pkg(pkg, &test_print_opts)?;
             }
             info!("");
-            println_action_green("Finished", &format!("in {:?}", duration));
+            println_action_green("Finished", &format!("in {duration:?}"));
             pkgs.iter().all(|pkg| pkg.tests_passed())
         }
         forc_test::Tested::Package(pkg) => {

--- a/forc/src/cli/commands/update.rs
+++ b/forc/src/cli/commands/update.rs
@@ -40,8 +40,6 @@ pub struct Command {
 pub(crate) fn exec(command: Command) -> ForcResult<()> {
     match forc_update::update(command) {
         Ok(_) => Ok(()),
-        Err(e) => Err(format!("couldn't update dependencies: {}", e)
-            .as_str()
-            .into()),
+        Err(e) => Err(format!("couldn't update dependencies: {e}").as_str().into()),
     }
 }

--- a/sway-core/src/abi_generation/abi_str.rs
+++ b/sway-core/src/abi_generation/abi_str.rs
@@ -25,7 +25,7 @@ impl TypeId {
             .get(*self)
             .abi_str(handler, ctx, engines, true)?;
         if self.is_generic_parameter(engines, resolved_type_id) {
-            Ok(format!("generic {}", self_abi_str))
+            Ok(format!("generic {self_abi_str}"))
         } else {
             match (
                 &*type_engine.get(*self),
@@ -84,9 +84,9 @@ impl TypeId {
                     } else {
                         "_".to_string()
                     };
-                    Ok(format!("[{}]", inner_type))
+                    Ok(format!("[{inner_type}]"))
                 }
-                (TypeInfo::Custom { .. }, _) => Ok(format!("generic {}", self_abi_str)),
+                (TypeInfo::Custom { .. }, _) => Ok(format!("generic {self_abi_str}")),
                 _ => type_engine
                     .get(resolved_type_id)
                     .abi_str(handler, ctx, engines, true),
@@ -207,7 +207,7 @@ impl TypeInfo {
             TraitType {
                 name,
                 trait_type_id: _,
-            } => Ok(format!("trait type {}", name)),
+            } => Ok(format!("trait type {name}")),
             Ref {
                 to_mutable_value,
                 referenced_type,

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -134,7 +134,7 @@ pub fn abi_str(type_info: &TypeInfo, engines: &Engines) -> String {
         TraitType {
             name,
             trait_type_id: _,
-        } => format!("trait type {}", name),
+        } => format!("trait type {name}"),
         Ref {
             to_mutable_value,
             referenced_type,

--- a/sway-core/src/abi_generation/fuel_abi.rs
+++ b/sway-core/src/abi_generation/fuel_abi.rs
@@ -206,7 +206,7 @@ impl TypeId {
         let mut hasher = Sha256::new();
         hasher.update(type_str.clone());
         let result = hasher.finalize();
-        let type_id = format!("{:x}", result);
+        let type_id = format!("{result:x}");
 
         if let Some(old_type_str) = ctx
             .type_ids_to_full_type_str

--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -211,10 +211,7 @@ fn to_bytecode_mut(
             FuelAsmData::DatasectionOffset(data) => {
                 if build_config.print_bytecode {
                     print!("{}{:#010x} ", " ".repeat(indentation), bytecode.len());
-                    println!(
-                        "                                                ;; {:?}",
-                        data
-                    );
+                    println!("                                                ;; {data:?}");
                 }
 
                 // Static assert to ensure that we're only dealing with DataSectionOffsetPlaceholder,
@@ -227,10 +224,7 @@ fn to_bytecode_mut(
             FuelAsmData::ConfigurablesOffset(data) => {
                 if build_config.print_bytecode {
                     print!("{}{:#010x} ", " ".repeat(indentation), bytecode.len());
-                    println!(
-                        "                                                ;; {:?}",
-                        data
-                    );
+                    println!("                                                ;; {data:?}");
                 }
 
                 // Static assert to ensure that we're only dealing with ConfigurablesOffsetPlaceholder,

--- a/sway-core/src/asm_generation/fuel/data_section.rs
+++ b/sway-core/src/asm_generation/fuel/data_section.rs
@@ -15,7 +15,7 @@ impl fmt::Display for EntryName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EntryName::NonConfigurable => write!(f, "NonConfigurable"),
-            EntryName::Configurable(name) => write!(f, "<Configurable, {}>", name),
+            EntryName::Configurable(name) => write!(f, "<Configurable, {name}>"),
         }
     }
 }

--- a/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
+++ b/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
@@ -132,7 +132,7 @@ impl AsmBuilder for FuelAsmBuilder<'_, '_> {
                         VirtualRegister::Constant(ConstantRegister::FuncArg0),
                         dataid,
                     )),
-                    comment: format!("get pointer to configurable {} default value", name),
+                    comment: format!("get pointer to configurable {name} default value"),
                     owning_span: None,
                 });
 
@@ -145,7 +145,7 @@ impl AsmBuilder for FuelAsmBuilder<'_, '_> {
                             "Error representing encoded_bytes length as 12-bit immediate",
                         ),
                     )),
-                    comment: format!("get length of configurable {} default value", name),
+                    comment: format!("get length of configurable {name} default value"),
                     owning_span: None,
                 });
 
@@ -158,7 +158,7 @@ impl AsmBuilder for FuelAsmBuilder<'_, '_> {
                             "Error representing global offset as 12-bit immediate",
                         ),
                     )),
-                    comment: format!("get pointer to configurable {} stack address", name),
+                    comment: format!("get pointer to configurable {name} stack address"),
                     owning_span: None,
                 });
 
@@ -168,7 +168,7 @@ impl AsmBuilder for FuelAsmBuilder<'_, '_> {
                         to: *decode_fn_label,
                         type_: JumpType::Call,
                     }),
-                    comment: format!("decode configurable {}", name),
+                    comment: format!("decode configurable {name}"),
                     owning_span: None,
                 });
             }
@@ -638,10 +638,7 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
 
             (
                 ret_reg,
-                format!(
-                    "return value from ASM block with return register {}",
-                    ret_reg_name
-                ),
+                format!("return value from ASM block with return register {ret_reg_name}"),
             )
         } else {
             // If the return register is not specified, the return value is unit, `()`, and we
@@ -1395,7 +1392,7 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
                         "offset must fit in 12 bits",
                     ),
                 )),
-                comment: format!("get address of configurable {}", name),
+                comment: format!("get address of configurable {name}"),
                 owning_span: self.md_mgr.val_to_span(self.context, *addr_val),
             });
             self.reg_map.insert(*addr_val, addr_reg);
@@ -1407,7 +1404,7 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
                     addr_reg.clone(),
                     dataid.clone(),
                 )),
-                comment: format!("get address of configurable {}", name),
+                comment: format!("get address of configurable {name}"),
                 owning_span: self.md_mgr.val_to_span(self.context, *addr_val),
             });
             self.reg_map.insert(*addr_val, addr_reg);

--- a/sway-core/src/asm_generation/fuel/programs/final.rs
+++ b/sway-core/src/asm_generation/fuel/programs/final.rs
@@ -53,7 +53,7 @@ impl std::fmt::Display for FinalProgram {
             ..
         } = self;
 
-        writeln!(f, ";; Program kind: {:?}", kind)?;
+        writeln!(f, ";; Program kind: {kind:?}")?;
         writeln!(
             f,
             ".program:\n{}\n{}",

--- a/sway-core/src/asm_generation/fuel/register_allocator.rs
+++ b/sway-core/src/asm_generation/fuel/register_allocator.rs
@@ -633,9 +633,8 @@ pub(crate) fn allocate_registers(
 
                     return Err(CompileError::InternalOwned(
                         format!(
-                            "The allocator cannot resolve a register mapping for function {}. \
-                                     Using #[inline(never)] on some functions may help.",
-                            comment
+                            "The allocator cannot resolve a register mapping for function {comment}. \
+                                     Using #[inline(never)] on some functions may help."
                         ),
                         Span::dummy(),
                     ));

--- a/sway-core/src/asm_lang/allocated_ops.rs
+++ b/sway-core/src/asm_lang/allocated_ops.rs
@@ -879,8 +879,7 @@ fn realize_load(
         Ok(value) => value,
         Err(_) => panic!(
             "Unable to offset into the data section more than 2^12 bits. \
-                                Unsupported data section length: {} words.",
-            offset_words
+                                Unsupported data section length: {offset_words} words."
         ),
     };
 

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -56,7 +56,7 @@ fn fmt_opcode_and_comment(
             op_and_comment.push(' ');
             op_length += 1;
         }
-        write!(op_and_comment, "; {}", comment)?;
+        write!(op_and_comment, "; {comment}")?;
     }
 
     write!(fmtr, "{op_and_comment}")

--- a/sway-core/src/decl_engine/parsed_engine.rs
+++ b/sway-core/src/decl_engine/parsed_engine.rs
@@ -450,7 +450,7 @@ impl ParsedDeclEngine {
         for f in self.function_slab.values() {
             let _ = write!(&mut s, "Function: {}", f.name);
             for node in f.body.contents.iter() {
-                let _ = write!(&mut s, "    Node: {:#?}", node);
+                let _ = write!(&mut s, "    Node: {node:#?}");
             }
         }
 

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -1737,7 +1737,7 @@ mod tests {
         let (errors, _warnings, _infos) = handler.consume();
 
         if !errors.is_empty() {
-            panic!("{:#?}", errors);
+            panic!("{errors:#?}");
         }
 
         let f = r.unwrap();

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -4904,8 +4904,7 @@ impl<'a> FnCompiler<'a> {
                     //       want to improve and refactor Storage API in the future.
                     assert!(
                         offset_in_bytes % 8 == 0,
-                        "Expected struct fields to be aligned to word boundary. The field offset in bytes was {}.",
-                        offset_in_bytes
+                        "Expected struct fields to be aligned to word boundary. The field offset in bytes was {offset_in_bytes}."
                     );
                     offset_in_bytes / 8
                 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/abi_encoding.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/abi_encoding.rs
@@ -444,7 +444,7 @@ where
             format!("let result: raw_slice = encode::<{return_type}>({method_name}()); __contract_ret(result.ptr(), result.len::<u8>());")
         } else {
             // as the old encoding does
-            format!("__revert({});", MISMATCHED_SELECTOR_REVERT_CODE)
+            format!("__revert({MISMATCHED_SELECTOR_REVERT_CODE});")
         };
 
         let att = match (reads, writes) {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/debug.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/debug.rs
@@ -139,17 +139,13 @@ where
                     format!(
                         "{enum_name}::{variant_name} => {{
                         _f.print_str(\"{variant_name}\");
-                    }}, \n",
-                        enum_name = enum_name,
-                        variant_name = variant_name
+                    }}, \n"
                     )
                 } else {
                     format!(
                         "{enum_name}::{variant_name}(value) => {{
                         _f.debug_tuple(\"{enum_name}\").field(value).finish();
                     }}, \n",
-                        enum_name = enum_name,
-                        variant_name = variant_name,
                     )
                 }
             })

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
@@ -68,8 +68,8 @@ where
 
         let r = p.parse();
 
-        assert!(!handler.has_errors(), "{:?}", handler);
-        assert!(!handler.has_warnings(), "{:?}", handler);
+        assert!(!handler.has_errors(), "{handler:?}");
+        assert!(!handler.has_warnings(), "{handler:?}");
 
         assert!(!p.has_errors());
         assert!(!p.has_warnings());
@@ -188,7 +188,7 @@ where
                 original_source_id.map(|x| engines.se().get_file_name(x))
             );
         }
-        assert!(!handler.has_warnings(), "{:?}", handler);
+        assert!(!handler.has_warnings(), "{handler:?}");
 
         let mut ctx = self.ctx.by_ref();
         let _r = TyDecl::collect(

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
@@ -506,7 +506,7 @@ impl ty::TyMatchExpression {
                             BaseIdent::new_no_span("slice_ptr".into()),
                             BaseIdent::new_no_span("slice_ptr".into()),
                         ],
-                        immediate: Some(BaseIdent::new_no_span(format!("i{}", slice_pos))),
+                        immediate: Some(BaseIdent::new_no_span(format!("i{slice_pos}"))),
                         span: Span::dummy(),
                     },
                     AsmOp {
@@ -524,7 +524,7 @@ impl ty::TyMatchExpression {
                             BaseIdent::new_no_span("prefix_ptr".into()),
                             BaseIdent::new_no_span("prefix_ptr".into()),
                         ],
-                        immediate: Some(BaseIdent::new_no_span(format!("i{}", prefix_pos))),
+                        immediate: Some(BaseIdent::new_no_span(format!("i{prefix_pos}"))),
                         span: Span::dummy(),
                     },
                     AsmOp {

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -116,7 +116,7 @@ impl ModuleDepGraph {
             use petgraph::dot::{Config, Dot};
             let string_graph = self.dep_graph.filter_map(
                 |_idx, node| Some(format!("{:?}", engines.help_out(node))),
-                |_idx, edge| Some(format!("{}", edge)),
+                |_idx, edge| Some(format!("{edge}")),
             );
 
             let output = format!(

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -93,10 +93,7 @@ impl Namespace {
             .root_module_mut()
             .submodule_mut(package_relative_path)
             .unwrap_or_else(|| {
-                panic!(
-                    "Could not retrieve submodule for mod_path: {:?}",
-                    package_relative_path
-                );
+                panic!("Could not retrieve submodule for mod_path: {package_relative_path:?}");
             })
     }
 

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -1505,7 +1505,7 @@ impl TraitMap {
                 handler.emit_err(CompileError::TraitConstraintNotSatisfied {
                     type_id: type_id.index(),
                     ty: engines.help_out(type_id).to_string(),
-                    trait_name: format!("{}{}", trait_name, type_arguments_string),
+                    trait_name: format!("{trait_name}{type_arguments_string}"),
                     span: access_span.clone(),
                 });
             }

--- a/sway-core/src/semantic_analysis/type_check_analysis.rs
+++ b/sway-core/src/semantic_analysis/type_check_analysis.rs
@@ -224,7 +224,7 @@ impl TypeCheckAnalysisContext<'_> {
             use petgraph::dot::{Config, Dot};
             let string_graph = self.dep_graph.filter_map(
                 |_idx, node| Some(format!("{:?}", engines.help_out(node))),
-                |_idx, edge| Some(format!("{}", edge)),
+                |_idx, edge| Some(format!("{edge}")),
             );
 
             let output = format!(
@@ -369,7 +369,7 @@ impl DebugWithEngines for TyNodeDepGraphNode {
                     ty::TyTraitItem::Constant(node) => node.name().as_str(),
                     ty::TyTraitItem::Type(node) => node.name().as_str(),
                 };
-                format!("{:?}", str)
+                format!("{str:?}")
             }
             TyNodeDepGraphNode::ImplTrait { node } => {
                 let decl = engines.de().get_impl_self_or_trait(&node.decl_id);

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -898,7 +898,7 @@ fn handle_impl_contract(
                 // Generate ABI name using project name with "Abi" suffix
                 let contract_name = to_upper_camel_case(context.package_name.as_str());
                 let anon_abi_name =
-                    Ident::new_with_override(format!("{}Abi", contract_name), span.clone());
+                    Ident::new_with_override(format!("{contract_name}Abi"), span.clone());
 
                 // Convert the methods to ABI interface
                 let mut interface_surface = Vec::new();

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -237,12 +237,12 @@ impl DebugWithEngines for TypeParameter {
             TypeParameter::Const(p) => match p.expr.as_ref() {
                 Some(ConstGenericExpr::Literal { val, .. }) => format!("{} -> {}", p.name, val),
                 Some(ConstGenericExpr::AmbiguousVariableExpression { ident }) => {
-                    format!("{}", ident)
+                    format!("{ident}")
                 }
                 None => format!("{} -> None", p.name),
             },
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -577,7 +577,7 @@ impl DisplayWithEngines for TypeInfo {
                         ident.as_str().to_string()
                     }
                 };
-                format!("str[{}]", length)
+                format!("str[{length}]")
             }
             UnsignedInteger(x) => match x {
                 IntegerBits::Eight => "u8",
@@ -704,7 +704,7 @@ impl DebugWithEngines for TypeInfo {
                 if tc_str.is_empty() {
                     name.to_string()
                 } else {
-                    format!("{}:{}", name, tc_str)
+                    format!("{name}:{tc_str}")
                 }
             }
             Placeholder(t) => format!("placeholder({:?})", engines.help_out(t)),
@@ -992,7 +992,7 @@ impl TypeInfo {
                     .expr()
                     .as_literal_val()
                     .expect("unexpected non literal length");
-                format!("str[{}]", len)
+                format!("str[{len}]")
             }
             UnsignedInteger(bits) => {
                 use IntegerBits::{Eight, Sixteen, SixtyFour, ThirtyTwo, V256};
@@ -1151,7 +1151,7 @@ impl TypeInfo {
                     error_msg_span,
                 );
                 let name = name?;
-                format!("a[{};{}]", name, len)
+                format!("a[{name};{len}]")
             }
             RawUntypedPtr => "rawptr".to_string(),
             RawUntypedSlice => "rawslice".to_string(),
@@ -1914,7 +1914,7 @@ impl TypeInfo {
             TraitType {
                 name,
                 trait_type_id: _,
-            } => format!("trait type {}", name),
+            } => format!("trait type {name}"),
             Ref {
                 to_mutable_value,
                 referenced_type,

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -44,7 +44,7 @@ impl DebugWithEngines for TypeSubstMap {
                 .join(", "),
             self.const_generics_renaming
                 .iter()
-                .map(|(a, b)| format!("{:?} -> {:?}", a, b))
+                .map(|(a, b)| format!("{a:?} -> {b:?}"))
                 .collect::<Vec<_>>()
                 .join(", ")
         )

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -2824,7 +2824,7 @@ impl ToDiagnostic for CompileError {
                                 // TODO: Temporary we use `self` here to achieve backward compatibility.
                                 //       In general, `self` must not be used. All the values for the formatting
                                 //       of a diagnostic must come from its enum variant parameters.
-                                issue: Issue::error(source_engine, self.span(), format!("{}", self)),
+                                issue: Issue::error(source_engine, self.span(), format!("{self}")),
                                 ..Default::default()
                         },
                 }
@@ -2961,7 +2961,7 @@ impl ToDiagnostic for CompileError {
                                 // TODO: Temporarily we use `self` here to achieve backward compatibility.
                                 //       In general, `self` must not be used. All the values for the formatting
                                 //       of a diagnostic must come from its enum variant parameters.
-                                issue: Issue::error(source_engine, self.span(), format!("{}", self)),
+                                issue: Issue::error(source_engine, self.span(), format!("{self}")),
                                 ..Default::default()
                         },
                 }
@@ -3193,7 +3193,7 @@ impl ToDiagnostic for CompileError {
                     // TODO: Temporarily we use `self` here to achieve backward compatibility.
                     //       In general, `self` must not be used. All the values for the formatting
                     //       of a diagnostic must come from its enum variant parameters.
-                    issue: Issue::error(source_engine, self.span(), format!("{}", self)),
+                    issue: Issue::error(source_engine, self.span(), format!("{self}")),
                     ..Default::default()
             }
         }
@@ -3343,8 +3343,7 @@ fn marker_trait_name(marker_trait_full_name: &str) -> &str {
     const MARKER_TRAITS_MODULE: &str = "std::marker::";
     assert!(
         marker_trait_full_name.starts_with(MARKER_TRAITS_MODULE),
-        "`marker_trait_full_name` must start with \"std::marker::\", but it was \"{}\"",
-        marker_trait_full_name
+        "`marker_trait_full_name` must start with \"std::marker::\", but it was \"{marker_trait_full_name}\""
     );
 
     let lower_boundary = MARKER_TRAITS_MODULE.len();

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -211,8 +211,7 @@ impl fmt::Display for IrError {
             IrError::VerifyGepInconsistentTypes(error, _) => {
                 write!(
                     f,
-                    "Verification failed: Struct field type mismatch: ({}).",
-                    error
+                    "Verification failed: Struct field type mismatch: ({error})."
                 )
             }
             IrError::VerifyGepFromNonPointer(ty, _) => {

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -168,7 +168,7 @@ impl Context<'_> {
             let block = if let Some(problematic_value) = error.get_problematic_value() {
                 printer::context_print(self, &|current_value: &Value, doc: Doc| {
                     if *current_value == *problematic_value {
-                        doc.append(Doc::text_line(format!("\x1b[0;31m^ {}\x1b[0m", error)))
+                        doc.append(Doc::text_line(format!("\x1b[0;31m^ {error}\x1b[0m")))
                     } else {
                         doc
                     }
@@ -177,7 +177,7 @@ impl Context<'_> {
                 printer::block_print(self, cur_function, cur_block, &|_, doc| doc)
             };
 
-            println!("{}", block);
+            println!("{block}");
         }
 
         r?;

--- a/sway-ir/tests/tests.rs
+++ b/sway-ir/tests/tests.rs
@@ -177,7 +177,7 @@ fn inline() {
             .flat_map(|module| module.function_iter(ir))
             .collect::<Vec<_>>();
 
-        if params.iter().any(|&p| p == "all") {
+        if params.contains(&"all") {
             // Just inline everything, replacing all CALL instructions.
             funcs.into_iter().fold(false, |acc, func| {
                 opt::inline_all_function_calls(ir, &func).unwrap() || acc

--- a/sway-lsp/src/capabilities/code_actions/diagnostic/auto_import.rs
+++ b/sway-lsp/src/capabilities/code_actions/diagnostic/auto_import.rs
@@ -244,7 +244,7 @@ fn get_text_edit_for_group(
 
         TextEdit {
             range: get_range_from_span(&span.clone()),
-            new_text: format!("use {}::{{{}}};", prefix_string, suffix_string),
+            new_text: format!("use {prefix_string}::{{{suffix_string}}};"),
         }
     })
 }
@@ -278,7 +278,7 @@ fn get_text_edit_in_use_block(
 
     Some(TextEdit {
         range: Range::new(Position::new(range_line, 0), Position::new(range_line, 0)),
-        new_text: format!("use {};\n", call_path),
+        new_text: format!("use {call_path};\n"),
     })
 }
 

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -431,7 +431,7 @@ fn fn_decl_detail(parameters: &[TyFunctionParameter], return_type: &GenericArgum
         .call_path_tree()
         .map(|_| format!(" -> {}", return_type.span().as_str()))
         .unwrap_or_default();
-    format!("fn({}){}", params, return_type)
+    format!("fn({params}){return_type}")
 }
 
 /// Extracts the header of a sway construct such as an `impl` block or `abi` declaration,

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -373,7 +373,7 @@ pub(crate) fn edit_manifest_dependency_paths(
         .parse::<toml_edit::DocumentMut>()
         .map_err(|err| DocumentError::IOError {
             path: manifest_path.to_string_lossy().to_string(),
-            error: format!("Failed to parse TOML: {}", err),
+            error: format!("Failed to parse TOML: {err}"),
         })?;
 
     let manifest =

--- a/sway-lsp/tests/integration/code_actions.rs
+++ b/sway-lsp/tests/integration/code_actions.rs
@@ -83,7 +83,7 @@ fn create_changes_for_import(
             character: end_char,
         },
     };
-    create_changes_map(uri, range, &format!("use {};{}", call_path, newline))
+    create_changes_map(uri, range, &format!("use {call_path};{newline}"))
 }
 
 fn create_changes_for_qualify(
@@ -110,7 +110,7 @@ async fn send_request(server: &ServerState, params: &CodeActionParams) -> Vec<Co
     request::handle_code_action(server, params.clone())
         .await
         .unwrap()
-        .unwrap_or_else(|| panic!("Empty response from server for request: {:#?}", params))
+        .unwrap_or_else(|| panic!("Empty response from server for request: {params:#?}"))
 }
 
 pub(crate) async fn code_action_abi_request(server: &ServerState, uri: &Url) {
@@ -514,14 +514,14 @@ pub(crate) async fn code_action_auto_import_struct_request(server: &ServerState,
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 0, call_path, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 8, 12, 22, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -557,14 +557,14 @@ pub(crate) async fn code_action_auto_import_struct_request(server: &ServerState,
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 0, call_path, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 17, 12, 22, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -604,14 +604,14 @@ pub(crate) async fn code_action_auto_import_enum_request(server: &ServerState, u
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 0, call_path, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 23, 28, 37, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -647,14 +647,14 @@ pub(crate) async fn code_action_auto_import_enum_request(server: &ServerState, u
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 0, call_path, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 16, 11, 19, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -695,14 +695,14 @@ pub(crate) async fn code_action_auto_import_function_request(server: &ServerStat
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 0, call_path, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 13, 4, 12, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -743,14 +743,14 @@ pub(crate) async fn code_action_auto_import_constant_request(server: &ServerStat
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 23, "test_mod::{TEST_CONST, test_fun}", ""),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 19, 12, 22, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -788,14 +788,14 @@ pub(crate) async fn code_action_auto_import_trait_request(server: &ServerState, 
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 0, call_path, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 34, 5, 12, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -831,14 +831,14 @@ pub(crate) async fn code_action_auto_import_trait_request(server: &ServerState, 
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path),
+            format!("Import `{call_path}`"),
             create_changes_for_import(uri, 5, 0, call_path, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path),
+            format!("Qualify as `{call_path}`"),
             create_changes_for_qualify(uri, 30, 5, 14, call_path),
             None,
             Some(CodeActionKind::QUICKFIX),
@@ -878,28 +878,28 @@ pub(crate) async fn code_action_auto_import_alias_request(server: &ServerState, 
     let expected = vec![
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path1),
+            format!("Import `{call_path1}`"),
             create_changes_for_import(uri, 5, 0, call_path1, "\n"),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Import `{}`", call_path2),
+            format!("Import `{call_path2}`"),
             create_changes_for_import(uri, 5, 23, "test_mod::{A, test_fun}", ""),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path1),
+            format!("Qualify as `{call_path1}`"),
             create_changes_for_qualify(uri, 14, 4, 5, call_path1),
             None,
             Some(CodeActionKind::QUICKFIX),
         ),
         create_code_action(
             uri.clone(),
-            format!("Qualify as `{}`", call_path2),
+            format!("Qualify as `{call_path2}`"),
             create_changes_for_qualify(uri, 14, 4, 5, call_path2),
             None,
             Some(CodeActionKind::QUICKFIX),

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -68,10 +68,7 @@ pub(crate) async fn initialize_request(
     };
 
     let root_uri = Url::from_directory_path(&project_root_path_for_uri).unwrap_or_else(|_| {
-        panic!(
-            "Failed to create directory URL from project root: {:?}",
-            project_root_path_for_uri
-        )
+        panic!("Failed to create directory URL from project root: {project_root_path_for_uri:?}")
     });
 
     // Construct the InitializeParams using the defined client_capabilities
@@ -318,7 +315,7 @@ pub(crate) async fn get_document_symbols(server: &ServerState, uri: &Url) -> Vec
     if let Some(DocumentSymbolResponse::Nested(symbols)) = response {
         symbols
     } else {
-        panic!("Expected nested document symbols response: {:#?}", response);
+        panic!("Expected nested document symbols response: {response:#?}");
     }
 }
 
@@ -830,9 +827,7 @@ pub(crate) async fn inlay_hints_request(server: &ServerState, uri: &Url) -> Opti
 
     assert!(
         compare_inlay_hint_vecs(&expected, &res),
-        "InlayHint vectors are not equal.\nExpected:\n{:#?}\n\nActual:\n{:#?}",
-        expected,
-        res
+        "InlayHint vectors are not equal.\nExpected:\n{expected:#?}\n\nActual:\n{res:#?}"
     );
     Some(res)
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -205,7 +205,7 @@ fn did_open_all_members_in_examples() {
 
             // Open all workspace members and assert that we are able to return semantic tokens for each workspace member.
             for (name, package_manifest) in &member_manifests {
-                eprintln!("compiling {:?}", name);
+                eprintln!("compiling {name:?}");
                 let dir = package_manifest.path().parent().unwrap();
 
                 // If the workspace is not initialized, we need to initialize it
@@ -2553,15 +2553,15 @@ fn run_garbage_collection_tests(
             .unwrap();
 
         let test_result = if status.success() {
-            println!("  ✅ Passed: {}", project_name);
+            println!("  ✅ Passed: {project_name}");
             (project_name, test_file, true, None)
         } else {
-            println!("  ❌ Failed: {} ({})", project_name, status);
+            println!("  ❌ Failed: {project_name} ({status})");
             (
                 project_name,
                 test_file,
                 false,
-                Some(format!("Exit code: {}", status)),
+                Some(format!("Exit code: {status}")),
             )
         };
 
@@ -2577,9 +2577,9 @@ fn run_garbage_collection_tests(
     let passed = results.iter().filter(|r| r.2).count();
     let failed = total - passed;
 
-    println!("Total tests: {}", total);
-    println!("✅ Passed:   {}", passed);
-    println!("❌ Failed:   {}", failed);
+    println!("Total tests: {total}");
+    println!("✅ Passed:   {passed}");
+    println!("❌ Failed:   {failed}");
     println!();
 
     if failed > 0 {
@@ -2593,8 +2593,7 @@ fn run_garbage_collection_tests(
         println!();
 
         Err(format!(
-            "{} project(s) failed garbage collection testing",
-            failed
+            "{failed} project(s) failed garbage collection testing"
         ))
     } else {
         Ok(())

--- a/sway-types/src/lib.rs
+++ b/sway-types/src/lib.rs
@@ -159,10 +159,7 @@ impl Source {
             .as_path()
             .to_str()
             .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    "Failed to get the string representation of the path!",
-                )
+                io::Error::other("Failed to get the string representation of the path!")
             })?
             .as_bytes()
             .iter())

--- a/sway-types/src/source_engine.rs
+++ b/sway-types/src/source_engine.rs
@@ -262,7 +262,7 @@ impl SourceEngine {
         let pkg = if package_version.is_empty() {
             package_name.clone()
         } else {
-            format!("{}@{}", package_name, package_version)
+            format!("{package_name}@{package_version}")
         };
 
         // Get the relative path of the source file with respect to the manifest path.

--- a/swayfmt/src/items/item_abi/mod.rs
+++ b/swayfmt/src/items/item_abi/mod.rs
@@ -41,7 +41,7 @@ impl Format for ItemAbi {
         // abi_items
         for trait_item in abi_items.iter() {
             trait_item.format(formatted_code, formatter)?;
-            write!(formatted_code, "{}", NEW_LINE)?;
+            write!(formatted_code, "{NEW_LINE}")?;
         }
 
         if abi_items.is_empty() {
@@ -59,10 +59,10 @@ impl Format for ItemAbi {
             Self::open_curly_brace(formatted_code, formatter)?;
             for item in abi_defs.get().iter() {
                 item.format(formatted_code, formatter)?;
-                write!(formatted_code, "{}", NEW_LINE)?;
+                write!(formatted_code, "{NEW_LINE}")?;
             }
             if abi_defs.get().is_empty() {
-                write!(formatted_code, "{}", NEW_LINE)?;
+                write!(formatted_code, "{NEW_LINE}")?;
             }
             Self::close_curly_brace(formatted_code, formatter)?;
         }

--- a/swayfmt/src/items/item_impl/mod.rs
+++ b/swayfmt/src/items/item_impl/mod.rs
@@ -54,10 +54,10 @@ impl Format for ItemImpl {
         } else {
             Self::open_curly_brace(formatted_code, formatter)?;
             formatter.indent();
-            write!(formatted_code, "{}", NEW_LINE)?;
+            write!(formatted_code, "{NEW_LINE}")?;
             for item in contents.iter() {
                 item.format(formatted_code, formatter)?;
-                write!(formatted_code, "{}", NEW_LINE)?;
+                write!(formatted_code, "{NEW_LINE}")?;
             }
             Self::close_curly_brace(formatted_code, formatter)?;
         }

--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -60,7 +60,7 @@ impl Format for ItemTrait {
         } else {
             for item in trait_items.iter() {
                 item.format(formatted_code, formatter)?;
-                write!(formatted_code, "{}", NEW_LINE)?;
+                write!(formatted_code, "{NEW_LINE}")?;
             }
         }
 
@@ -71,10 +71,10 @@ impl Format for ItemTrait {
             for trait_items in trait_defs.get().iter() {
                 // format `Annotated<ItemFn>`
                 trait_items.format(formatted_code, formatter)?;
-                write!(formatted_code, "{}", NEW_LINE)?;
+                write!(formatted_code, "{NEW_LINE}")?;
             }
             if trait_defs.get().is_empty() {
-                write!(formatted_code, "{}", NEW_LINE)?;
+                write!(formatted_code, "{NEW_LINE}")?;
             }
             Self::close_curly_brace(formatted_code, formatter)?;
         };

--- a/swayfmt/src/utils/language/attribute.rs
+++ b/swayfmt/src/utils/language/attribute.rs
@@ -29,7 +29,7 @@ impl<T: Format + Spanned + std::fmt::Debug> Format for Annotated<T> {
                 // attributes and the value
                 write_comments(formatted_code, start..attr.span().start(), formatter)?;
                 if !formatted_code.ends_with(NEW_LINE) {
-                    write!(formatted_code, "{}", NEW_LINE)?;
+                    write!(formatted_code, "{NEW_LINE}")?;
                 }
             }
             formatter.write_indent_into_buffer(formatted_code)?;
@@ -41,7 +41,7 @@ impl<T: Format + Spanned + std::fmt::Debug> Format for Annotated<T> {
             // attributes and the value
             write_comments(formatted_code, start..self.value.span().start(), formatter)?;
             if !formatted_code.ends_with(NEW_LINE) {
-                write!(formatted_code, "{}", NEW_LINE)?;
+                write!(formatted_code, "{NEW_LINE}")?;
             }
         }
         // format `ItemKind`

--- a/swayfmt/src/utils/language/expr/asm_block.rs
+++ b/swayfmt/src/utils/language/expr/asm_block.rs
@@ -94,7 +94,7 @@ fn format_asm_block(
                 AsmBlock::close_parenthesis(formatted_code, formatter)?;
             } else {
                 AsmBlock::open_parenthesis(formatted_code, formatter)?;
-                write!(formatted_code, "{}", inline_arguments)?;
+                write!(formatted_code, "{inline_arguments}")?;
                 AsmBlock::close_parenthesis(formatted_code, formatter)?;
             }
 

--- a/swayfmt/src/utils/language/expr/mod.rs
+++ b/swayfmt/src/utils/language/expr/mod.rs
@@ -76,10 +76,10 @@ fn two_parts_expr(
                 )?;
             }
             _ => {
-                write!(formatted_code, " {} ", operator)?;
+                write!(formatted_code, " {operator} ")?;
             }
         }
-        write!(formatted_code, "{}", rhs_code)?;
+        write!(formatted_code, "{rhs_code}")?;
     }
     Ok(())
 }
@@ -206,7 +206,7 @@ impl Format for Expr {
                             array_descriptor.format(formatted_code, formatter)?;
                         } else {
                             // Expr fits in a single line
-                            write!(formatted_code, "{}", buf)?;
+                            write!(formatted_code, "{buf}")?;
                         }
 
                         Ok(())
@@ -312,7 +312,7 @@ impl Format for Expr {
 
                         Self::open_parenthesis(formatted_code, formatter)?;
                         let (_, args_str) = write_function_call_arguments(args.get(), formatter)?;
-                        write!(formatted_code, "{}", args_str)?;
+                        write!(formatted_code, "{args_str}")?;
                         Self::close_parenthesis(formatted_code, formatter)?;
 
                         Ok(())
@@ -947,7 +947,7 @@ fn format_method_call(
 
     Expr::open_parenthesis(formatted_code, formatter)?;
     let (args_inline, args_str) = write_function_call_arguments(args.get(), formatter)?;
-    write!(formatted_code, "{}", args_str)?;
+    write!(formatted_code, "{args_str}")?;
     Expr::close_parenthesis(formatted_code, formatter)?;
 
     if formatter.shape.code_line.expr_new_line {

--- a/swayfmt/src/utils/language/literal.rs
+++ b/swayfmt/src/utils/language/literal.rs
@@ -58,7 +58,7 @@ impl Format for Literal {
                             LitIntType::I32 => "_i32",
                             LitIntType::I64 => "_i64",
                         };
-                        write!(formatted_code, "{}", int_type)?;
+                        write!(formatted_code, "{int_type}")?;
                     }
                 } else {
                     write!(formatted_code, "{}", lit_int.span.as_str())?;

--- a/swayfmt/src/utils/language/punctuated.rs
+++ b/swayfmt/src/utils/language/punctuated.rs
@@ -88,7 +88,7 @@ where
                     let mut iter = value_separator_pairs.iter().peekable();
 
                     while let Some((type_field, comma_token)) = iter.next() {
-                        write!(formatted_code, "{}{}", type_field, comma_token)?;
+                        write!(formatted_code, "{type_field}{comma_token}")?;
                         if iter.peek().is_none() && self.final_value_opt.is_none() {
                             break;
                         }

--- a/test/src/e2e_vm_tests/harness_callback_handler.rs
+++ b/test/src/e2e_vm_tests/harness_callback_handler.rs
@@ -75,7 +75,7 @@ impl Inner {
         for cmd in cmds.iter() {
             match cmd {
                 Cmds::PrintArgs => {
-                    self.snapshot.push_str(&format!("{}\n", args));
+                    self.snapshot.push_str(&format!("{args}\n"));
                 }
                 Cmds::Trace(enable) => {
                     ctx.engines.obs().enable_trace(*enable);

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -153,7 +153,7 @@ fn print_receipts(output: &mut String, receipts: &[Receipt]) {
                             let data = data.as_deref().unwrap();
                             let s = u64::from_be_bytes(data.try_into().unwrap());
 
-                            text_log.push_str(&format!("{}", s));
+                            text_log.push_str(&format!("{s}"));
                         }
                         2 => {
                             text_log.push('\n');
@@ -422,11 +422,7 @@ impl TestContext {
                                 }
                                 Syscall::Fflush { .. } => {}
                                 Syscall::Unknown { ra, rb, rc, rd } => {
-                                    let _ = writeln!(
-                                        output,
-                                        "Unknown ecal: {} {} {} {}",
-                                        ra, rb, rc, rd
-                                    );
+                                    let _ = writeln!(output, "Unknown ecal: {ra} {rb} {rc} {rd}");
                                 }
                             }
                         }
@@ -461,7 +457,7 @@ impl TestContext {
                         },
                         revm::primitives::ExecutionResult::Revert { .. } => TestResult::Result(0),
                         revm::primitives::ExecutionResult::Halt { reason, .. } => {
-                            panic!("EVM exited with unhandled reason: {:?}", reason);
+                            panic!("EVM exited with unhandled reason: {reason:?}");
                         }
                     },
                 };
@@ -560,7 +556,7 @@ impl TestContext {
 
                 if result.is_ok() {
                     if verbose {
-                        eprintln!("[{}]", output);
+                        eprintln!("[{output}]");
                     }
 
                     Err(anyhow::Error::msg("Test compiles but is expected to fail"))
@@ -677,7 +673,7 @@ impl TestContext {
                             if verbose {
                                 println!("Test: {} {}", test.name, test.passed());
                                 for log in test.logs.iter() {
-                                    println!("{:?}", log);
+                                    println!("{log:?}");
                                 }
                             }
 
@@ -698,8 +694,7 @@ impl TestContext {
                                         let var_value = decoded_log_data.value;
                                         if verbose {
                                             println!(
-                                                "Decoded log value: {}, log rb: {}",
-                                                var_value, rb
+                                                "Decoded log value: {var_value}, log rb: {rb}"
                                             );
                                         }
                                         decoded_logs.push(var_value);
@@ -722,17 +717,16 @@ impl TestContext {
                     let expected_decoded_test_logs = expected_decoded_test_logs.unwrap_or_default();
 
                     if !failed.is_empty() {
-                        println!("FAILED!! output:\n{}", output);
+                        println!("FAILED!! output:\n{output}");
                         panic!(
                             "For {name}\n{} tests failed:\n{}",
                             failed.len(),
                             failed.into_iter().collect::<String>()
                         );
                     } else if expected_decoded_test_logs != decoded_logs {
-                        println!("FAILED!! output:\n{}", output);
+                        println!("FAILED!! output:\n{output}");
                         panic!(
-                            "For {name}\ncollected decoded logs: {:?}\nexpected decoded logs: {:?}",
-                            decoded_logs, expected_decoded_test_logs
+                            "For {name}\ncollected decoded logs: {decoded_logs:?}\nexpected decoded logs: {expected_decoded_test_logs:?}"
                         );
                     }
                 })

--- a/test/src/e2e_vm_tests/util.rs
+++ b/test/src/e2e_vm_tests/util.rs
@@ -40,7 +40,7 @@ pub(crate) fn duration_to_str(duration: &std::time::Duration) -> String {
 
     parts
         .iter()
-        .map(|part| format!("{:#02}", part))
+        .map(|part| format!("{part:#02}"))
         .collect::<Vec<_>>()
         .join(":")
 }

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -140,9 +140,9 @@ fn pretty_print_error_report(error: &str) {
                     println!("{}", line.bold())
                 }
             }
-            println!("{}", current)
+            println!("{current}")
         } else if current.starts_with("Define") {
-            println!("{}", current)
+            println!("{current}")
         } else if current.starts_with("Missed") && current.contains("check: ") {
             for line in stash.drain(..) {
                 if line.contains("^~") {
@@ -160,7 +160,7 @@ fn pretty_print_error_report(error: &str) {
                     println!("{}", line.bold())
                 }
             }
-            println!("{}", current)
+            println!("{current}")
         } else {
             stash.push(current);
         }

--- a/test/src/snapshot/mod.rs
+++ b/test/src/snapshot/mod.rs
@@ -75,7 +75,7 @@ pub(super) async fn run(filter_regex: Option<&regex::Regex>) -> Result<()> {
                 for cmd in cmds {
                     let cmd = cmd.replace("{root}", &root);
 
-                    let _ = writeln!(&mut snapshot, "> {}", cmd);
+                    let _ = writeln!(&mut snapshot, "> {cmd}");
 
                     let mut last_output: Option<String> = None;
 


### PR DESCRIPTION
## Description

This PR improves the readability of `format!`, `write!`, etc. macros by rolling out the Clippy fixes for the `uninlined_format_args` lint. `cargo clippy` started showing this lint after locally switching to Cargo v1.88.0.

Additionally, the PR:
- replaces a few occurrences of `io::Error::new(std::io::ErrorKind::Other, <msg>)` with `io::Error::other(<msg>)`.
- replaces a single occurrence of `if params.iter().any(|&p| p == "all")` with `if params.contains(&"all")`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.