### PR TITLE
Fix CI issue by relaxing typo checker for "aloc".

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,6 +9,9 @@ extend-ignore-identifiers-re = [
     "NOOP",
     "Nam",
     "typ",
+    "ALOC",
+    "Aloc",
+    "aloc",
 ]
 
 extend-ignore-re = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `.typos.toml` to ignore `ALOC`, `Aloc`, and `aloc` identifiers in the typo checker.
> 
> - **Config**:
>   - Update `extend-ignore-identifiers-re` in `.typos.toml` to include `ALOC`, `Aloc`, and `aloc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 575fdd9495b84f095dd5bce11adc1e0534b5b008. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->