### PR TITLE
Fix build warnings in `in-language` tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,21 +538,21 @@ jobs:
       - name: Run Std Unit Tests - Experimental feature 'const_generics,new_hashing' (Release)
         run: forc test --release --path sway-lib-std --experimental const_generics --no-experimental new_hashing
       - name: Run In Language Unit Tests (Debug)
-        run: forc test --path test/src/in_language_tests
+        run: forc test --error-on-warnings --path test/src/in_language_tests
       - name: Run In Language Unit Tests (Release)
-        run: forc test --release --path test/src/in_language_tests
+        run: forc test --error-on-warnings --release --path test/src/in_language_tests
       - name: Run In Language Unit Tests - Experimental feature 'const_generics' (Debug)
-        run: forc test --path test/src/in_language_tests --experimental const_generics
+        run: forc test --error-on-warnings --path test/src/in_language_tests --experimental const_generics
       - name: Run In Language Unit Tests - Experimental feature 'const_generics' (Release)
-        run: forc test --release --path test/src/in_language_tests --experimental const_generics
+        run: forc test --error-on-warnings --release --path test/src/in_language_tests --experimental const_generics
       - name: Run In Language Unit Tests - Experimental feature 'new_hashing' (Debug)
-        run: forc test --path test/src/in_language_tests --no-experimental new_hashing
+        run: forc test --error-on-warnings --path test/src/in_language_tests --no-experimental new_hashing
       - name: Run In Language Unit Tests - Experimental feature 'new_hashing' (Release)
-        run: forc test --release --path test/src/in_language_tests --no-experimental new_hashing
+        run: forc test --error-on-warnings --release --path test/src/in_language_tests --no-experimental new_hashing
       - name: Run In Language Unit Tests - Experimental feature 'const_generics,new_hashing' (Debug)
-        run: forc test --path test/src/in_language_tests --experimental const_generics --no-experimental new_hashing
+        run: forc test --error-on-warnings --path test/src/in_language_tests --experimental const_generics --no-experimental new_hashing
       - name: Run In Language Unit Tests - Experimental feature 'const_generics,new_hashing' (Release)
-        run: forc test --release --path test/src/in_language_tests --experimental const_generics --no-experimental new_hashing
+        run: forc test --error-on-warnings --release --path test/src/in_language_tests --experimental const_generics --no-experimental new_hashing
 
   forc-pkg-fuels-deps-check:
     runs-on: ubuntu-latest

--- a/test/src/in_language_tests/test_programs/crypto_ed25519_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_ed25519_inline_tests/src/main.sw
@@ -37,7 +37,7 @@ fn ed25519_bits() {
 }
 
 #[test]
-fn ed25519__verify() {
+fn ed25519_verify() {
     let pub_key = 0x314fa58689bbe1da2430517de2d772b384a1c1d2e9cb87e73c6afcf246045b10;
     let msg = b256::zero();
     let msg_hash = sha256(msg);

--- a/test/src/in_language_tests/test_programs/crypto_secp256k1_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_secp256k1_inline_tests/src/main.sw
@@ -165,7 +165,7 @@ fn secp256k1_verify_address() {
     let lo_2 = 0x2555de81cd3a40382d3d64eb1c77e463eea5a76d65ec85f283e0b3d568352678;
     let msg_hash_2 = 0xa13f4ab54057ce064d3dd97ac3ff30ed704e73956896c03650fe59b1a561fe15;
     let address_2 = Address::zero();
-    let signature_2 = Secp256k1::from((hi_2, lo_2));
+    let _signature_2 = Secp256k1::from((hi_2, lo_2));
     let message_2 = Message::from(msg_hash_2);
 
     // A recovered Fuel address.
@@ -190,7 +190,7 @@ fn secp256k1_verify_evm_address() {
     let lo_2 = 0x44ac566bd156b4fc71a4a4cb2655d3dd360c695edb17dc3b64d611e122fea23d;
     let msg_hash_2 = 0xee45573606c96c98ba970ff7cf9511f1b8b25e6bcd52ced30b89df1e4a9c4323;
     let address_2 = EvmAddress::zero();
-    let signature_2 = Secp256k1::from((hi_2, lo_2));
+    let _signature_2 = Secp256k1::from((hi_2, lo_2));
     let message_2 = Message::from(msg_hash_2);
 
     // A recovered Fuel address.

--- a/test/src/in_language_tests/test_programs/crypto_secp256r1_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_secp256r1_inline_tests/src/main.sw
@@ -165,7 +165,7 @@ fn secp256r1_verify_address() {
     let lo_2 = 0x44ac566bd156b4fc71a4a4cb2655d3dd360c695edb17dc3b64d611e122fea23d;
     let msg_hash_2 = 0xee45573606c96c98ba970ff7cf9511f1b8b25e6bcd52ced30b89df1e4a9c4323;
     let address_2 = Address::zero();
-    let signature_2 = Secp256r1::from((hi_2, lo_2));
+    let _signature_2 = Secp256r1::from((hi_2, lo_2));
     let message_2 = Message::from(msg_hash_2);
 
     // A recovered Fuel address.

--- a/test/src/in_language_tests/test_programs/crypto_signature_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_signature_inline_tests/src/main.sw
@@ -52,7 +52,7 @@ fn signature_recover() {
     let msg_hash_3 = sha256(msg_3);
     let hi_3 = 0xf38cef9361894be6c6e0eddec28a663d099d7ddff17c8077a1447d7ecb4e6545;
     let lo_3 = 0xf5084560039486d3462dd65a40c80a74709b2f06d450ffc5dc00345c6b2cdd00;
-    let public_key_3: PublicKey = PublicKey::from(pub_key_3);
+    let _public_key_3: PublicKey = PublicKey::from(pub_key_3);
     let signature_3: Signature = Signature::Ed25519(Ed25519::from((hi_3, lo_3)));
     let message_3: Message = Message::from(msg_hash_3);
 
@@ -92,7 +92,7 @@ fn signature_address() {
     let msg_hash_3 = sha256(msg_3);
     let hi_3 = 0xf38cef9361894be6c6e0eddec28a663d099d7ddff17c8077a1447d7ecb4e6545;
     let lo_3 = 0xf5084560039486d3462dd65a40c80a74709b2f06d450ffc5dc00345c6b2cdd00;
-    let public_key_3: PublicKey = PublicKey::from(pub_key_3);
+    let _public_key_3: PublicKey = PublicKey::from(pub_key_3);
     let signature_3: Signature = Signature::Ed25519(Ed25519::from((hi_3, lo_3)));
     let message_3: Message = Message::from(msg_hash_3);
 
@@ -130,7 +130,7 @@ fn signature_evm_address() {
     let msg_hash_3 = sha256(msg_3);
     let hi_3 = 0xf38cef9361894be6c6e0eddec28a663d099d7ddff17c8077a1447d7ecb4e6545;
     let lo_3 = 0xf5084560039486d3462dd65a40c80a74709b2f06d450ffc5dc00345c6b2cdd00;
-    let public_key_3: PublicKey = PublicKey::from(pub_key_3);
+    let _public_key_3: PublicKey = PublicKey::from(pub_key_3);
     let signature_3: Signature = Signature::Ed25519(Ed25519::from((hi_3, lo_3)));
     let message_3: Message = Message::from(msg_hash_3);
 
@@ -210,7 +210,7 @@ fn signature_verify_address() {
     let msg_hash_3 = sha256(msg_3);
     let hi_3 = 0xf38cef9361894be6c6e0eddec28a663d099d7ddff17c8077a1447d7ecb4e6545;
     let lo_3 = 0xf5084560039486d3462dd65a40c80a74709b2f06d450ffc5dc00345c6b2cdd00;
-    let public_key_3: PublicKey = PublicKey::from(pub_key_3);
+    let _public_key_3: PublicKey = PublicKey::from(pub_key_3);
     let signature_3: Signature = Signature::Ed25519(Ed25519::from((hi_3, lo_3)));
     let message_3: Message = Message::from(msg_hash_3);
 
@@ -248,7 +248,7 @@ fn signature_verify_evm_address() {
     let msg_hash_3 = sha256(msg_3);
     let hi_3 = 0xf38cef9361894be6c6e0eddec28a663d099d7ddff17c8077a1447d7ecb4e6545;
     let lo_3 = 0xf5084560039486d3462dd65a40c80a74709b2f06d450ffc5dc00345c6b2cdd00;
-    let public_key_3: PublicKey = PublicKey::from(pub_key_3);
+    let _public_key_3: PublicKey = PublicKey::from(pub_key_3);
     let signature_3: Signature = Signature::Ed25519(Ed25519::from((hi_3, lo_3)));
     let message_3: Message = Message::from(msg_hash_3);
 

--- a/test/src/in_language_tests/test_programs/ecr_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/ecr_inline_tests/src/main.sw
@@ -16,6 +16,7 @@ use std::{
     },
 };
 
+#[allow(deprecated)]
 #[test]
 fn ecr_ec_recover() {
     let hi_1 = 0x61f3caf4c0912cec69ff0b226638d397115c623a7f057914d48a7e4daf1cf6d8;
@@ -41,6 +42,7 @@ fn ecr_ec_recover() {
     assert(result_2.is_err());
 }
 
+#[allow(deprecated)]
 #[test]
 fn ecr_ec_recover_r1() {
     let hi_1 = 0xbd0c9b8792876712afadbff382e1bf31c44437823ed761cc3600d0016de511ac;
@@ -65,6 +67,7 @@ fn ecr_ec_recover_r1() {
     assert(result_2.is_err());
 }
 
+#[allow(deprecated)]
 #[test]
 fn ecr_ec_recover_address() {
     let hi_1 = 0x61f3caf4c0912cec69ff0b226638d397115c623a7f057914d48a7e4daf1cf6d8;
@@ -86,6 +89,7 @@ fn ecr_ec_recover_address() {
     assert(result_2.is_err());
 }
 
+#[allow(deprecated)]
 #[test]
 fn ecr_ec_recover_address_r1() {
     let hi_1 = 0xbd0c9b8792876713afa8bf3383eebf31c43437823ed761cc3600d0016de5110c;
@@ -150,6 +154,7 @@ fn ecr_ec_recover_address_r1() {
 // x = 16, (5573fe0bf140c8f1ca1b6b41fd4dc0bfcf92aefc67ab7dfd8aac1c264a66e67f, b47ed5cd8285cc2e8bf4a24a5e923a543278c43630f6e3d3da5a884de4982406)
 // x = 32, (00d8a17c74a926854155f0092fe8c2db55220cff891a38f0ee00e549fec8ba07, f2dda3573b2f03d19eefebf93aa93d4ebca81e2c42de5b0f52d8c957f6390a0b)
 // x = 64, (9a9e7077c905c855c86fb6aea6052f50a2cf29f70205f465d809cb0b81c6503f, fea5d320a5f9d4164b7eca627d3e81293083e7f6682b3b1ebc257459fcf89b08)
+#[allow(deprecated)]
 #[test]
 fn ecr_ed_verify() {
     let pub_key = 0x7127a92630327cfa3fac37b0dcc969968da0efb18bbbbf498c16966373973b21;
@@ -194,6 +199,7 @@ fn ecr_ed_verify() {
     }
 }
 
+#[allow(deprecated)]
 #[test]
 fn ecr_ed_verify_fail() {
     let pub_key = 0x7127a92630327cfa3fac37b0dcc969968da0efb18bbbbf498c16966373973b21;

--- a/test/src/in_language_tests/test_programs/flags_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/flags_inline_tests/src/main.sw
@@ -73,7 +73,7 @@ fn test_panic_on_overflow_enabled() {
     // Enabled by default
     assert(panic_on_overflow_enabled());
 
-    disable_panic_on_overflow();
+    let _ = disable_panic_on_overflow();
     assert(!panic_on_overflow_enabled());
 
     enable_panic_on_overflow();
@@ -85,7 +85,7 @@ fn test_panic_on_unsafe_math_enabled() {
     // Enabled by default
     assert(panic_on_unsafe_math_enabled());
 
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
     assert(!panic_on_unsafe_math_enabled());
 
     enable_panic_on_unsafe_math();

--- a/test/src/in_language_tests/test_programs/math_inline_tests/src/modulo.sw
+++ b/test/src/in_language_tests/test_programs/math_inline_tests/src/modulo.sw
@@ -31,7 +31,7 @@ pub fn revert_math_u8_modulo_panic_on_overflow_disabled() {
 
 #[test]
 pub fn math_u8_modulo_unsafe_math() {
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
     assert(0u8 % 0u8 == 0u8);
     assert(1u8 % 0u8 == 0u8);
     assert(u8::max() % 0u8 == 0u8);
@@ -66,7 +66,7 @@ pub fn revert_math_u16_modulo_panic_on_overflow_disabled() {
 
 #[test]
 pub fn math_u16_modulo_unsafe_math() {
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
     assert(0u16 % 0u16 == 0u16);
     assert(1u16 % 0u16 == 0u16);
     assert(u16::max() % 0u16 == 0u16);
@@ -101,7 +101,7 @@ pub fn revert_math_u32_modulo_panic_on_overflow_disabled() {
 
 #[test]
 pub fn math_u32_modulo_unsafe_math() {
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
     assert(0u32 % 0u32 == 0u32);
     assert(1u32 % 0u32 == 0u32);
     assert(u32::max() % 0u32 == 0u32);
@@ -136,7 +136,7 @@ pub fn revert_math_u64_modulo_panic_on_disabled_overflow() {
 
 #[test]
 pub fn math_u64_modulo_unsafe_math() {
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
     assert(0u64 % 0u64 == 0u64);
     assert(1u64 % 0u64 == 0u64);
     assert(u64::max() % 0u64 == 0u64);
@@ -170,7 +170,7 @@ pub fn revert_math_u256_modulo_panic_on_disabled_overflow() {
 
 #[test]
 pub fn math_u256_modulo_unsafe_math() {
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
     assert(0x0u256 % 0x0u256 == 0x0u256);
     assert(0x1u256 % 0x0u256 == 0x0u256);
     assert(u256::max() % 0x0u256 == 0x0u256);

--- a/test/src/in_language_tests/test_programs/math_inline_tests/src/pow.sw
+++ b/test/src/in_language_tests/test_programs/math_inline_tests/src/pow.sw
@@ -221,6 +221,7 @@ fn math_power_u256() {
     let zero = 0x00u256;
     let one = 0x01u256;
     let two = 0x02u256;
+    let three = 0x03u256;
     let four = 0x04u256;
     let five = 0x05u256;
     let eight = 0x08u256;
@@ -241,6 +242,9 @@ fn math_power_u256() {
 
     assert(two.pow(3) == eight);
     assert(two ** 3 == eight);
+
+    assert(three.pow(2) == nine);
+    assert(three ** 2 == nine);
 
     assert(0x2au256.pow(2) == 0x06e4u256);
     assert(0x2au256 ** 2 == 0x06e4u256);

--- a/test/src/in_language_tests/test_programs/storage_vec_iter_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_iter_tests/src/main.sw
@@ -13,12 +13,14 @@ storage {
     vec_of_vec: StorageVec<StorageVec<u64>> = StorageVec {},
 }
 
+#[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read)]
 fn assert_empty_vec_next_returns_none_impl<T>(slot_id_preimage: u64) {
     let vec: StorageKey<StorageVec<T>> = StorageKey::new(sha256(slot_id_preimage), 0, sha256(slot_id_preimage + 100));
     assert(vec.iter().next().is_none());
 }
 
+#[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
 fn assert_vec_with_elements_next_returns_element_impl<T>(
     slot_id_preimage: u64,
@@ -54,6 +56,7 @@ where
     assert(element_after_last.is_none());
 }
 
+#[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
 fn assert_vec_with_elements_for_loop_iteration_impl<T>(
     slot_id_preimage: u64,

--- a/test/src/in_language_tests/test_programs/u128_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/u128_inline_tests/src/main.sw
@@ -887,7 +887,7 @@ fn revert_u128_mod_zero() {
     let a = U128::from((0, 1));
     let b = U128::zero();
 
-    let result = a % b;
+    let _ = a % b;
 }
 
 #[test(should_revert)]
@@ -896,7 +896,7 @@ fn revert_u128_mod_zero_disabled_overflow() {
     let a = U128::from((0, 1));
     let b = U128::zero();
 
-    let result = a % b;
+    let _ = a % b;
 }
 
 #[test]

--- a/test/src/in_language_tests/test_programs/vec_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/vec_inline_tests/src/main.sw
@@ -744,7 +744,7 @@ fn vec_encode_and_decode() {
 
 #[test]
 fn vec_resize() {
-    let (mut vec_1, a, b, c) = setup();
+    let (mut vec_1, _, _, _) = setup();
     assert(vec_1.len() == 3);
     assert(vec_1.capacity() == 4);
 
@@ -808,7 +808,7 @@ fn vec_resize() {
 
 #[test]
 fn vec_last() {
-    let (mut vec_1, a, b, c) = setup();
+    let (mut vec_1, _, _, _) = setup();
     assert(vec_1.last() == Some(9));
 
     vec_1.push(2);

--- a/test/src/in_language_tests/test_programs/vm_evm_ecr_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/vm_evm_ecr_inline_tests/src/main.sw
@@ -2,6 +2,7 @@ library;
 
 use std::{b512::B512, vm::evm::{ecr::ec_recover_evm_address, evm_address::EvmAddress}};
 
+#[allow(deprecated)]
 #[test]
 fn ecr_ec_recover() {
     let hi_1 = 0xbd0c9b8792876713afa8bff383eebf31c43437823ed761cc3600d0016de5110c;

--- a/test/src/in_language_tests/test_programs/vm_evm_evm_address_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/vm_evm_evm_address_inline_tests/src/main.sw
@@ -178,27 +178,27 @@ fn evm_address_try_from_bytes() {
 
     // Test zero bytes
     let bytes_3_full = Bytes::from(b256::zero());
-    let (bytes_3, bytes_3_discard) = bytes_3_full.split_at(20);
+    let (bytes_3, _bytes_3_discard) = bytes_3_full.split_at(20);
     let evm_address_3 = EvmAddress::try_from(bytes_3);
     assert(evm_address_3.is_some());
     assert(evm_address_3.unwrap() == EvmAddress::zero());
 
     // Test max bytes
     let bytes_4_full = Bytes::from(b256::max());
-    let (bytes_4, bytes_4_discard) = bytes_4_full.split_at(20);
+    let (bytes_4, _bytes_4_discard) = bytes_4_full.split_at(20);
     let evm_address_4 = EvmAddress::try_from(bytes_4);
     assert(evm_address_4.is_some());
     assert(evm_address_4.unwrap() == EvmAddress::from(b256::max()));
 
     // Test too many bytes
     let bytes_5_full = Bytes::from(b256::zero());
-    let (mut bytes_5, bytes_5_discard) = bytes_5_full.split_at(20);
+    let (mut bytes_5, _bytes_5_discard) = bytes_5_full.split_at(20);
     bytes_5.push(255u8);
     assert(EvmAddress::try_from(bytes_5).is_none());
 
     // Test modifying bytes after doesn't impact 
     let bytes_6_full = Bytes::from(b256::zero());
-    let (mut bytes_6, bytes_6_discard) = bytes_6_full.split_at(20);
+    let (mut bytes_6, _bytes_6_discard) = bytes_6_full.split_at(20);
     let evm_address_6 = EvmAddress::try_from(bytes_6);
     assert(evm_address_6.is_some());
     assert(evm_address_6.unwrap() == EvmAddress::zero());


### PR DESCRIPTION
## Description

This PR fixes warnings emitted in `in-language` tests and sets the `--error-on-warnings` flag when running those tests on CI. This removes unnecessary output, e.g., when extracting performance data (gas usages and bytecode sizes) from the output of the `forc test` runs.

Removal of warnings revealed additional DCA issues that are marked as `TODO-DCA` in code and linked to #7462.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.