### PR TITLE
feat: add pkg names to the output of predicate roots while building

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -551,7 +551,7 @@ impl BuiltPackage {
                 let root_file_name = format!("{}{}", &pkg_name, SWAY_BIN_ROOT_SUFFIX);
                 let root_path = output_dir.join(root_file_name);
                 fs::write(root_path, &root)?;
-                info!("      Predicate root: {}", root);
+                info!("      Predicate root [{}]: {}", pkg_name, root);
             }
             TreeType::Script => {
                 // hash the bytecode for scripts and store the result in a file in the output directory


### PR DESCRIPTION
## Description

Adding the pkg names to the predicate root output lines:

```console
  Compiling contract abi_impl_methods_callable (/Users/kayagokalp/fuel/dev/sway/test/src/sdk-harness/test_projects/abi_impl_methods_callable)
    Finished release [optimized + fuel] target(s) [414.936 KB] in 58.52s
      Predicate root [tx_witness_predicate]: 0xb051a6b1746fec3b85f59b8a92f2cce8d9374a2b3c597d6365fccacc2d4c0144
      Predicate root [tx_type_predicate]: 0x7250140ea9feebf94efb7b4a10c32c93d6dab0eb885af419e0654f481dcbdc5e
      Predicate root [tx_output_predicate]: 0x8cc7d1698eea5ed603d95fa2a862dee9755cff19a90192284ec8a38d86cc1fdf
      Predicate root [tx_output_count_predicate]: 0xb0f9e8d58b8dbb4866e6ba70041839bfd0a6ba80856bdc19052ded9c81884cc4
      Predicate root [tx_output_contract_creation_predicate]: 0x09581776efcb424ec845b0cf51f67fc5c209660f7c9f13a1afac0719dba6f6be
      Predicate root [tx_input_count_predicate]: 0xff1ad2668d4cebc96351475ba820e15606886542f2c7f844031c4522c277eaba
      Predicate root [tx_fields]: 0x16832c508c72264b102879fe6b4825ba6ad5b5c5be2b09cc24e939c0a97de6cd
      Predicate root [string_slice_predicate]: 0x638bc7a660dbf3ae28e75783241b6c3b4ab095d5e9ef22130c8ec11ce2a02bae
      Predicate root [predicate_panic_expression]: 0x8ef52c650da1be2f5d488171d4dbd1bcbc982997e10942168cf943cd2d5ce2ec
      Predicate root [predicate_data_struct]: 0x037c0020a66b1af06e7077c850b8a78a55acfbe25597ae911c38aafebf81c244
      Predicate root [predicate_data_simple]: 0xfa491602de830295e06b11eded5dbd715451c576891acb6d39a9b57bd68aed47
      Predicate root [ec_recover_and_match_predicate]: 0x9cd9776d0a8212e6aca07e8ee344a7c9e233684757e2e8776de09e5339f35639
      Predicate root [auth_predicate]: 0xe549825429a82fde8b7906f216485a8a7641f9dab25252dabed67eb4e6262b29
```

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
