### PR TITLE
Removing todo const generics

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -227,7 +227,9 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             Ok(Some(entry_node))
         }
         ty::TyDecl::ConstGenericDecl(_) => {
-            todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+            // connect_declaration is only called from AstNode,
+            // from where a ConstGenericDecl is not reacheable
+            unreachable!()
         }
         ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
             let fn_decl = decl_engine.get_function(decl_id);

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -600,7 +600,9 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             }
         }
         ty::TyDecl::ConstGenericDecl(_) => {
-            todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860");
+            //This is only called from AstNode
+            // where a ConstGenericDecl is unreacheable
+            unreachable!()
         }
         ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
             let fn_decl = decl_engine.get_function(decl_id);
@@ -2589,7 +2591,9 @@ fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> b
                 allow_dead_code(decl_engine.get_configurable(decl_id).attributes.clone())
             }
             ty::TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                // only called from AstNode from where
+                // ConstGenericDecl is unreacheable
+                unreachable!()
             }
             ty::TyDecl::TraitTypeDecl(ty::TraitTypeDecl { decl_id, .. }) => {
                 allow_dead_code(decl_engine.get_type(decl_id).attributes.clone())

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -351,7 +351,8 @@ impl<'a> FnCompiler<'a> {
                     unreachable!()
                 }
                 ty::TyDecl::ConstGenericDecl(_) => {
-                    todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                    // ConstGenericDecl is not reacheable from AstNode
+                    unreachable!()
                 }
                 ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
                     let ted = self.engines.de().get_enum(decl_id);

--- a/sway-core/src/language/parsed/declaration.rs
+++ b/sway-core/src/language/parsed/declaration.rs
@@ -123,7 +123,7 @@ impl Declaration {
             TypeAliasDeclaration(decl_id) => pe.get_type_alias(decl_id).span(),
             TraitTypeDeclaration(decl_id) => pe.get_trait_type(decl_id).span(),
             TraitFnDeclaration(decl_id) => pe.get_trait_fn(decl_id).span(),
-            ConstGenericDeclaration(_) => {
+            ConstGenericDeclaration(decl_id) => {
                 todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
             }
         }
@@ -232,7 +232,8 @@ impl Declaration {
             | Declaration::TraitTypeDeclaration(_)
             | Declaration::TraitFnDeclaration(_) => Visibility::Public,
             Declaration::ConstGenericDeclaration(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                // const generics do not have visibility
+                unreachable!()
             }
         }
     }

--- a/sway-core/src/language/parsed/declaration.rs
+++ b/sway-core/src/language/parsed/declaration.rs
@@ -123,7 +123,7 @@ impl Declaration {
             TypeAliasDeclaration(decl_id) => pe.get_type_alias(decl_id).span(),
             TraitTypeDeclaration(decl_id) => pe.get_trait_type(decl_id).span(),
             TraitFnDeclaration(decl_id) => pe.get_trait_fn(decl_id).span(),
-            ConstGenericDeclaration(decl_id) => {
+            ConstGenericDeclaration(_) => {
                 todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
             }
         }

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -274,7 +274,8 @@ impl TyAstNode {
                     }
                 }
                 TyDecl::ConstGenericDecl(_) => {
-                    todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                    // Const generics are not reacheable from AstNode
+                    unreachable!()
                 }
                 TyDecl::TraitTypeDecl(_) => {}
                 TyDecl::FunctionDecl(decl) => {
@@ -336,7 +337,8 @@ impl TyAstNode {
                     TyDecl::ConstantDecl(_decl) => {}
                     TyDecl::ConfigurableDecl(_decl) => {}
                     TyDecl::ConstGenericDecl(_decl) => {
-                        todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                        // Const generics are not reachable from AstNode
+                        unreachable!()
                     }
                     TyDecl::TraitTypeDecl(_) => {}
                     TyDecl::FunctionDecl(decl) => {

--- a/sway-core/src/language/ty/declaration/const_generic.rs
+++ b/sway-core/src/language/ty/declaration/const_generic.rs
@@ -1,13 +1,16 @@
+use std::hash::{Hash as _, Hasher};
+
 use crate::{
     decl_engine::MaterializeConstGenerics,
+    engine_threading::HashWithEngines,
     has_changes,
     language::{parsed::ConstGenericDeclaration, ty::TyExpression, CallPath},
     semantic_analysis::{TypeCheckAnalysis, TypeCheckAnalysisContext},
-    HasChanges, SubstTypes, TypeId,
+    Engines, HasChanges, SubstTypes, TypeId,
 };
 use serde::{Deserialize, Serialize};
 use sway_error::handler::{ErrorEmitted, Handler};
-use sway_types::{BaseIdent, Ident, Named, Span, Spanned};
+use sway_types::{Ident, Named, Span, Spanned};
 
 use super::TyDeclParsedType;
 
@@ -17,6 +20,20 @@ pub struct TyConstGenericDecl {
     pub return_type: TypeId,
     pub span: Span,
     pub value: Option<TyExpression>,
+}
+
+impl HashWithEngines for TyConstGenericDecl {
+    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+        let type_engine = engines.te();
+        let TyConstGenericDecl {
+            call_path,
+            return_type,
+            span: _,
+            value: _,
+        } = self;
+        call_path.hash(state);
+        type_engine.get(*return_type).hash(state, engines);
+    }
 }
 
 impl SubstTypes for TyConstGenericDecl {
@@ -73,12 +90,6 @@ impl TypeCheckAnalysis for TyConstGenericDecl {
         _ctx: &mut TypeCheckAnalysisContext,
     ) -> Result<(), ErrorEmitted> {
         Ok(())
-    }
-}
-
-impl TyConstGenericDecl {
-    pub fn name(&self) -> &BaseIdent {
-        &self.call_path.suffix
     }
 }
 

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -570,7 +570,7 @@ impl TyDecl {
             TyDecl::VariableDecl(_decl) => None,
             TyDecl::ConstantDecl(decl) => decl_engine.get_parsed_decl(&decl.decl_id),
             TyDecl::ConfigurableDecl(decl) => decl_engine.get_parsed_decl(&decl.decl_id),
-            TyDecl::ConstGenericDecl(decl) => {
+            TyDecl::ConstGenericDecl(_) => {
                 todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
             }
             TyDecl::TraitTypeDecl(decl) => decl_engine.get_parsed_decl(&decl.decl_id),

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -211,8 +211,8 @@ impl HashWithEngines for TyDecl {
             TyDecl::ConfigurableDecl(ConfigurableDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+            TyDecl::ConstGenericDecl(ConstGenericDecl { decl_id }) => {
+                decl_engine.get(decl_id).hash(state, engines);
             }
             TyDecl::TraitTypeDecl(TraitTypeDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
@@ -293,9 +293,7 @@ impl SubstTypes for TyDecl {
             | TyDecl::StorageDecl(_)
             | TyDecl::GenericTypeForFunctionScope(_)
             | TyDecl::ErrorRecovery(..) => HasChanges::No,
-            TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
-            }
+            TyDecl::ConstGenericDecl(_) => HasChanges::No,
         }
     }
 }
@@ -311,8 +309,9 @@ impl SpannedWithEngines for TyDecl {
                 let decl = engines.de().get(decl_id);
                 decl.span.clone()
             }
-            TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+            TyDecl::ConstGenericDecl(ConstGenericDecl { decl_id }) => {
+                let decl = engines.de().get(decl_id);
+                decl.span.clone()
             }
             TyDecl::TraitTypeDecl(TraitTypeDecl { decl_id }) => {
                 engines.de().get_type(decl_id).span.clone()
@@ -501,9 +500,7 @@ impl CollectTypesMetadata for TyDecl {
                     return Ok(vec![]);
                 }
             }
-            TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
-            }
+            TyDecl::ConstGenericDecl(_) => return Ok(vec![]),
             TyDecl::ErrorRecovery(..)
             | TyDecl::StorageDecl(_)
             | TyDecl::TraitDecl(_)
@@ -529,8 +526,8 @@ impl GetDeclIdent for TyDecl {
             TyDecl::ConfigurableDecl(ConfigurableDecl { decl_id }) => {
                 Some(engines.de().get_configurable(decl_id).name().clone())
             }
-            TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+            TyDecl::ConstGenericDecl(ConstGenericDecl { decl_id }) => {
+                Some(engines.de().get_const_generic(decl_id).name().clone())
             }
             TyDecl::TraitTypeDecl(TraitTypeDecl { decl_id }) => {
                 Some(engines.de().get_type(decl_id).name().clone())
@@ -573,7 +570,7 @@ impl TyDecl {
             TyDecl::VariableDecl(_decl) => None,
             TyDecl::ConstantDecl(decl) => decl_engine.get_parsed_decl(&decl.decl_id),
             TyDecl::ConfigurableDecl(decl) => decl_engine.get_parsed_decl(&decl.decl_id),
-            TyDecl::ConstGenericDecl(_) => {
+            TyDecl::ConstGenericDecl(decl) => {
                 todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
             }
             TyDecl::TraitTypeDecl(decl) => decl_engine.get_parsed_decl(&decl.decl_id),
@@ -915,7 +912,8 @@ impl TyDecl {
                 decl_engine.get_configurable(decl_id).visibility
             }
             TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                // const generics do not have visibility
+                unreachable!()
             }
             TyDecl::StructDecl(StructDecl { decl_id, .. }) => {
                 decl_engine.get_struct(decl_id).visibility

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -1488,8 +1488,8 @@ impl DisplayWithEngines for TyExpressionVariant {
 impl DebugWithEngines for TyExpressionVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
         let s = match self {
-            TyExpressionVariant::ConstGenericExpression { .. } => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+            TyExpressionVariant::ConstGenericExpression { call_path, .. } => {
+                format!("const generics {}", call_path.span().as_str())
             }
             TyExpressionVariant::Literal(lit) => format!("literal {lit}"),
             TyExpressionVariant::FunctionApplication {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -536,7 +536,12 @@ impl TyDecl {
                     ty: GenericArgument::Type(GenericTypeArgument {
                         initial_type_id: ty.initial_type_id(),
                         type_id: new_ty,
-                        call_path_tree: ty.call_path_tree().cloned(),
+                        call_path_tree: ty
+                            .as_type_argument()
+                            .unwrap()
+                            .call_path_tree
+                            .as_ref()
+                            .cloned(),
                         span: ty.span(),
                     }),
                     visibility: decl.visibility,
@@ -553,7 +558,9 @@ impl TyDecl {
                 unreachable!();
             }
             parsed::Declaration::ConstGenericDeclaration(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                // This is called from AstNode and auto_impl
+                // both will never ask for a const generic decl
+                unreachable!()
             }
         };
 
@@ -580,7 +587,9 @@ impl TypeCheckAnalysis for TyDecl {
                 const_decl.type_check_analyze(handler, ctx)?;
             }
             TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                // Only called from AstNode, from where
+                // const generics are unreachable
+                unreachable!()
             }
             TyDecl::FunctionDecl(node) => {
                 let fn_decl = ctx.engines.de().get_function(&node.decl_id);
@@ -640,7 +649,9 @@ impl TypeCheckFinalization for TyDecl {
                 config_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::ConstGenericDecl(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+                // Only called from AstNode from where
+                // const generics are unreachable
+                unreachable!()
             }
             TyDecl::FunctionDecl(node) => {
                 let mut fn_decl = (*ctx.engines.de().get_function(&node.decl_id)).clone();

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -695,7 +695,12 @@ fn type_check_size_of_type(
             type_id,
             initial_type_id,
             span: targ.span(),
-            call_path_tree: targ.call_path_tree().cloned(),
+            call_path_tree: targ
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
+                .cloned(),
         })],
         span,
     };
@@ -745,7 +750,12 @@ fn type_check_is_reference_type(
             type_id,
             initial_type_id,
             span: targ.span(),
-            call_path_tree: targ.call_path_tree().cloned(),
+            call_path_tree: targ
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
+                .cloned(),
         })],
         span,
     };
@@ -795,7 +805,12 @@ fn type_check_assert_is_str_array(
             type_id,
             initial_type_id,
             span: targ.span(),
-            call_path_tree: targ.call_path_tree().cloned(),
+            call_path_tree: targ
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
+                .cloned(),
         })],
         span,
     };
@@ -975,7 +990,12 @@ fn type_check_gtf(
                 type_id,
                 initial_type_id,
                 span: targ.span(),
-                call_path_tree: targ.call_path_tree().cloned(),
+                call_path_tree: targ
+                    .as_type_argument()
+                    .unwrap()
+                    .call_path_tree
+                    .as_ref()
+                    .cloned(),
             })],
             span,
         },
@@ -1184,7 +1204,12 @@ fn type_check_state_store_word(
             type_id,
             initial_type_id,
             span: span.clone(),
-            call_path_tree: targ.call_path_tree().cloned(),
+            call_path_tree: targ
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
+                .cloned(),
         })
     });
     let intrinsic_function = ty::TyIntrinsicFunctionKind {
@@ -1275,7 +1300,12 @@ fn type_check_state_quad(
             type_id,
             initial_type_id,
             span: span.clone(),
-            call_path_tree: targ.call_path_tree().cloned(),
+            call_path_tree: targ
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
+                .cloned(),
         })
     });
     let intrinsic_function = ty::TyIntrinsicFunctionKind {
@@ -1692,7 +1722,12 @@ fn type_check_ptr_ops(
                 type_id,
                 initial_type_id,
                 span: targ.span(),
-                call_path_tree: targ.call_path_tree().cloned(),
+                call_path_tree: targ
+                    .as_type_argument()
+                    .unwrap()
+                    .call_path_tree
+                    .as_ref()
+                    .cloned(),
             })],
             span,
         },
@@ -1756,7 +1791,12 @@ fn type_check_smo(
             type_id,
             initial_type_id,
             span: span.clone(),
-            call_path_tree: targ.call_path_tree().cloned(),
+            call_path_tree: targ
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
+                .cloned(),
         })
     });
 

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -300,7 +300,7 @@ fn depends_on(
 // -------------------------------------------------------------------------------------------------
 // Dependencies are just a collection of dependee symbols.
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Dependencies {
     deps: DependencySet,
 }
@@ -482,9 +482,7 @@ impl Dependencies {
                 let TypeAliasDeclaration { ty, .. } = &*engines.pe().get_type_alias(decl_id);
                 self.gather_from_type_argument(engines, ty)
             }
-            Declaration::ConstGenericDeclaration(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
-            }
+            Declaration::ConstGenericDeclaration(_) => Dependencies::default(),
         }
     }
 

--- a/sway-core/src/semantic_analysis/symbol_resolve.rs
+++ b/sway-core/src/semantic_analysis/symbol_resolve.rs
@@ -394,7 +394,7 @@ impl ResolveSymbols for TypeAliasDeclaration {
 
 impl ResolveSymbols for GenericArgument {
     fn resolve_symbols(&mut self, handler: &Handler, ctx: SymbolResolveContext) {
-        if let Some(call_path) = self.call_path_tree_mut() {
+        if let Some(call_path) = self.as_type_argument_mut().unwrap().call_path_tree.as_mut() {
             call_path.resolve_symbols(handler, ctx);
         }
     }

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -1785,7 +1785,11 @@ fn ty_to_type_info(
             }
         }
         Ty::Never { .. } => TypeInfo::Never,
-        Ty::Expr(_) => todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860"),
+        Ty::Expr(expr) => {
+            return Err(
+                handler.emit_err(CompileError::ConstGenericNotSupportedHere { span: expr.span() })
+            );
+        }
     };
     Ok(type_info)
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -196,7 +196,9 @@ impl PartialEqWithEngines for TypeParameter {
     fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         match (self, other) {
             (TypeParameter::Type(l), TypeParameter::Type(r)) => l.eq(r, ctx),
-            (TypeParameter::Const(l), TypeParameter::Const(r)) => l.eq(r, ctx),
+            (TypeParameter::Const(l), TypeParameter::Const(r)) => {
+                <ConstGenericParameter as PartialEqWithEngines>::eq(l, r, ctx)
+            }
             _ => false,
         }
     }
@@ -234,9 +236,7 @@ impl OrdWithEngines for TypeParameter {
     fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         match (self, other) {
             (TypeParameter::Type(l), TypeParameter::Type(r)) => l.cmp(r, ctx),
-            (TypeParameter::Const(_), TypeParameter::Const(_)) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
-            }
+            (TypeParameter::Const(l), TypeParameter::Const(r)) => l.cmp(r),
             _ => todo!(),
         }
     }
@@ -1136,6 +1136,26 @@ impl PartialOrd for ConstGenericExpr {
     }
 }
 
+impl Ord for ConstGenericExpr {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (Self::Literal { val: l, .. }, Self::Literal { val: r, .. }) => l.cmp(r),
+            (
+                Self::AmbiguousVariableExpression { ident: l, .. },
+                Self::AmbiguousVariableExpression { ident: r, .. },
+            ) => l.cmp(r),
+            (
+                ConstGenericExpr::Literal { .. },
+                ConstGenericExpr::AmbiguousVariableExpression { .. },
+            ) => Ordering::Less,
+            (
+                ConstGenericExpr::AmbiguousVariableExpression { .. },
+                ConstGenericExpr::Literal { .. },
+            ) => Ordering::Greater,
+        }
+    }
+}
+
 impl Eq for ConstGenericExpr {}
 
 impl PartialEq for ConstGenericExpr {
@@ -1250,5 +1270,25 @@ impl SubstTypes for ConstGenericParameter {
 impl IsConcrete for ConstGenericParameter {
     fn is_concrete(&self, _engines: &Engines) -> bool {
         todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
+    }
+}
+
+impl PartialEq for ConstGenericParameter {
+    fn eq(&self, other: &Self) -> bool {
+        self.name.as_str() == other.name.as_str()
+    }
+}
+
+impl Eq for ConstGenericParameter {}
+
+impl PartialOrd for ConstGenericParameter {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.name.as_str().partial_cmp(other.name.as_str())
+    }
+}
+
+impl Ord for ConstGenericParameter {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.as_str().cmp(other.name.as_str())
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -1125,14 +1125,7 @@ impl ConstGenericExpr {
 
 impl PartialOrd for ConstGenericExpr {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match (self, other) {
-            (Self::Literal { val: l, .. }, Self::Literal { val: r, .. }) => l.partial_cmp(r),
-            (
-                Self::AmbiguousVariableExpression { ident: l, .. },
-                Self::AmbiguousVariableExpression { ident: r, .. },
-            ) => l.partial_cmp(r),
-            _ => None,
-        }
+        Some(self.cmp(other))
     }
 }
 
@@ -1283,7 +1276,7 @@ impl Eq for ConstGenericParameter {}
 
 impl PartialOrd for ConstGenericParameter {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.name.as_str().partial_cmp(other.name.as_str())
+        Some(self.cmp(other))
     }
 }
 

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -870,13 +870,22 @@ impl GetCallPathWithEngines for TypeInfo {
             TypeInfo::RawUntypedPtr => None,
             TypeInfo::RawUntypedSlice => None,
             TypeInfo::Ptr(generic_argument) => generic_argument
-                .call_path_tree()
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
                 .map(|v| v.qualified_call_path.call_path.clone()),
             TypeInfo::Slice(generic_argument) => generic_argument
-                .call_path_tree()
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
                 .map(|v| v.qualified_call_path.call_path.clone()),
             TypeInfo::Alias { name: _, ty } => ty
-                .call_path_tree()
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
                 .map(|v| v.qualified_call_path.call_path.clone()),
             TypeInfo::TraitType {
                 name: _,
@@ -886,7 +895,10 @@ impl GetCallPathWithEngines for TypeInfo {
                 to_mutable_value: _,
                 referenced_type,
             } => referenced_type
-                .call_path_tree()
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .as_ref()
                 .map(|v| v.qualified_call_path.call_path.clone()),
         }
     }

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -375,7 +375,9 @@ fn collect_enum_variants(decl: &TyEnumDecl) -> Vec<DocumentSymbol> {
             // Check for the presence of a CallPathTree, and if it exists, use the type information as the detail.
             let detail = variant
                 .type_argument
-                .call_path_tree()
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
                 .as_ref()
                 .map(|_| Some(variant.type_argument.span().as_str().to_string()))
                 .unwrap_or(None);
@@ -428,7 +430,10 @@ fn fn_decl_detail(parameters: &[TyFunctionParameter], return_type: &GenericArgum
 
     // Check for the presence of a CallPathTree, and if it exists, add it to the return type.
     let return_type = return_type
-        .call_path_tree()
+        .as_type_argument()
+        .unwrap()
+        .call_path_tree
+        .as_ref()
         .map(|_| format!(" -> {}", return_type.span().as_str()))
         .unwrap_or_default();
     format!("fn({params}){return_type}")

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -74,7 +74,13 @@ pub fn inlay_hints(
             }
 
             // Variable declaration hints
-            if var.type_ascription.call_path_tree().is_none() {
+            if var
+                .type_ascription
+                .as_type_argument()
+                .unwrap()
+                .call_path_tree
+                .is_none()
+            {
                 let type_info = engines.te().get(var.type_ascription.type_id());
                 if !matches!(
                     *type_info,

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -1122,7 +1122,7 @@ impl Parse for GenericArgument {
             }
             _ => {
                 let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), &type_info, None);
-                if let Some(tree) = &self.call_path_tree() {
+                if let Some(tree) = &self.as_type_argument().unwrap().call_path_tree.as_ref() {
                     let token =
                         Token::from_parsed(ParsedAstToken::TypeArgument(self.clone()), symbol_kind);
                     collect_call_path_tree(ctx, tree, &token, ctx.tokens);

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -655,7 +655,13 @@ impl Parse for ty::TyVariableDecl {
             ));
             token.type_def = Some(TypeDefinition::Ident(self.name.clone()));
         }
-        if let Some(call_path_tree) = &self.type_ascription.call_path_tree() {
+        if let Some(call_path_tree) = &self
+            .type_ascription
+            .as_type_argument()
+            .unwrap()
+            .call_path_tree
+            .as_ref()
+        {
             collect_call_path_tree(ctx, call_path_tree, &self.type_ascription);
         }
         self.body.parse(ctx);
@@ -879,7 +885,10 @@ impl Parse for ty::ImplSelfOrTrait {
                 implementing_for.type_id(),
                 &typed_token,
                 implementing_for
-                    .call_path_tree()
+                    .as_type_argument()
+                    .unwrap()
+                    .call_path_tree
+                    .as_ref()
                     .map(|tree| tree.qualified_call_path.call_path.suffix.span())
                     .unwrap_or(implementing_for.span()),
             );
@@ -1367,7 +1376,13 @@ fn collect_const_decl(ctx: &ParseContext, const_decl: &ty::TyConstantDecl, ident
             TokenAstNode::Typed(TypedAstToken::TypedConstantDeclaration(const_decl.clone()));
         token.type_def = Some(TypeDefinition::Ident(const_decl.call_path.suffix.clone()));
     }
-    if let Some(call_path_tree) = &const_decl.type_ascription.call_path_tree() {
+    if let Some(call_path_tree) = &const_decl
+        .type_ascription
+        .as_type_argument()
+        .unwrap()
+        .call_path_tree
+        .as_ref()
+    {
         collect_call_path_tree(ctx, call_path_tree, &const_decl.type_ascription);
     }
     if let Some(value) = &const_decl.value {
@@ -1387,7 +1402,13 @@ fn collect_configurable_decl(
             TokenAstNode::Typed(TypedAstToken::TypedConfigurableDeclaration(decl.clone()));
         token.type_def = Some(TypeDefinition::Ident(decl.call_path.suffix.clone()));
     }
-    if let Some(call_path_tree) = &decl.type_ascription.call_path_tree() {
+    if let Some(call_path_tree) = &decl
+        .type_ascription
+        .as_type_argument()
+        .unwrap()
+        .call_path_tree
+        .as_ref()
+    {
         collect_call_path_tree(ctx, call_path_tree, &decl.type_ascription);
     }
     if let Some(value) = &decl.value {
@@ -1516,7 +1537,7 @@ fn collect_type_id(
 }
 
 fn collect_type_argument(ctx: &ParseContext, type_arg: &GenericArgument) {
-    if let Some(call_path_tree) = type_arg.call_path_tree() {
+    if let Some(call_path_tree) = type_arg.as_type_argument().unwrap().call_path_tree.as_ref() {
         collect_call_path_tree(ctx, call_path_tree, type_arg);
     } else {
         collect_type_id(

--- a/swayfmt/src/utils/language/ty.rs
+++ b/swayfmt/src/utils/language/ty.rs
@@ -254,9 +254,7 @@ impl LeafSpans for Ty {
                 collected_spans
             }
             Ty::Never { bang_token } => vec![ByteSpan::from(bang_token.span())],
-            Ty::Expr(_) => {
-                todo!("Will be implemented by https://github.com/FuelLabs/sway/issues/6860")
-            }
+            Ty::Expr(expr) => expr.leaf_spans(),
         }
     }
 }


### PR DESCRIPTION
## Description

Continuation of https://github.com/FuelLabs/sway/issues/6860?reload=1?reload=1.

The summary of removed `todo!()` are:
1 - Some `todo!()` are actually unreachable. In future PRs I will try to model the AST better and remove these match arms;
2 - Some are trivial impls like spans;
3 - Some are trivial from traits like `PartialEq` and `PartialOrd`.

Others will be removed in future PRs.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
