### PR TITLE
ci: ensure forc-crypto moved to forc repo still gets installed for doc generation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Forc plugins
         run: |
           cargo install --locked --debug --path ./forc-plugins/forc-client
-          cargo install --locked --debug forc-crypto
+          cargo install --locked --debug --git https://github.com/FuelLabs/forc forc-crypto
           cargo install --locked --debug --path ./forc-plugins/forc-debug
           cargo install --locked --debug --path ./forc-plugins/forc-fmt
           cargo install --locked --debug --path ./forc-plugins/forc-doc


### PR DESCRIPTION
## Description

We moved these plugins to a new repo but they are still needed for doc generation. This is one way we can keep the docs here during the transition period