### PR TITLE
fix: move std library assets into docs directory to fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -55,12 +55,20 @@ jobs:
       - name: Build Sway std library
         run: forc doc --path ./sway-lib-std
 
+      - name: Move assets into std directory  
+        run: |
+          mv ./sway-lib-std/out/doc/static.files ./sway-lib-std/out/doc/std/
+          mv ./sway-lib-std/out/doc/search.js ./sway-lib-std/out/doc/std/
+          # Fix relative paths in HTML files
+          find ./sway-lib-std/out/doc/std -name "*.html" -type f -exec sed -i 's|../static\.files/|static.files/|g' {} \;
+          find ./sway-lib-std/out/doc/std -name "*.html" -type f -exec sed -i 's|../search\.js|search.js|g' {} \;
+
       - name: Deploy master std
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./sway-lib-std/out/doc/std
-          destination_dir: master
+          destination_dir: master/std
         if: github.ref == 'refs/heads/master'
 
       - name: Deploy master book
@@ -125,7 +133,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./sway-lib-std/out/doc/std
+          publish_dir: ./sway-lib-std/out/doc
           destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}/std
         if: startsWith(github.ref, 'refs/tags')
 


### PR DESCRIPTION
## Description

PR #7362 attempted to fix the std library documentation deployment but broke it completely - the site now shows a 404 error at https://fuellabs.github.io/sway/master/std/.

The issue was that CSS and JavaScript assets (`static.files/`, `search.js`) were not being deployed, causing the documentation to be unusable even when HTML pages loaded.

This fix:
1. Builds docs with `forc doc`
2. Moves `static.files/` and `search.js` into the `std/` directory
3. Updates HTML relative paths (removes `../` references)
4. Deploys the complete package to `master/std`

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
