### PR TITLE
fix: correct GitHub Pages deployment path for std library docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -59,7 +59,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./sway-lib-std/out/doc
+          publish_dir: ./sway-lib-std/out/doc/std
           destination_dir: master
         if: github.ref == 'refs/heads/master'
 


### PR DESCRIPTION
## Description
The GitHub Pages deployment for the Sway standard library documentation was pointing to the wrong directory, causing only partial content to be deployed to https://fuellabs.github.io/sway/master/std/.

`.github/workflows/gh-pages.yml` was deploying from `./sway-lib-std/out/doc` but the actual documentation files are generated in `./sway-lib-std/out/doc/std/`. This path mismatch resulted in incomplete documentation deployment.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
