### PR TITLE
Update nightly toolchain for cargo-udeps CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.86.0
-  NIGHTLY_RUST_VERSION: nightly-2025-03-20
+  NIGHTLY_RUST_VERSION: nightly-2025-08-15
 
 jobs:
   verifications-complete:


### PR DESCRIPTION
## Description
Point `cargo-unused-deps-check` at `nightly-2025-08-15`, which ships rustc 1.88 so `cargo-udeps` and its cargo dependencies install cleanly. This should fix the currently [failing](https://github.com/FuelLabs/sway/actions/runs/17906778883/job/50909289626?pr=7399) job. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
