### PR TITLE
feat: forc node account funding

### DIFF
--- a/forc-plugins/forc-node/src/local/cmd.rs
+++ b/forc-plugins/forc-node/src/local/cmd.rs
@@ -21,23 +21,104 @@ pub struct LocalCmd {
     pub account: Vec<String>,
 }
 
+fn get_coins_per_account(
+    account_strings: Vec<String>,
+    base_asset_id: &AssetId,
+    current_coin_idx: usize,
+) -> anyhow::Result<Vec<CoinConfig>> {
+    let mut coin_generator = CoinConfigGenerator::new();
+    let mut coins = Vec::new();
+
+    for account_string in account_strings {
+        let parts: Vec<&str> = account_string.trim().split(':').collect();
+        let (owner, asset_id, amount) = match parts.as_slice() {
+            [owner_str] => {
+                // Only account-id provided, use default asset and amount
+                let owner = Address::from_str(owner_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid account ID: {}", e))?;
+                (owner, *base_asset_id, TESTNET_INITIAL_BALANCE)
+            }
+            [owner_str, asset_str] => {
+                // account-id:asset-id provided, use default amount
+                let owner = Address::from_str(owner_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid account ID: {}", e))?;
+                let asset_id = AssetId::from_str(asset_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid asset ID: {}", e))?;
+                (owner, asset_id, TESTNET_INITIAL_BALANCE)
+            }
+            [owner_str, asset_str, amount_str] => {
+                // Full format: account-id:asset-id:amount
+                let owner = Address::from_str(owner_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid account ID: {}", e))?;
+                let asset_id = AssetId::from_str(asset_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid asset ID: {}", e))?;
+                let amount = amount_str
+                    .parse::<u64>()
+                    .map_err(|e| anyhow::anyhow!("Invalid amount: {}", e))?;
+                (owner, asset_id, amount)
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid account format: {}. Expected format: <account-id>[:asset-id[:amount]]",
+                    account_string
+                ));
+            }
+        };
+        let coin = CoinConfig {
+            amount,
+            owner,
+            asset_id,
+            output_index: (current_coin_idx + coins.len()) as u16,
+            ..coin_generator.generate()
+        };
+        coins.push(coin);
+    }
+    Ok(coins)
+}
+
 impl From<LocalCmd> for Config {
     fn from(cmd: LocalCmd) -> Self {
-        let mut config = Config::local_node();
-
-        config.name = "fuel-core".to_string();
-
-        // Handle chain config/snapshot
         let snapshot_path = cmd
             .chain_config
-            .unwrap_or_else(|| ChainConfig::Local.into());
-        if snapshot_path.exists() {
-            if let Ok(metadata) = SnapshotMetadata::read(&snapshot_path) {
-                if let Ok(reader) = SnapshotReader::open(metadata) {
-                    config.snapshot_reader = reader;
+            .unwrap_or_else(|| crate::chain_config::ChainConfig::Local.into());
+        let chain_config = match SnapshotMetadata::read(&snapshot_path) {
+            Ok(metadata) => ChainConfig::from_snapshot_metadata(&metadata).unwrap(),
+            Err(e) => {
+                tracing::error!("Failed to open snapshot reader: {}", e);
+                tracing::warn!("Using local testnet snapshot reader");
+                ChainConfig::local_testnet()
+            }
+        };
+        let base_asset_id = chain_config.consensus_parameters.base_asset_id();
+
+        // Parse and validate account funding if provided
+        let mut state_config = fuel_core_chain_config::StateConfig::local_testnet();
+        state_config
+            .coins
+            .iter_mut()
+            .for_each(|coin| coin.asset_id = *base_asset_id);
+
+        let current_coin_idx = state_config.coins.len();
+        if !cmd.account.is_empty() {
+            let coins = get_coins_per_account(cmd.account, base_asset_id, current_coin_idx)
+                .map_err(|e| anyhow::anyhow!("Error parsing account funding: {}", e))
+                .unwrap();
+            if !coins.is_empty() {
+                tracing::info!("Additional accounts");
+                for coin in &coins {
+                    tracing::info!(
+                        "Address({:#x}), Asset ID({:#x}), Balance({})",
+                        coin.owner,
+                        coin.asset_id,
+                        coin.amount
+                    );
                 }
+                state_config.coins.extend(coins);
             }
         }
+
+        let mut config = Config::local_node_with_configs(chain_config, state_config);
+        config.name = "fuel-core".to_string();
 
         // Local-specific settings
         config.debug = true;

--- a/forc-plugins/forc-node/src/local/cmd.rs
+++ b/forc-plugins/forc-node/src/local/cmd.rs
@@ -167,7 +167,7 @@ mod tests {
 
         let coins = result.unwrap();
         assert_eq!(coins.len(), 1);
-        
+
         let coin = &coins[0];
         assert_eq!(coin.owner, Address::from_str(account_id).unwrap());
         assert_eq!(coin.asset_id, base_asset_id);

--- a/forc-plugins/forc-node/src/local/cmd.rs
+++ b/forc-plugins/forc-node/src/local/cmd.rs
@@ -15,6 +15,10 @@ pub struct LocalCmd {
     #[clap(long)]
     /// If a db path is provided local node runs in persistent mode.
     pub db_path: Option<PathBuf>,
+    #[clap(long)]
+    /// Fund accounts with the format: <account-id>:<asset-id>:<amount>
+    /// Multiple accounts can be provided via comma separation or multiple --account flags
+    pub account: Vec<String>,
 }
 
 impl From<LocalCmd> for Config {

--- a/forc-plugins/forc-node/tests/local.rs
+++ b/forc-plugins/forc-node/tests/local.rs
@@ -12,6 +12,7 @@ async fn start_local_node_check_health() {
         chain_config: None,
         port: Some(port),
         db_path: None,
+        account: vec![],
     };
 
     let _service = run(local_cmd, false).await.unwrap().unwrap();


### PR DESCRIPTION
## Description

This PR adds support for directly funding accounts when starting a local Fuel node with `forc-node`, eliminating the need to manually edit chainspec files - via specifying `--account` parameter.

## Changes

- Added `--account` flag to `forc-node local` command that supports multiple funding formats:
  - `<account-id>` - funds account with base asset and default amount
  - `<account-id>:<asset-id>` - funds account with specified asset and default amount  
  - `<account-id>:<asset-id>:<amount>` - funds account with specified asset and amount

## Usage Examples

```bash
# Fund single account with default asset and amount
forc-node local --account 0x0000000000000000000000000000000000000000000000000000000000000001

# Fund account with custom asset
forc-node local --account 0x0000000000000000000000000000000000000000000000000000000000000001:0x0000000000000000000000000000000000000000000000000000000000000002

# Fund account with custom asset and amount
forc-node local --account 0x0000000000000000000000000000000000000000000000000000000000000001:0x0000000000000000000000000000000000000000000000000000000000000002:1000000

# Fund multiple accounts
forc-node local --account 0x0000000000000000000000000000000000000000000000000000000000000001 --account 0x0000000000000000000000000000000000000000000000000000000000000002
```

## Implementation Details

- Default amount uses `TESTNET_INITIAL_BALANCE` constant when not specified
- Default asset uses the chain's base asset ID when not specified

Addresses: https://github.com/FuelLabs/sway/issues/7317

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
