### PR TITLE
fix: change runners for publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,7 +743,7 @@ jobs:
         pre-publish-check,
       ]
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x # needs at least 100 gb hdd
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x # needs at least 100 gb hdd
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Description

Using larger Actions runners for the GitHub pages and Sway publish steps due to disk size limitations on the standard runners.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [X] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
