### PR TITLE
Collect more storage access performance data from tests

### DIFF
--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -1690,7 +1690,7 @@ fn parse_test_toml(path: &Path, run_config: &RunConfig) -> Result<TestDescriptio
             None => Err(anyhow!(
                 "Malformed category '{category_val}', should be a string."
             )),
-            Some(other) => Err(anyhow!("Unknown category '{}'.", other)),
+            Some(other) => Err(anyhow!("Unknown test category '{other}'. Valid categories are: run, run_on_node, fail, compile, disabled, and unit_tests_pass.")),
         })?;
 
     let expected_decoded_test_logs = if let Some(toml::Value::Array(a)) =

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
@@ -301,3 +301,52 @@ fn test_storage() {
 fn assert_streq<S1>(lhs: S1, rhs: str) {
     assert_eq(sha256_str_array(lhs), sha256(rhs));
 }
+
+#[test]
+fn collect_basic_storage_contract_gas_usages() {
+    let caller = abi(BasicStorage, CONTRACT_ID);
+    let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    let value = 4242;
+
+    caller.store_u64(key, value);
+    let _ = caller.get_u64(key);
+
+    let key = 0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    caller.intrinsic_store_word(key, value);
+    let _ = caller.intrinsic_load_word(key);
+
+    let key = 0x11ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    let q = Quad {
+        v1: 1,
+        v2: 2,
+        v3: 4,
+        v4: 100,
+    };
+    let mut values = Vec::new();
+    values.push(q);
+    caller.intrinsic_store_quad(key, values);
+    let _ = caller.intrinsic_load_quad(key, 1).get(0);
+
+    let key = 0x11ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    let q0 = Quad {
+        v1: 1,
+        v2: 2,
+        v3: 4,
+        v4: 100,
+    };
+    let q1 = Quad {
+        v1: 2,
+        v2: 3,
+        v3: 5,
+        v4: 101,
+    };
+    let mut values = Vec::new();
+    values.push(q0);
+    values.push(q1);
+    caller.intrinsic_store_quad(key, values);
+    let r = caller.intrinsic_load_quad(key, values.len());
+    let r0 = r.get(0);
+    let r1 = r.get(1);
+
+    caller.test_storage_exhaustive();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/test.toml
@@ -1,4 +1,4 @@
-category = "compile"
+category = "unit_tests_pass"
 validate_abi = true
 validate_storage_slots = true
 expected_warnings = 2 # TODO-DCA: Set to zero once https://github.com/FuelLabs/sway/issues/5921 is fixed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/src/main.sw
@@ -39,3 +39,10 @@ impl Incrementor for Contract {
 fn fallback() -> u64 {
     444444444
 }
+
+#[test]
+fn collect_incrementor_contract_gas_usages() {
+    let caller = abi(Incrementor, CONTRACT_ID);
+    let _ = caller.get();
+    let _ = caller.increment(0);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/test.toml
@@ -1,3 +1,3 @@
-category = "compile"
+category = "unit_tests_pass"
 validate_abi = true
 validate_storage_slots = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/main.sw
@@ -17,3 +17,9 @@ impl MyContract for Contract {
         storage.a.get(1).try_read()
     }
 }
+
+#[test]
+fn collect_my_contract_gas_usages() {
+    let caller = abi(MyContract, CONTRACT_ID);
+    let _ = caller.test_function();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/test.toml
@@ -1,2 +1,2 @@
-category = "compile"
+category = "unit_tests_pass"
 validate_abi = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/src/main.sw
@@ -165,3 +165,71 @@ impl StorageAccess for Contract {
         storage.string.read()
     }
 }
+
+#[test]
+fn collect_storage_access_contract_gas_usages() {
+    let caller = abi(StorageAccess, CONTRACT_ID);
+    let _ = caller.set_x(0);
+    let _ = caller.set_y(b256::zero());
+    let _ = caller.set_s(S {
+        x: 1,
+        y: 2,
+        z: 0x0000000000000000000000000000000000000000000000000000000000000003,
+        t: T {
+            x: 4,
+            y: 5,
+            z: 0x0000000000000000000000000000000000000000000000000000000000000006,
+            boolean: true,
+            int8: 7,
+            int16: 8,
+            int32: 9,
+        },
+    });
+    let _ = caller.set_boolean(false);
+    let _ = caller.set_int8(0);
+    let _ = caller.set_int16(0);
+    let _ = caller.set_int32(0);
+    let _ = caller.set_s_dot_x(0);
+    let _ = caller.set_s_dot_y(0);
+    let _ = caller.set_s_dot_z(b256::zero());
+    let _ = caller.set_s_dot_t(T {
+        x: 1,
+        y: 2,
+        z: 0x0000000000000000000000000000000000000000000000000000000000000003,
+        boolean: true,
+        int8: 4,
+        int16: 5,
+        int32: 6,
+    },);
+    let _ = caller.set_s_dot_t_dot_x(0);
+    let _ = caller.set_s_dot_t_dot_y(0);
+    let _ = caller.set_s_dot_t_dot_z(b256::zero());
+    let _ = caller.set_s_dot_t_dot_boolean(false);
+    let _ = caller.set_s_dot_t_dot_int8(0);
+    let _ = caller.set_s_dot_t_dot_int16(0);
+    let _ = caller.set_s_dot_t_dot_int32(0);
+    let _ = caller.set_e(E::A(0));
+    let _ = caller.set_string(__to_str_array("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"));
+
+    let _ = caller.get_x();
+    let _ = caller.get_y();
+    let _ = caller.get_s();
+    let _ = caller.get_boolean();
+    let _ = caller.get_int8();
+    let _ = caller.get_int16();
+    let _ = caller.get_int32();
+    let _ = caller.get_s_dot_x();
+    let _ = caller.get_s_dot_y();
+    let _ = caller.get_s_dot_z();
+    let _ = caller.get_s_dot_t();
+    let _ = caller.get_s_dot_t_dot_x();
+    let _ = caller.get_s_dot_t_dot_y();
+    let _ = caller.get_s_dot_t_dot_z();
+    let _ = caller.get_s_dot_t_dot_boolean();
+    let _ = caller.get_s_dot_t_dot_int8();
+    let _ = caller.get_s_dot_t_dot_int16();
+    let _ = caller.get_s_dot_t_dot_int32();
+    let _ = caller.get_e();
+    let _ = caller.get_e2();
+    let _ = caller.get_string();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/test.toml
@@ -1,4 +1,4 @@
-category = "compile"
+category = "unit_tests_pass"
 validate_abi = true
 validate_storage_slots = true
 expected_warnings = 6

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_enum_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_enum_contract/src/main.sw
@@ -253,3 +253,9 @@ fn check_lt_slot(expected_u8: u8, expected_tuple: (u64, u64, u64, u64, u64)) -> 
         }
     }
 }
+
+#[test]
+fn collect_storage_enum_contract_gas_usages() {
+    let caller = abi(StorageEnum, CONTRACT_ID);
+    let _ = caller.read_write_enums();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_enum_contract/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_enum_contract/test.toml
@@ -1,4 +1,4 @@
-category = "compile"
+category = "unit_tests_pass"
 validate_abi = true
 validate_storage_slots = true
 expected_warnings = 6


### PR DESCRIPTION
## Description

As we continue to optimize storage access, it becomes important to have more performance data to measure improvements.

This PR adapts E2E `test_contract` tests that use storage, by adding unit tests that collect gas usage data.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.