### PR TITLE
symlink docs dirs for forc-mcp resources for publish CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,6 +849,14 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
 
+      - name: Link forc-mcp docs into Cargo target
+        run: |
+          set -euo pipefail
+          DOCS_SRC="${{ github.workspace }}/docs/book/src/forc/plugins/forc_mcp/forc_call_tool"
+          DOCS_DST="${{ github.workspace }}/target/docs/book/src/forc/plugins/forc_mcp/forc_call_tool"
+          mkdir -p "$(dirname "$DOCS_DST")"
+          ln -sfn "$DOCS_SRC" "$DOCS_DST"
+
       - name: Publish crate
         uses: FuelLabs/publish-crates@v1
         with:


### PR DESCRIPTION
## Description
This pull request adds a step to the CI workflow to link the `forc-mcp` documentation into the Cargo target directory. This ensures that the documentation is available in the correct location during the build process.

Documentation integration:

* Added a CI job step in `.github/workflows/ci.yml` to create a symbolic link for the `forc-mcp` documentation from `docs/book/src/forc/plugins/forc_mcp/forc_call_tool` to `target/docs/book/src/forc/plugins/forc_mcp/forc_call_tool`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
