### PR TITLE
bugfix: forc call explicit support for no external contracts

### DIFF
--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -403,10 +403,12 @@ pub struct Command {
     pub gas: Option<Gas>,
 
     /// The external contract addresses to use for the call
-    /// If none are provided, the call will automatically populate external contracts by making a dry-run calls
-    /// to the node, and extract the contract addresses based on the revert reason
-    #[clap(long, alias = "contracts", help_heading = "CONTRACT")]
-    pub external_contracts: Option<Vec<ContractId>>,
+    /// If none are provided, the call will automatically populate external contracts by making dry-run calls
+    /// to the node, and extract the contract addresses based on the revert reason.
+    /// Use an empty string '' to explicitly specify no external contracts.
+    /// Multiple contract IDs can be provided separated by commas.
+    #[clap(long, alias = "contracts", value_delimiter = ',', help_heading = "CONTRACT")]
+    pub external_contracts: Option<Vec<String>>,
 
     /// Output format for the call result
     #[clap(long, short = 'o', default_value = "default", help_heading = "OUTPUT")]

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -407,7 +407,12 @@ pub struct Command {
     /// to the node, and extract the contract addresses based on the revert reason.
     /// Use an empty string '' to explicitly specify no external contracts.
     /// Multiple contract IDs can be provided separated by commas.
-    #[clap(long, alias = "contracts", value_delimiter = ',', help_heading = "CONTRACT")]
+    #[clap(
+        long,
+        alias = "contracts",
+        value_delimiter = ',',
+        help_heading = "CONTRACT"
+    )]
     pub external_contracts: Option<Vec<String>>,
 
     /// Output format for the call result

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -115,7 +115,7 @@ pub async fn call_function(
 
     // Get external contracts (either provided or auto-detected)
     let external_contracts = match external_contracts {
-        Some(contracts) if contracts.len() == 1 && (contracts[0].is_empty()) => vec![],
+        Some(contracts) if contracts.first().is_some_and(|s| s.is_empty()) => vec![],
         Some(contracts) => {
             // Parse each contract ID
             contracts

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -122,7 +122,7 @@ pub async fn call_function(
                 .into_iter()
                 .filter(|s| !s.is_empty())
                 .map(|s| {
-                    ContractId::from_str(&format!("0x{}", s.trim_start_matches("0x")))
+                    ContractId::from_str(s.strip_prefix("0x").unwrap_or(&s))
                         .map_err(|e| anyhow!("Invalid contract ID '{}': {}", s, e))
                 })
                 .collect::<Result<Vec<_>>>()?

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -31,7 +31,7 @@ use fuels_core::{
         ContractId,
     },
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 /// Calls a contract function with the given parameters
 pub async fn call_function(
@@ -115,9 +115,21 @@ pub async fn call_function(
 
     // Get external contracts (either provided or auto-detected)
     let external_contracts = match external_contracts {
-        Some(external_contracts) => external_contracts,
+        Some(contracts) if contracts.len() == 1 && (contracts[0].is_empty()) => vec![],
+        Some(contracts) => {
+            // Parse each contract ID
+            contracts
+                .into_iter()
+                .filter(|s| !s.is_empty())
+                .map(|s| {
+                    ContractId::from_str(&format!("0x{}", s.trim_start_matches("0x")))
+                        .map_err(|e| anyhow!("Invalid contract ID '{}': {}", s, e))
+                })
+                .collect::<Result<Vec<_>>>()?
+        }
         None => {
             // Automatically retrieve missing contract addresses from the call
+            forc_tracing::println_warning("Automatically retrieving missing contract addresses for the call");
             let external_contracts = determine_missing_contracts(
                 &call,
                 wallet.provider(),

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -129,7 +129,9 @@ pub async fn call_function(
         }
         None => {
             // Automatically retrieve missing contract addresses from the call
-            forc_tracing::println_warning("Automatically retrieving missing contract addresses for the call");
+            forc_tracing::println_warning(
+                "Automatically retrieving missing contract addresses for the call",
+            );
             let external_contracts = determine_missing_contracts(
                 &call,
                 wallet.provider(),


### PR DESCRIPTION
## Description

Addresses https://github.com/FuelLabs/sway/issues/7366

This pull request updates how external contract addresses are handled in the call command, improving user experience and error handling.
The main changes allow:
- explicitly indicate when no external contracts should be used
  - can now explicitly provide no external contracts (which prevents redundant RPC request(s)) using `--external-contracts ''`
- users to specify multiple contract IDs in a more flexible format (comma separated string)


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
