### PR TITLE
CI: Update checkout to v4 and rust-cache to v2

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/nightly-cargo-audit.yml
+++ b/.github/workflows/nightly-cargo-audit.yml
@@ -8,7 +8,7 @@ jobs:
   cargo_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
- Bump actions/checkout from v1 → v4 in .github/workflows/nightly-cargo-audit.yml
- Bump Swatinem/rust-cache from v1 → v2 in .github/workflows/gh-pages.yml

## Why
- Removes version drift and aligns with the main CI (already on newer versions).
- Newer action versions include security and reliability fixes; v1 is outdated.
- v2 rust-cache has better, more predictable caching behavior.
