### PR TITLE
Speed up execution of `cargo-run-e2e-test-release` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,7 @@ jobs:
         run: |
           fuel-core run --db-type in-memory --debug &
           sleep 5 &&
-          cargo run --locked --release --bin test -- --locked --release --verify-ir all
+          cargo run --locked --release --bin test -- --locked --release --verify-ir all --kind e2e
 
   # TODO: Remove this upon merging std tests with the rest of the E2E tests.
   cargo-test-lib-std:


### PR DESCRIPTION
## Description

This PR shortens the execution time of the `cargo-run-e2e-test-release` step by removing redundant runs of `ir_generation` and `snapshot` tests, that are already tested in the `cargo-run-e2e-test` step.

Only the `e2e` tests (`--kind e2e`) actually use the `--release` flag. `ir_generation` tests in general test just specific optimization passes and the `snapshot` test explicitely choose in their `snapshot.toml` how to run the tools. There are, e.g., snapshot tests that run `forc` in both `debug` and `release` build.

By using `--kind e2e` flag for release test we ensure that the same `ir_generation` and `snapshot` tests execution is not done in both CI steps but just in the `cargo-run-e2e-test`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.