### PR TITLE
Use larger disk for publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,7 +743,7 @@ jobs:
         pre-publish-check,
       ]
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Publish CI step is running out of disk using ubuntu-latest
