### PR TITLE
Remove workarounds based on `asm` blocks from `std::hash`

### DIFF
--- a/sway-lib-std/src/hash.sw
+++ b/sway-lib-std/src/hash.sw
@@ -107,42 +107,21 @@ impl Hash for u8 {
 
 impl Hash for u16 {
     fn hash(self, ref mut state: Hasher) {
-        // TODO: Remove this workaround once `__addr_of(self)` is supported
-        //       for `u16`.
-        let temp = self;
-        let ptr = asm(ptr: &temp) {
-            ptr: raw_ptr
-        };
-        let ptr = ptr.add::<u8>(6);
-
+        let ptr = __addr_of(self).add::<u8>(6);
         state.write_raw_slice(raw_slice::from_parts::<u8>(ptr, 2));
     }
 }
 
 impl Hash for u32 {
     fn hash(self, ref mut state: Hasher) {
-        // TODO: Remove this workaround once `__addr_of(self)` is supported
-        //       for `u32`.
-        let temp = self;
-        let ptr = asm(ptr: &temp) {
-            ptr: raw_ptr
-        };
-        let ptr = ptr.add::<u8>(4);
-
+        let ptr = __addr_of(self).add::<u8>(4);
         state.write_raw_slice(raw_slice::from_parts::<u8>(ptr, 4));
     }
 }
 
 impl Hash for u64 {
     fn hash(self, ref mut state: Hasher) {
-        // TODO: Remove this workaround once `__addr_of(self)` is supported
-        //       for `u64`.
-        let temp = self;
-        let ptr = asm(ptr: &temp) {
-            ptr: raw_ptr
-        };
-
-        state.write_raw_slice(raw_slice::from_parts::<u8>(ptr, 8));
+        state.write_raw_slice(raw_slice::from_parts::<u8>(__addr_of(self), 8));
     }
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
@@ -63,97 +63,97 @@
       "concreteTypeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
       "indirect": false,
       "name": "BOOL",
-      "offset": 4936
+      "offset": 4912
     },
     {
       "concreteTypeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
       "indirect": false,
       "name": "U8",
-      "offset": 5128
+      "offset": 5104
     },
     {
       "concreteTypeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
       "indirect": false,
       "name": "ANOTHER_U8",
-      "offset": 4864
+      "offset": 4840
     },
     {
       "concreteTypeId": "29881aad8730c5ab11d275376323d8e4ff4179aae8ccb6c13fe4902137e162ef",
       "indirect": false,
       "name": "U16",
-      "offset": 5072
+      "offset": 5048
     },
     {
       "concreteTypeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc",
       "indirect": false,
       "name": "U32",
-      "offset": 5112
+      "offset": 5088
     },
     {
       "concreteTypeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc",
       "indirect": false,
       "name": "U64",
-      "offset": 5120
+      "offset": 5096
     },
     {
       "concreteTypeId": "1b5759d94094368cfd443019e7ca5ec4074300e544e5ea993a979f5da627261e",
       "indirect": false,
       "name": "U256",
-      "offset": 5080
+      "offset": 5056
     },
     {
       "concreteTypeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
       "indirect": false,
       "name": "B256",
-      "offset": 4904
+      "offset": 4880
     },
     {
       "concreteTypeId": "81fc10c4681a3271cf2d66b2ec6fbc8ed007a442652930844fcf11818c295bff",
       "indirect": false,
       "name": "CONFIGURABLE_STRUCT",
-      "offset": 5024
+      "offset": 5000
     },
     {
       "concreteTypeId": "a2922861f03be8a650595dd76455b95383a61b46dd418f02607fa2e00dc39d5c",
       "indirect": false,
       "name": "CONFIGURABLE_ENUM_A",
-      "offset": 4944
+      "offset": 4920
     },
     {
       "concreteTypeId": "a2922861f03be8a650595dd76455b95383a61b46dd418f02607fa2e00dc39d5c",
       "indirect": false,
       "name": "CONFIGURABLE_ENUM_B",
-      "offset": 4984
+      "offset": 4960
     },
     {
       "concreteTypeId": "4926d35d1a5157936b0a29bc126b8aace6d911209a5c130e9b716b0c73643ea6",
       "indirect": false,
       "name": "ARRAY_BOOL",
-      "offset": 4872
+      "offset": 4848
     },
     {
       "concreteTypeId": "776fb5a3824169d6736138565fdc20aad684d9111266a5ff6d5c675280b7e199",
       "indirect": false,
       "name": "ARRAY_U64",
-      "offset": 4880
+      "offset": 4856
     },
     {
       "concreteTypeId": "c998ca9a5f221fe7b5c66ae70c8a9562b86d964408b00d17f883c906bc1fe4be",
       "indirect": false,
       "name": "TUPLE_BOOL_U64",
-      "offset": 5056
+      "offset": 5032
     },
     {
       "concreteTypeId": "94f0fa95c830be5e4f711963e83259fe7e8bc723278ab6ec34449e791a99b53a",
       "indirect": false,
       "name": "STR_4",
-      "offset": 5048
+      "offset": 5024
     },
     {
       "concreteTypeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
       "indirect": false,
       "name": "NOT_USED",
-      "offset": 5040
+      "offset": 5016
     }
   ],
   "encodingVersion": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x94db39f409a31b9f2ebcadeea44378e419208c20de90f5d8e1e33dc1523754cb;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x7bea5fdc8235952cd918b15ae4553e449bdd2b6297c1ce70a4188a176e8b145d; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
+const CONTRACT_ID = 0x55a636b2843307e245948ea70b113b81d1f30307d4fa6fa0f4bb27c0149afd5c; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/in_language_tests/test_programs/hash_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/hash_inline_tests/src/main.sw
@@ -113,6 +113,7 @@ fn hash_fn_sha256_str_array() {
 // hex    = "0.4"
 // bincode = "1.3"
 // serde  = { version = "1", features = ["derive"] }
+
 #[test()]
 fn hash_u8() {
     let mut hasher = Hasher::new();


### PR DESCRIPTION
## Description

This PR removes workarounds based on `asm` blocks used in the `std::hash` module to obtain an address of a copy-type. Those workarounds are replaced with `__addr_of` which since #7255 supports taking addresses of copy-types.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.