### PR TITLE
gh-pages workflow update to remove archived actions-rs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags:
       - v*
+  workflow_dispatch:
 
 env:
   RUST_VERSION: 1.86.0


### PR DESCRIPTION
## Description

Updated the `github pages` workflow; switch from `actions-rs/toolchain@v1` to `dtolnay/rust-toolchain@master` for rust env setup.
Also added the `wasm32-unknown-unknown` target.

Completely removed `actions-rs` actions - since these are now archived.
Inlined the `actions-rs/cargo@v1` to `cargo install` - since the toolchain/binary is available via `dtolnay/rust-toolchain` action.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
