### PR TITLE
fix: migrate to warpbuild and github runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,19 +21,14 @@ concurrency:
 
 jobs:
   benchmarks:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: buildjet/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-provider: "warpbuild"
+
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-codspeed

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   benchmarks:
     runs-on: warp-ubuntu-latest-x64-4x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,11 @@ jobs:
       - forc-run-benchmarks
       - forc-unit-tests
       - forc-pkg-fuels-deps-check
-      - cargo-test-sway-lsp
-      - cargo-test-forc
-      - cargo-test-workspace
+      - cargo-test-tools
       - cargo-unused-deps-check
       - pre-publish-check
       - cargo-run-e2e-test
       - cargo-run-e2e-test-release
-      - cargo-test-forc-debug
-      - cargo-test-forc-client
-      - cargo-test-forc-mcp
-      - cargo-test-forc-node
       - notify-slack-on-failure
     runs-on: ubuntu-latest
     steps:
@@ -96,7 +90,7 @@ jobs:
           cargo run --manifest-path .github/workflows/scripts/check-forc-manifest-version/Cargo.toml --release -- Cargo.toml
 
   get-fuel-core-version:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     outputs:
       fuel_core_version: ${{steps.get_fuel_core_ver.outputs.version}}
     steps:
@@ -116,7 +110,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
   build-sway-lib-std:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -125,14 +119,14 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Install Forc
         run: cargo install --locked --path ./forc
       - name: Build sway-lib-std
         run: forc build --path sway-lib-std
 
   build-sway-examples:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -141,12 +135,12 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Build Sway examples workspace
         run: cargo run --locked -p forc -- build --locked --path ./examples/Forc.toml
 
   build-reference-examples:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -155,12 +149,12 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Build Sway examples workspace
         run: cargo run --locked -p forc -- build --locked --path ./docs/reference/src/code/Forc.toml
 
   forc-fmt-check-sway-lib-std:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -169,12 +163,12 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "github"
       - name: Check Sway sway-lib-std formatting
         run: cargo run --locked -p forc-fmt -- --check --path ./sway-lib-std
 
   forc-fmt-check-sway-examples:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -183,12 +177,12 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "github"
       - name: Check Sway examples formatting
         run: cargo run --locked -p forc-fmt -- --check --path ./examples
 
   forc-fmt-check-panic:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -197,14 +191,14 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "github"
       - name: Install forc-fmt
         run: cargo install --locked --path ./forc-plugins/forc-fmt
       - name: Run the formatter against all sway projects and fail if any of them panic
         run: scripts/formatter/forc-fmt-check-panic.sh
 
   check-sdk-harness-test-suite-compatibility:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -225,7 +219,7 @@ jobs:
           .github/workflows/scripts/check-sdk-harness-version.sh
 
   build-mdbook:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -233,12 +227,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32-unknown-unknown
-      - uses: buildjet/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-provider: "warpbuild"
       - name: Install Forc
         run: cargo install --locked --path ./forc
       - name: Install Forc plugins
@@ -277,7 +268,7 @@ jobs:
           fi
 
   build-forc-doc-sway-lib-std:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -286,7 +277,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "github"
       - name: Install Forc
         run: cargo install --locked --path ./forc
       - name: Install Forc plugins
@@ -296,7 +287,7 @@ jobs:
         run: forc doc --path ./sway-lib-std
 
   build-forc-test-project:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -306,7 +297,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Install Forc
         run: cargo install --locked --path ./forc
       - name: Initialize test project
@@ -333,7 +324,7 @@ jobs:
         run: (cd test-proj && cargo test --release)
 
   cargo-build-workspace:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -343,14 +334,14 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: "Build Workspace"
         run: cargo build --locked --workspace --all-features --all-targets
         env:
           RUSTFLAGS: "-D warnings"
 
   cargo-clippy:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -361,12 +352,12 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "github"
       - name: Check Clippy Linter
         run: cargo clippy --all-features --all-targets -- -D warnings
 
   cargo-toml-fmt-check:
-    runs-on: ubuntu-latest # Switching this runner to buildjet causes failure.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -382,7 +373,7 @@ jobs:
         run: git ls-files | grep Cargo.toml$ | grep -v 'templates/' | xargs --verbose -n 1 cargo-toml-lint
 
   cargo-fmt-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -394,7 +385,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   cargo-run-e2e-test:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     needs: get-fuel-core-version
     steps:
       - uses: actions/checkout@v3
@@ -405,7 +396,7 @@ jobs:
           targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Install fuel-core for tests
         run: |
           curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}/fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
@@ -419,7 +410,7 @@ jobs:
           cargo run --locked --release --bin test -- --locked
 
   cargo-run-e2e-test-release:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     needs: get-fuel-core-version
     steps:
       - uses: actions/checkout@v3
@@ -430,7 +421,7 @@ jobs:
           targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Install fuel-core for tests
         run: |
           curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}/fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
@@ -445,7 +436,7 @@ jobs:
 
   # TODO: Remove this upon merging std tests with the rest of the E2E tests.
   cargo-test-lib-std:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -453,12 +444,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
-      - uses: buildjet/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-provider: "warpbuild"
       - name: Build All Tests
         run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness
       - name: Test All Tests
@@ -487,7 +475,7 @@ jobs:
       #   run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
 
   forc-run-benchmarks:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     environment: fuel-sway-bot
     permissions:
       contents: write
@@ -499,7 +487,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Install Forc
         run: cargo install --locked --path ./forc
       - name: Run benchmarks
@@ -535,7 +523,7 @@ jobs:
           default_author: github_actions
 
   forc-unit-tests:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -544,7 +532,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
       - name: Install Forc
         run: cargo install --locked --path ./forc
       - name: Run Std Unit Tests (Debug)
@@ -581,7 +569,7 @@ jobs:
         run: forc test --release --path test/src/in_language_tests --experimental const_generics,new_hashing
 
   forc-pkg-fuels-deps-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -590,7 +578,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "github"
 
       # We require this check to avoid cyclic dependencies between 'fuels' and 'forc-pkg'.
       # Detailed explanation is found in the echo below.
@@ -613,19 +601,38 @@ jobs:
               exit 0
               ;;
           esac
-  cargo-test-forc-debug:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+
+  cargo-test-tools:
+    name: Build and test various forc tools
+    runs-on: warp-ubuntu-latest-x64-4x
     needs: get-fuel-core-version
+    strategy:
+      matrix:
+        tool:
+          - test: cargo test --locked --release -p forc-client -- --test-threads 1
+          - test: cargo test --locked --release -p forc-debug
+          - test: cargo test --locked --release -p forc-client -- --test-threads 1
+          - test: cargo test --locked --release -p forc-mcp -- --test-threads 1
+          - test: cargo test --locked --release -p forc-node -- --test-threads 1
+          - test: cargo nextest run --locked --release -p sway-lsp --no-capture --profile ci --config-file sway-lsp/tests/nextest.toml
+          - test: cargo test --locked --release -p forc -- --nocapture
+          - test: cargo test --locked --release --workspace --exclude forc-debug --exclude sway-lsp --exclude forc-client --exclude forc-mcp --exclude forc --exclude forc-node
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v4
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "warpbuild"
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Install fuel-core for tests
         run: |
           curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}/fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
@@ -633,114 +640,12 @@ jobs:
           chmod +x fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core
           mv fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core /usr/local/bin/fuel-core
       - name: Run tests
-        run: cargo test --locked --release -p forc-debug
-  cargo-test-forc-client:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    needs: get-fuel-core-version
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-      - name: Install fuel-core for tests
-        run: |
-          curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}/fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
-          tar -xvf fuel-core.tar.gz
-          chmod +x fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core
-          mv fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core /usr/local/bin/fuel-core
-      - name: Run tests
-        run: cargo test --locked --release -p forc-client -- --test-threads 1
-  cargo-test-forc-mcp:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    needs: get-fuel-core-version
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-      - name: Install fuel-core for tests
-        run: |
-          curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}/fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
-          tar -xvf fuel-core.tar.gz
-          chmod +x fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core
-          mv fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core /usr/local/bin/fuel-core
-      - name: Run tests
-        run: cargo test --locked --release -p forc-mcp -- --test-threads 1
-  cargo-test-forc-node:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    needs: get-fuel-core-version
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-      - name: Install fuel-core for tests
-        run: |
-          curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}/fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
-          tar -xvf fuel-core.tar.gz
-          chmod +x fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core
-          mv fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core /usr/local/bin/fuel-core
-      - name: Run tests
-        run: cargo test --locked --release -p forc-node -- --test-threads 1
-  cargo-test-sway-lsp:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Rust and cargo-nextest
-        uses: moonrepo/setup-rust@v0
-        with:
-          channel: stable
-          cache-target: release
-          bins: cargo-nextest
-      - name: Run sway-lsp tests sequentially
         env:
           RUST_BACKTRACE: full
-        run: cargo nextest run --locked --release -p sway-lsp --no-capture --profile ci --config-file sway-lsp/tests/nextest.toml
-  cargo-test-forc:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-      - name: Run forc tests separately 
-        env:
-          RUST_BACKTRACE: full
-        run: cargo test --locked --release -p forc -- --nocapture
-  cargo-test-workspace:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-      - name: Run tests
-        run: cargo test --locked --release --workspace --exclude forc-debug --exclude sway-lsp --exclude forc-client --exclude forc-mcp --exclude forc --exclude forc-node
+        run: ${{ matrix.tool.test }}
+
   cargo-unused-deps-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -751,7 +656,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-provider: "buildjet"
+          cache-provider: "github"
       - name: Install cargo-udeps
         run: cargo install --locked cargo-udeps
       - name: Check Unused Deps
@@ -768,11 +673,10 @@ jobs:
         cargo-fmt-check,
         cargo-run-e2e-test,
         cargo-test-lib-std,
-        cargo-test-workspace,
-        cargo-test-sway-lsp,
+        cargo-test-tools,
         cargo-unused-deps-check,
       ]
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Notify Slack On Failure
         uses: ravsamhq/notify-slack-action@v2
@@ -791,7 +695,7 @@ jobs:
   # This is a separate job because we want this to fail fast if something is invalid here.
   pre-publish-check:
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -831,13 +735,12 @@ jobs:
         cargo-fmt-check,
         cargo-run-e2e-test,
         cargo-test-lib-std,
-        cargo-test-workspace,
-        cargo-test-sway-lsp,
+        cargo-test-tools,
         cargo-unused-deps-check,
         pre-publish-check,
       ]
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -879,7 +782,7 @@ jobs:
   publish-sway-lib-std:
     needs: [publish, build-and-release-forc-binaries]
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
@@ -817,6 +820,8 @@ jobs:
     runs-on: ${{ matrix.job.os }}
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: [publish]
+    permissions:
+      contents: write
     strategy:
       matrix:
         job:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,9 @@ on:
 env:
   RUST_VERSION: 1.86.0
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Description

Cleans up GitHub actions, migrates Buildjet runners to WarpBuild, and consolidates multiple forc tool checks into a matrix to simplify the `ci.yml` file.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
