### PR TITLE
Remove emitting of `ConvertParseThreeError::SelfImplForContract`

### DIFF
--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -855,28 +855,24 @@ pub fn item_impl_to_declaration(
             let impl_trait = engines.pe().insert(impl_trait);
             Ok(Declaration::ImplSelfOrTrait(impl_trait))
         }
-        None => match &*engines.te().get(implementing_for.type_id()) {
-            TypeInfo::Contract => Err(handler
-                .emit_err(ConvertParseTreeError::SelfImplForContract { span: block_span }.into())),
-            _ => {
-                let impl_self = ImplSelfOrTrait {
-                    is_self: true,
-                    trait_name: CallPath {
-                        callpath_type: CallPathType::Ambiguous,
-                        prefixes: vec![],
-                        suffix: BaseIdent::dummy(),
-                    },
-                    trait_decl_ref: None,
-                    trait_type_arguments: vec![],
-                    implementing_for,
-                    impl_type_parameters,
-                    items,
-                    block_span,
-                };
-                let impl_self = engines.pe().insert(impl_self);
-                Ok(Declaration::ImplSelfOrTrait(impl_self))
-            }
-        },
+        None => {
+            let impl_self = ImplSelfOrTrait {
+                is_self: true,
+                trait_name: CallPath {
+                    callpath_type: CallPathType::Ambiguous,
+                    prefixes: vec![],
+                    suffix: BaseIdent::dummy(),
+                },
+                trait_decl_ref: None,
+                trait_type_arguments: vec![],
+                implementing_for,
+                impl_type_parameters,
+                items,
+                block_span,
+            };
+            let impl_self = engines.pe().insert(impl_self);
+            Ok(Declaration::ImplSelfOrTrait(impl_self))
+        }
     }
 }
 
@@ -1005,7 +1001,7 @@ fn handle_impl_contract(
         }
     }
 
-    // Not a Contract impl, return None
+    // Not a Contract impl, return empty node contents.
     Ok(vec![])
 }
 

--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -97,8 +97,6 @@ pub enum ConvertParseTreeError {
     DuplicateParameterIdentifier { name: Ident, span: Span },
     #[error("self parameter is not allowed for {fn_kind}")]
     SelfParameterNotAllowedForFn { fn_kind: String, span: Span },
-    #[error("`impl Self` for contracts is not supported")]
-    SelfImplForContract { span: Span },
     #[error("Expected module at the beginning before any other items.")]
     ExpectedModuleAtBeginning { span: Span },
     #[error("Constant requires expression.")]
@@ -253,7 +251,6 @@ impl Spanned for ConvertParseTreeError {
             ConvertParseTreeError::DuplicateStructField { span, .. } => span.clone(),
             ConvertParseTreeError::DuplicateParameterIdentifier { span, .. } => span.clone(),
             ConvertParseTreeError::SelfParameterNotAllowedForFn { span, .. } => span.clone(),
-            ConvertParseTreeError::SelfImplForContract { span, .. } => span.clone(),
             ConvertParseTreeError::ExpectedModuleAtBeginning { span } => span.clone(),
             ConvertParseTreeError::ConstantRequiresExpression { span } => span.clone(),
             ConvertParseTreeError::ConstantRequiresTypeAscription { span } => span.clone(),


### PR DESCRIPTION
## Description

This PR removes the `ConvertParseThreeError::SelfImplForContract` and the unreachable code branch that was emiting it.

#7275 introduces self impls for contracts and transforms every `impl Contract` into `impl <GeneratedAbiName> for Contract` which makes the `SelfImplForContract` error obsolete and the `match` arm that was emitting it unreachable.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.