### PR TITLE
Iterator trait for arrays

### DIFF
--- a/forc-plugins/forc-debug/src/error.rs
+++ b/forc-plugins/forc-debug/src/error.rs
@@ -54,6 +54,7 @@ pub enum ArgumentError {
     InvalidNumber(String),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum AdapterError {
     #[error("Unhandled command")]

--- a/forc-plugins/forc-doc/src/doc/descriptor.rs
+++ b/forc-plugins/forc-doc/src/doc/descriptor.rs
@@ -33,6 +33,7 @@ impl RequiredMethods for Vec<DeclRefTraitFn> {
 }
 
 /// Used in deciding whether or not a [Declaration] is documentable.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Descriptor {
     Documentable(Document),
     NonDocumentable,

--- a/sway-ast/src/expr/mod.rs
+++ b/sway-ast/src/expr/mod.rs
@@ -484,6 +484,7 @@ impl Expr {
     /// In case of an error, the returned [Expr] can be `self`
     /// or any subexpression of `self` that is not allowed
     /// in assignment targets.
+    #[allow(clippy::result_large_err)]
     pub fn try_into_assignable(self) -> Result<Assignable, Expr> {
         if let Expr::Deref { star_token, expr } = self {
             Ok(Assignable::Deref { star_token, expr })
@@ -494,6 +495,7 @@ impl Expr {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     fn try_into_element_access(
         self,
         accept_deref_without_parens: bool,

--- a/sway-ast/src/item/item_impl.rs
+++ b/sway-ast/src/item/item_impl.rs
@@ -10,6 +10,7 @@ pub enum ImplItemParent {
     Other,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize)]
 pub enum ItemImplItem {
     Fn(ItemFn),

--- a/sway-ast/src/item/item_trait.rs
+++ b/sway-ast/src/item/item_trait.rs
@@ -2,6 +2,7 @@ use sway_error::handler::ErrorEmitted;
 
 use crate::priv_prelude::*;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize)]
 pub enum ItemTraitItem {
     Fn(FnSignature, Option<SemicolonToken>),

--- a/sway-ast/src/path.rs
+++ b/sway-ast/src/path.rs
@@ -53,6 +53,7 @@ impl Spanned for PathExpr {
 }
 
 impl PathExpr {
+    #[allow(clippy::result_large_err)]
     pub fn try_into_ident(self) -> Result<Ident, PathExpr> {
         if self.root_opt.is_none()
             && self.suffix.is_empty()

--- a/sway-core/src/asm_generation/abi.rs
+++ b/sway-core/src/asm_generation/abi.rs
@@ -1,5 +1,6 @@
 use super::EvmAbiResult;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum ProgramABI {
     Fuel(fuel_abi_types::abi::program::ProgramABI),

--- a/sway-core/src/language/parsed/declaration/storage.rs
+++ b/sway-core/src/language/parsed/declaration/storage.rs
@@ -45,6 +45,7 @@ impl PartialEqWithEngines for StorageNamespace {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum StorageEntry {
     Namespace(StorageNamespace),

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -395,6 +395,7 @@ impl TyAstNode {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum TyAstNodeContent {
     Declaration(TyDecl),
     Expression(TyExpression),

--- a/sway-core/src/language/ty/expression/scrutinee.rs
+++ b/sway-core/src/language/ty/expression/scrutinee.rs
@@ -14,6 +14,7 @@ pub struct TyScrutinee {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum TyScrutineeVariant {
     Or(Vec<TyScrutinee>),
     CatchAll,

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -793,6 +793,7 @@ pub struct CompiledAsm {
     pub panic_occurrences: PanicOccurrences,
 }
 
+#[allow(clippy::result_large_err)]
 #[allow(clippy::too_many_arguments)]
 pub fn parsed_to_ast(
     handler: &Handler,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -34,6 +34,7 @@ pub(super) type MatchVarDecl = (Ident, ty::TyExpression);
 /// variable declaration but not both at the same time.
 /// In the case of the catch-all `_` we will have neither a requirement nor
 /// a variable declaration.
+#[allow(clippy::large_enum_variant)]
 pub(super) enum ReqOrVarDecl {
     /// Neither a requirement, nor a variable declaration.
     /// Means a catch-all pattern.
@@ -102,6 +103,7 @@ impl ReqDeclTree {
 }
 
 /// A single node in the [ReqDeclTree].
+#[allow(clippy::large_enum_variant)]
 pub(super) enum ReqDeclNode {
     /// The leaf node. Contains the information about a single requirement or
     /// variable declaration.

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -50,6 +50,7 @@ impl TyProgram {
     ///
     /// The given `namespace` acts as an initial state for each module within this program.
     /// It should contain a submodule for each library package dependency.
+    #[allow(clippy::result_large_err)]
     #[allow(clippy::too_many_arguments)]
     pub fn type_check(
         handler: &Handler,

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -8,7 +8,9 @@ use sway_error::{
 use sway_types::{BaseIdent, Named, Span, Spanned};
 
 use crate::{
-    decl_engine::{DeclEngineGet, DeclEngineGetParsedDecl, DeclEngineInsert, MaterializeConstGenerics},
+    decl_engine::{
+        DeclEngineGet, DeclEngineGetParsedDecl, DeclEngineInsert, MaterializeConstGenerics,
+    },
     engine_threading::{DebugWithEngines, DisplayWithEngines, Engines, WithEngines},
     language::{ty::TyStructDecl, CallPath},
     namespace::TraitMap,
@@ -150,7 +152,8 @@ impl MaterializeConstGenerics for TypeId {
                 let mut decl = (*decl).clone();
                 decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let parsed_decl = engines.de()
+                let parsed_decl = engines
+                    .de()
                     .get_parsed_decl(id)
                     .unwrap()
                     .to_enum_decl(handler, engines)
@@ -163,7 +166,8 @@ impl MaterializeConstGenerics for TypeId {
                 let mut decl = TyStructDecl::clone(&engines.de().get(id));
                 decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let parsed_decl = engines.de()
+                let parsed_decl = engines
+                    .de()
                     .get_parsed_decl(id)
                     .unwrap()
                     .to_struct_decl(handler, engines)

--- a/sway-lib-std/src/iterator.sw
+++ b/sway-lib-std/src/iterator.sw
@@ -64,7 +64,10 @@ pub trait Iterator {
 #[cfg(experimental_const_generics = true)]
 impl<T, const N: u64> [T; N] {
     fn iter(self) -> ArrayIterator<T, N> {
-        ArrayIterator { array: self, idx: 0 }
+        ArrayIterator {
+            array: self,
+            idx: 0,
+        }
     }
 }
 
@@ -76,8 +79,8 @@ pub struct ArrayIterator<T, const N: u64> {
 
 #[cfg(experimental_const_generics = true)]
 impl<T, const N: u64> Iterator for ArrayIterator<T, N> {
-    type Item = T;
-
+    type Item = T
+;
     fn next(ref mut self) -> Option<Self::Item> {
         if self.idx >= N {
             None

--- a/sway-lib-std/src/iterator.sw
+++ b/sway-lib-std/src/iterator.sw
@@ -79,8 +79,7 @@ pub struct ArrayIterator<T, const N: u64> {
 
 #[cfg(experimental_const_generics = true)]
 impl<T, const N: u64> Iterator for ArrayIterator<T, N> {
-    type Item = T
-;
+    type Item = T;
     fn next(ref mut self) -> Option<Self::Item> {
         if self.idx >= N {
             None

--- a/sway-lib-std/src/iterator.sw
+++ b/sway-lib-std/src/iterator.sw
@@ -58,3 +58,66 @@ pub trait Iterator {
     /// ```
     fn next(ref mut self) -> Option<Self::Item>;
 }
+
+// Array Iterator
+
+#[cfg(experimental_const_generics = true)]
+impl<T, const N: u64> [T; N] {
+    fn iter(self) -> ArrayIterator<T, N> {
+        ArrayIterator { array: self, idx: 0 }
+    }
+}
+
+#[cfg(experimental_const_generics = true)]
+pub struct ArrayIterator<T, const N: u64> {
+    array: [T; N],
+    idx: u64,
+}
+
+#[cfg(experimental_const_generics = true)]
+impl<T, const N: u64> Iterator for ArrayIterator<T, N> {
+    type Item = T;
+
+    fn next(ref mut self) -> Option<Self::Item> {
+        if self.idx >= N {
+            None
+        } else {
+            let elem = __elem_at(&self.array, self.idx);
+            self.idx += 1;
+            Some(*elem)
+        }
+    }
+}
+
+// Tests
+
+#[cfg(experimental_const_generics = true)]
+#[test]
+fn ok_array_iterator_manual() {
+    use ::assert::*;
+    let array: [u64; 3] = [1u64, 2u64, 3u64];
+
+    let mut iterator = array.iter();
+    let a = iterator.next();
+    let b = iterator.next();
+    let c = iterator.next();
+    let d = iterator.next();
+
+    assert(a == Some(1u64));
+    assert(b == Some(2u64));
+    assert(c == Some(3u64));
+    assert(d == None);
+}
+
+#[cfg(experimental_const_generics = true)]
+#[test]
+fn ok_array_iterator_for() {
+    use ::assert::*;
+    let array: [u64; 3] = [1u64, 2u64, 3u64];
+
+    let mut value = 0;
+    for v in array.iter() {
+        value += v;
+    }
+    assert(value == 6);
+}

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -58,6 +58,7 @@ pub enum ParsedAstToken {
 }
 
 /// The `TypedAstToken` holds the types produced by the [sway_core::language::ty::TyProgram].
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum TypedAstToken {
     TypedTypeAliasDeclaration(ty::TyTypeAliasDecl),
@@ -149,6 +150,7 @@ pub enum TypeDefinition {
     Ident(Ident),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum TokenAstNode {
     Parsed(ParsedAstToken),


### PR DESCRIPTION
## Description

Continuation of https://github.com/FuelLabs/sway/issues/6860.

This PR implements `Iterator` trait for arrays, which allows codes like below:

```sway
let array: [u64; 3] = [1u64, 2u64, 3u64];
let mut value = 0;
for v in array.iter() {
    value += v;
}
assert(value == 6);
```

PS: `#allow` and some unrelated changes demanded by `clippy`.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
