### PR TITLE
Add "Experimental Features" chapter to The Sway Book

### DIFF
--- a/docs/book/spell-check-custom-words.txt
+++ b/docs/book/spell-check-custom-words.txt
@@ -265,3 +265,4 @@ schemas
 CallResponse
 md
 URIs
+Const

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -78,6 +78,7 @@
   - [Differences From Rust](./reference/rust_differences.md)
   - [Contributing To Sway](./reference/contributing_to_sway.md)
   - [Keywords](./reference/keywords.md)
+  - [Experimental Features](./reference/experimental_features.md)
 - [Forc Reference](./forc/index.md)
   - [Manifest Reference](./forc/manifest_reference.md)
   - [Workspaces](./forc/workspaces.md)

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -19,6 +19,7 @@ The `Forc.toml` (the _manifest_ file) is a compulsory file for each package and 
   * `implicit-std` -  Controls whether provided `std` version (with the current `forc` version) will get added as a dependency _implicitly_. _Unless you know what you are doing, leave this as default._
   * `forc-version` - The minimum forc version required for this project to work properly.
   * `metadata` - Metadata for the project; can be used by tools which would like to store package configuration in `Forc.toml`.
+  * `experimental` - [Experimental features](../reference/experimental_features.md) enabled or disabled during the compilation.
 
 * [`[dependencies]`](#the-dependencies-section) — Defines the dependencies.
 * `[network]` — Defines a network for forc to interact with.
@@ -43,6 +44,7 @@ An example `Forc.toml` is shown below. Under `[project]` the following fields ar
 * `documentation`
 * `categories`
 * `keywords`
+* `experimental`
 
 Also for the following fields, a default value is provided so omitting them is allowed:
 
@@ -63,6 +65,7 @@ license = "Apache-2.0"
 name = "wallet_contract"
 categories = ["example"]
 keywords = ["example"]
+experimental = { some_feature = true, some_other_feature = false }
 
 [project.metadata]
 indexing = { namespace = "counter-contract", schema_path = "out/release/counter-contract-abi.json" }

--- a/docs/book/src/reference/attributes.md
+++ b/docs/book/src/reference/attributes.md
@@ -85,7 +85,7 @@ The `#[cfg(...)]` attribute allows conditional compilation. The annotated code e
 
 - `#[cfg(target = "<target>")]` where `<target>` can be either "evm" or "fuel";
 - `#[cfg(program_type = "<program_type>")]` where `<program_type>` can be either "predicate", "script", "contract", or "library";
-- `#[cfg(experimental_<feature_flag> = true/false)]` where `<feature_flag>` is one of the known experimental feature flags.
+- `#[cfg(experimental_<feature_flag> = true/false)]` where `<feature_flag>` is one of the known [experimental feature](../reference/experimental_features.md) flags.
 
 ## Deprecated
 

--- a/docs/book/src/reference/experimental_features.md
+++ b/docs/book/src/reference/experimental_features.md
@@ -1,0 +1,84 @@
+# Experimental Features
+
+Sway compiler supports experimental features. Experimental features are used to:
+
+- develop larger language features that might be unstable during the development (e.g., [References](https://github.com/FuelLabs/sway/issues/5063)),
+- bring breaking changes in a controlled manner (e.g., [Partial equivalence](https://github.com/FuelLabs/sway/issues/6883)),
+- ensure previous compiler behavior in case of incompatible changes ([e.g., New hashing](https://github.com/FuelLabs/sway/issues/7256)).
+
+The list of [currently active](https://github.com/FuelLabs/sway/issues/?q=is%3Aissue%20state%3Aopen%20label%3Atracking-issue) and [already integrated](https://github.com/FuelLabs/sway/issues/?q=is%3Aissue%20state%3Aclosed%20label%3Atracking-issue) experimental features can be seen at Sway GitHub repository, as [issues marked with `tracking-issue` label](https://github.com/FuelLabs/sway/issues/?q=is%3Aissue%20label%3Atracking-issue). Each tracking issue contains detailed description of its experimental feature, as well as any breaking changes that the feature brings.
+
+### Enabling and Disabling Experimental Features
+
+Each experimental feature has a unique _feature flag_ defined for it. Feature flags are used to early opt-in for a feature, or to opt-out if the feature is already enabled by default, and you want to have the previous compiler behavior.
+
+E.g., a feature flag for the [Const Generics](https://github.com/FuelLabs/sway/issues/6860) feature is `const_generics`.
+
+Experimental features can be enabled and disabled using the `Forc.toml`, `forc` CLI, or environment variables.
+
+If some feature is turned on in the `Forc.toml`, it can be turned off by the CLI or by environment variables.
+
+If a feature is _not_ turned on in the `Forc.toml`, it can still be turned on by the CLI and environment variables.
+
+**Environment variables overwrite CLI arguments, which overwrite the `Forc.toml` configuration.**
+
+#### `Forc.toml`
+
+To enable and disable experimental features for a package, use the `experimental` field inside of the `Forc.toml`'s `[project]` section. Each experimental feature can be turned on or off, by setting its feature flag to `true` or `false`, respectively. If a feature flag of some existing experimental feature is not listed in the `experimental` field, the default value for enabling that feature will be used.
+
+```toml
+[project]
+... # Other project fields.
+experimental = { some_feature = true, some_other_feature = false }
+```
+
+#### `forc` CLI
+
+In `forc` CLI, opting in and out of an experimental feature is done by using two compiler flags, `--experimental` and `--no-experimental`, respectively:
+
+```console
+forc build --experimental some_feature --no-experimental some_other_feature
+```
+
+To opt-in or out of several experimental features, separate them by comma:
+
+```console
+forc build --experimental some_feature_1,some_feature_2 --no-experimental some_other_feature_1,some_other_feature_2
+```
+
+#### Environment Variables
+
+To enable and disable experimental features on the environment level, use the environment variables `FORC_EXPERIMENTAL` and `FORC_NO_EXPERIMENTAL`, respectively. Here are some examples that set those environment variables prior running `forc`: 
+
+```console
+FORC_EXPERIMENTAL=some_feature,other_feature forc build
+FORC_NO_EXPERIMENTAL=some_feature,other_feature forc build
+FORC_EXPERIMENTAL=some_feature FORC_NO_EXPERIMENTAL=other_feature forc build
+```
+
+### Conditional Compilation
+
+Experimental features are supported in [conditional compilation](../reference/attributes.md#cfg) using the `#[cfg]` attribute. For each `<feature_flag>` there is a boolean argument named `experimental_<feature_flag>` which can be set to `true` or `false`. The annotated code will be compiled only:
+
+- if the feature is enabled during compilation and the `experimental_<feature_flag>` is set to `true`.
+- if the feature is _not_ enabled during compilation and the `experimental_<feature_flag>` is set to `false`.
+
+If the conditional compilation depends upon several experimental features, multiple `#[cfg]` attributes can be combined. E.g.:
+
+```sway
+#[cfg(experimental_some_feature = true)]
+fn conditionally_compiled() {
+    log("This is compiled only if `some_feature` is enabled.");
+}
+
+#[cfg(experimental_some_feature = false)]
+fn conditionally_compiled() {
+    log("This is compiled only if `some_feature` is disabled.");
+}
+
+#[cfg(experimental_some_feature = true)]
+#[cfg(experimental_some_other_feature = true)]
+fn conditionally_compiled() {
+    log("This is compiled only if both `some_feature` and `some_other_feature` are enabled.");
+}
+```

--- a/docs/book/src/reference/experimental_features.md
+++ b/docs/book/src/reference/experimental_features.md
@@ -8,7 +8,7 @@ Sway compiler supports experimental features. Experimental features are used to:
 
 The list of [currently active](https://github.com/FuelLabs/sway/issues/?q=is%3Aissue%20state%3Aopen%20label%3Atracking-issue) and [already integrated](https://github.com/FuelLabs/sway/issues/?q=is%3Aissue%20state%3Aclosed%20label%3Atracking-issue) experimental features can be seen at Sway GitHub repository, as [issues marked with `tracking-issue` label](https://github.com/FuelLabs/sway/issues/?q=is%3Aissue%20label%3Atracking-issue). Each tracking issue contains detailed description of its experimental feature, as well as any breaking changes that the feature brings.
 
-### Enabling and Disabling Experimental Features
+## Enabling and Disabling Experimental Features
 
 Each experimental feature has a unique _feature flag_ defined for it. Feature flags are used to early opt-in for a feature, or to opt-out if the feature is already enabled by default, and you want to have the previous compiler behavior.
 
@@ -22,7 +22,7 @@ If a feature is _not_ turned on in the `Forc.toml`, it can still be turned on by
 
 **Environment variables overwrite CLI arguments, which overwrite the `Forc.toml` configuration.**
 
-#### `Forc.toml`
+### `Forc.toml`
 
 To enable and disable experimental features for a package, use the `experimental` field inside of the `Forc.toml`'s `[project]` section. Each experimental feature can be turned on or off, by setting its feature flag to `true` or `false`, respectively. If a feature flag of some existing experimental feature is not listed in the `experimental` field, the default value for enabling that feature will be used.
 
@@ -32,7 +32,7 @@ To enable and disable experimental features for a package, use the `experimental
 experimental = { some_feature = true, some_other_feature = false }
 ```
 
-#### `forc` CLI
+### `forc` CLI
 
 In `forc` CLI, opting in and out of an experimental feature is done by using two compiler flags, `--experimental` and `--no-experimental`, respectively:
 
@@ -46,9 +46,9 @@ To opt-in or out of several experimental features, separate them by comma:
 forc build --experimental some_feature_1,some_feature_2 --no-experimental some_other_feature_1,some_other_feature_2
 ```
 
-#### Environment Variables
+### Environment Variables
 
-To enable and disable experimental features on the environment level, use the environment variables `FORC_EXPERIMENTAL` and `FORC_NO_EXPERIMENTAL`, respectively. Here are some examples that set those environment variables prior running `forc`: 
+To enable and disable experimental features on the environment level, use the environment variables `FORC_EXPERIMENTAL` and `FORC_NO_EXPERIMENTAL`, respectively. Here are some examples that set those environment variables prior running `forc`:
 
 ```console
 FORC_EXPERIMENTAL=some_feature,other_feature forc build
@@ -56,7 +56,7 @@ FORC_NO_EXPERIMENTAL=some_feature,other_feature forc build
 FORC_EXPERIMENTAL=some_feature FORC_NO_EXPERIMENTAL=other_feature forc build
 ```
 
-### Conditional Compilation
+## Conditional Compilation
 
 Experimental features are supported in [conditional compilation](../reference/attributes.md#cfg) using the `#[cfg]` attribute. For each `<feature_flag>` there is a boolean argument named `experimental_<feature_flag>` which can be set to `true` or `false`. The annotated code will be compiled only:
 

--- a/docs/book/src/reference/index.md
+++ b/docs/book/src/reference/index.md
@@ -1,10 +1,13 @@
 # Sway Reference
 
+- [Sway Libraries](./sway_libs.md)
 - [Compiler Intrinsics](./compiler_intrinsics.md)
 - [Attributes](./attributes.md)
 - [Style Guide](./style_guide.md)
 - [Known Issues and Workarounds](./known_issues_and_workarounds.md)
-- [Differences from Rust](./rust_differences.md)
+- [Behavior Considered Undefined](./undefined_behavior.md)
 - [Differences from Solidity](./solidity_differences.md)
+- [Differences from Rust](./rust_differences.md)
 - [Contributing to Sway](./contributing_to_sway.md)
 - [Keywords](./keywords.md)
+- [Experimental Features](./experimental_features.md)


### PR DESCRIPTION
## Description

This PR adds "Experimental Features" chapter to The Sway Book.

#7256 will likely create need for some developers to actively use experimental features as a part of their project configurations, or CI. It was already reported that it's unclear how to add experimental features in the `Forc.toml`, and the [RFC chapter on enabling features in Sway](https://github.com/FuelLabs/sway-rfcs/blob/master/rfcs/0013-changes-lifecycle.md#enabling-features-on-sway) is unfortunately outdated. Also, some of the possibilities listed in the RFC are currently not implemented, like, e.g., the meta token for enabling and disabling all experimental features.

This PR documents the actually implemented way of using experimental features.

Additionally, it fixes the index page of the "Sway Reference" chapter, by listing all the sub-chapters in the right order.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.