### PR TITLE
Hash attributes to avoid undesired `dedup` matches

### DIFF
--- a/sway-ir/src/optimize/fn_dedup.rs
+++ b/sway-ir/src/optimize/fn_dedup.rs
@@ -140,7 +140,16 @@ fn hash_fn(
         m_hash.hash(hasher);
     }
 
-    // Start with the function return type.
+    // Hash attributes...
+    function.is_entry(context).hash(state);
+    function.is_original_entry(context).hash(state);
+    function.is_fallback(context).hash(state);
+
+    for i in 0..function.num_args(context) {
+        function.is_arg_immutable(context, i).hash(state);
+    }
+
+    // ... and return type.
     function.get_return_type(context).hash(state);
 
     // ... and local variables.
@@ -150,6 +159,7 @@ fn hash_fn(
             init.hash(state);
         }
         local_var.get_type(context).hash(state);
+        local_var.is_mutable(context).hash(state);
     }
 
     // Process every block, first its arguments and then the instructions.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/panic_expression/panic_handling_in_unit_tests/stdout.snap
@@ -18,7 +18,7 @@ warning: Error message is empty
 ____
 
   Compiled script "panic_handling_in_unit_tests" with 1 warning.
-    Finished debug [unoptimized + fuel] target(s) [8.28 KB] in ???
+    Finished debug [unoptimized + fuel] target(s) [8.32 KB] in ???
      Running 2 tests, filtered 18 tests
 
 tested -- panic_handling_in_unit_tests
@@ -31,7 +31,7 @@ tested -- panic_handling_in_unit_tests
 AsciiString { data: "This is a log from the passing test." }, log rb: 10098701174489624218
 42, log rb: 1515152261580153489
            raw logs:
-[{"LogData":{"data":"0000000000000024546869732069732061206c6f672066726f6d207468652070617373696e6720746573742e","digest":"29d742ad9093cdf81404ff756467a44448729b85ab3c0d65197829fb61d2dd29","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":44,"pc":10828,"ptr":67107840,"ra":0,"rb":10098701174489624218}},{"LogData":{"data":"000000000000002a","digest":"a6bb133cb1e3638ad7b8a3ff0539668e9e56f9b850ef1b2a810f5422eaa6c323","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":15716,"ptr":19416,"ra":0,"rb":1515152261580153489}}]
+[{"LogData":{"data":"0000000000000024546869732069732061206c6f672066726f6d207468652070617373696e6720746573742e","digest":"29d742ad9093cdf81404ff756467a44448729b85ab3c0d65197829fb61d2dd29","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":44,"pc":10832,"ptr":67107840,"ra":0,"rb":10098701174489624218}},{"LogData":{"data":"000000000000002a","digest":"a6bb133cb1e3638ad7b8a3ff0539668e9e56f9b850ef1b2a810f5422eaa6c323","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":15752,"ptr":19456,"ra":0,"rb":1515152261580153489}}]
       test passing_no_dbgs_or_logs ... ok (???, 74 gas)
 
 test result: OK. 2 passed; 0 failed; finished in ???
@@ -55,7 +55,7 @@ warning: Error message is empty
 ____
 
   Compiled script "panic_handling_in_unit_tests" with 1 warning.
-    Finished debug [unoptimized + fuel] target(s) [8.28 KB] in ???
+    Finished debug [unoptimized + fuel] target(s) [8.32 KB] in ???
      Running 20 tests, filtered 0 tests
 
 tested -- panic_handling_in_unit_tests
@@ -102,7 +102,7 @@ AsciiString { data: "This is a log from the reverting test." }, log rb: 10098701
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 46,
-      "pc": 11288,
+      "pc": 11292,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -136,7 +136,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 64,
-      "pc": 12472,
+      "pc": 12476,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -149,8 +149,8 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 15716,
-      "ptr": 19368,
+      "pc": 15752,
+      "ptr": 19408,
       "ra": 0,
       "rb": 1515152261580153489
     }
@@ -162,8 +162,8 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 15716,
-      "ptr": 19368,
+      "pc": 15752,
+      "ptr": 19408,
       "ra": 0,
       "rb": 1515152261580153489
     }
@@ -189,7 +189,7 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 64,
-      "pc": 12844,
+      "pc": 12848,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -202,8 +202,8 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 15716,
-      "ptr": 19360,
+      "pc": 15752,
+      "ptr": 19400,
       "ra": 0,
       "rb": 1515152261580153489
     }
@@ -215,8 +215,8 @@ AsciiString { data: "We will get logged the asserted values and this message." }
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 15716,
-      "ptr": 19360,
+      "pc": 15752,
+      "ptr": 19400,
       "ra": 0,
       "rb": 1515152261580153489
     }
@@ -238,7 +238,7 @@ AsciiString { data: "This is an error message in a `require` call." }, log rb: 1
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 53,
-      "pc": 13056,
+      "pc": 13060,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -261,7 +261,7 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 9,
-      "pc": 13192,
+      "pc": 13196,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016
@@ -286,8 +286,8 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 0,
-      "pc": 13260,
-      "ptr": 18904,
+      "pc": 13264,
+      "ptr": 18944,
       "ra": 0,
       "rb": 3330666440490685604
     }
@@ -311,8 +311,8 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 0,
-      "pc": 13312,
-      "ptr": 18904,
+      "pc": 13316,
+      "ptr": 18944,
       "ra": 0,
       "rb": 3330666440490685604
     }
@@ -359,7 +359,7 @@ AsciiString { data: "Panicked with a non-const evaluated string argument." }, lo
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 60,
-      "pc": 13444,
+      "pc": 13448,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -386,7 +386,7 @@ AsciiString { data: "" }, log rb: 10098701174489624218
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 8,
-      "pc": 13548,
+      "pc": 13552,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -413,7 +413,7 @@ AsciiString { data: "    " }, log rb: 10098701174489624218
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 12,
-      "pc": 13660,
+      "pc": 13664,
       "ptr": 67107840,
       "ra": 0,
       "rb": 10098701174489624218
@@ -439,7 +439,7 @@ B(true), log rb: 8516346929033386016
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 9,
-      "pc": 13744,
+      "pc": 13748,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016
@@ -465,7 +465,7 @@ C(AsciiString { data: "This is an error with an empty error message." }), log rb
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 61,
-      "pc": 13848,
+      "pc": 13852,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016
@@ -491,7 +491,7 @@ D(AsciiString { data: "This is an error with a whitespace error message." }), lo
       "id": "0000000000000000000000000000000000000000000000000000000000000000",
       "is": 10368,
       "len": 65,
-      "pc": 13952,
+      "pc": 13956,
       "ptr": 67107840,
       "ra": 0,
       "rb": 8516346929033386016


### PR DESCRIPTION
## Description

The current version of `dedup` does not hash attributes. This allow undesired matches like the one for the test `trait_constraint_param_order` below.

We do not inline `main` inside `__entry`, but in this test `main` is so simple that it is being matched by another function. Later, this new function ends up being inlined.

<img width="556" height="368" alt="image" src="https://github.com/user-attachments/assets/39e046dd-a27a-436b-85a4-0fba42c69e9d" />

In this case the final IR does not have a original entry. But if the match was reversed, we could end up multiple methods calling the `main` function generating a cycle, which can complicate CFG analysis and others...

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
