### PR TITLE
Improve execution time and coverage of SDK harness and in-language tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Read and compare versions
         env:
-          PACKAGE_NAMES: "fuel-core-client" # multiple packages can be specified delimeted with `,`.
+          PACKAGE_NAMES: "fuel-core-client" # multiple packages can be specified delimited with `,`.
         run: |
           .github/workflows/scripts/check-sdk-harness-version.sh
 
@@ -449,27 +449,27 @@ jobs:
         with:
           cache-provider: "warpbuild"
       - name: Build All Test Projects (Debug)
-        run: cargo run --locked --release -p forc -- build --locked --path ./test/src/sdk-harness --output-directory ./test/src/sdk-harness/out_for_sdk_harness_tests
+        run: cargo run --locked --release -p forc -- build --locked --path ./test/src/sdk-harness --output-directory ./test/src/sdk-harness/out
       - name: Run All SDK Tests (Debug)
-        run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
+        run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --skip can_get_predicate_address --nocapture
       - name: Build All Test Projects (Release)
-        run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness --output-directory ./test/src/sdk-harness/out_for_sdk_harness_tests
+        run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness --output-directory ./test/src/sdk-harness/out
       - name: Run All SDK Tests (Release)
         run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
       - name: Build All Test Projects - ['new_hashing' disabled] (Debug)
-        run: cargo run --locked --release -p forc -- build --locked --path ./test/src/sdk-harness --no-experimental new_hashing --output-directory ./test/src/sdk-harness/out_for_sdk_harness_tests
+        run: cargo run --locked --release -p forc -- build --locked --path ./test/src/sdk-harness --no-experimental new_hashing --output-directory ./test/src/sdk-harness/out
       - name: Run All SDK Tests - ['new_hashing' disabled] (Debug)
-        run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
+        run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --skip can_get_predicate_address --nocapture
       - name: Build All Test Projects - ['new_hashing' disabled] (Release)
-        run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness --no-experimental new_hashing --output-directory ./test/src/sdk-harness/out_for_sdk_harness_tests
+        run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness --no-experimental new_hashing --output-directory ./test/src/sdk-harness/out
       - name: Run All SDK Tests - ['new_hashing' disabled] (Release)
         run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
       - name: Build All Test Projects - ['str_array_no_padding' enabled] (Debug)
-        run: cargo run --locked --release -p forc -- build --locked --path ./test/src/sdk-harness --experimental str_array_no_padding --output-directory ./test/src/sdk-harness/out_for_sdk_harness_tests
+        run: cargo run --locked --release -p forc -- build --locked --path ./test/src/sdk-harness --experimental str_array_no_padding --output-directory ./test/src/sdk-harness/out
       - name: Run All SDK Tests - ['str_array_no_padding' enabled] (Debug)
-        run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
+        run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --skip can_get_predicate_address --nocapture
       - name: Build All Test Projects - ['str_array_no_padding' enabled] (Release)
-        run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness --experimental str_array_no_padding --output-directory ./test/src/sdk-harness/out_for_sdk_harness_tests
+        run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness --experimental str_array_no_padding --output-directory ./test/src/sdk-harness/out
       - name: Run All SDK Tests - ['str_array_no_padding' enabled] (Release)
         run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
 

--- a/test/src/sdk-harness/.gitignore
+++ b/test/src/sdk-harness/.gitignore
@@ -1,1 +1,0 @@
-out_for_sdk_harness_tests

--- a/test/src/sdk-harness/test_projects/abi_impl_methods_callable/mod.rs
+++ b/test/src/sdk-harness/test_projects/abi_impl_methods_callable/mod.rs
@@ -2,13 +2,13 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "AbiImplMethodsCallable",
-    abi = "out_for_sdk_harness_tests/abi_impl_methods_callable-abi.json"
+    abi = "out/abi_impl_methods_callable-abi.json"
 ));
 
 async fn get_abi_impl_methods_callable_instance() -> AbiImplMethodsCallable<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/abi_impl_methods_callable.bin",
+        "out/abi_impl_methods_callable.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/asset_id/mod.rs
+++ b/test/src/sdk-harness/test_projects/asset_id/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestAssetId",
-    abi = "out_for_sdk_harness_tests/asset_id-abi.json"
+    abi = "out/asset_id-abi.json"
 ));
 
 #[tokio::test]
@@ -25,7 +25,7 @@ async fn can_get_base_asset_id() {
 
 async fn get_instance(wallet: Wallet) -> (TestAssetId<Wallet>, ContractId) {
     let fuelcontract_id = Contract::load_from(
-        "out_for_sdk_harness_tests/asset_id.bin",
+        "out/asset_id.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/asset_ops/mod.rs
+++ b/test/src/sdk-harness/test_projects/asset_ops/mod.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 abigen!(Contract(
     name = "TestFuelCoinContract",
-    abi = "out_for_sdk_harness_tests/asset_ops-abi.json"
+    abi = "out/asset_ops-abi.json"
 ));
 
 #[tokio::test]
@@ -502,7 +502,7 @@ async fn can_send_message_output_without_data() {
 
 async fn get_fuelcoin_instance(wallet: Wallet) -> (TestFuelCoinContract<Wallet>, ContractId) {
     let fuelcontract_id = Contract::load_from(
-        "out_for_sdk_harness_tests/asset_ops.bin",
+        "out/asset_ops.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -522,7 +522,7 @@ async fn get_fuelcoin_instance(wallet: Wallet) -> (TestFuelCoinContract<Wallet>,
 
 async fn get_balance_contract_id(wallet: Wallet) -> ContractId {
     let balance_id = Contract::load_from(
-        "out_for_sdk_harness_tests/balance_contract.bin",
+        "out/balance_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -15,15 +15,15 @@ use std::str::FromStr;
 abigen!(
     Contract(
         name = "AuthContract",
-        abi = "out_for_sdk_harness_tests/auth_testing_contract-abi.json"
+        abi = "out/auth_testing_contract-abi.json"
     ),
     Contract(
         name = "AuthCallerContract",
-        abi = "out_for_sdk_harness_tests/auth_caller_contract-abi.json"
+        abi = "out/auth_caller_contract-abi.json"
     ),
     Predicate(
         name = "AuthPredicate",
-        abi = "out_for_sdk_harness_tests/auth_predicate-abi.json"
+        abi = "out/auth_predicate-abi.json"
     ),
 );
 
@@ -95,7 +95,7 @@ async fn input_message_msg_sender_from_contract() {
 
     // Setup contract
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/auth_testing_contract.bin",
+        "out/auth_testing_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -198,7 +198,7 @@ async fn caller_addresses_from_messages() {
     let wallet4 = Wallet::new(signer_4, provider.clone());
 
     let id_1 = Contract::load_from(
-        "out_for_sdk_harness_tests/auth_testing_contract.bin",
+        "out/auth_testing_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -325,7 +325,7 @@ async fn caller_addresses_from_coins() {
     let wallet4 = Wallet::new(signer_4, provider.clone());
 
     let id_1 = Contract::load_from(
-        "out_for_sdk_harness_tests/auth_testing_contract.bin",
+        "out/auth_testing_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -454,7 +454,7 @@ async fn caller_addresses_from_coins_and_messages() {
     let wallet4 = Wallet::new(signer_4, provider.clone());
 
     let id_1 = Contract::load_from(
-        "out_for_sdk_harness_tests/auth_testing_contract.bin",
+        "out/auth_testing_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -538,7 +538,7 @@ async fn get_contracts() -> (
     let wallet = launch_provider_and_get_wallet().await.unwrap();
 
     let id_1 = Contract::load_from(
-        "out_for_sdk_harness_tests/auth_testing_contract.bin",
+        "out/auth_testing_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -548,7 +548,7 @@ async fn get_contracts() -> (
     .contract_id;
 
     let id_2 = Contract::load_from(
-        "out_for_sdk_harness_tests/auth_caller_contract.bin",
+        "out/auth_caller_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -592,7 +592,7 @@ async fn can_get_predicate_address() {
         .encode_data(predicate_address)
         .unwrap();
     let predicate: Predicate =
-        Predicate::load_from("out_for_sdk_harness_tests/auth_predicate.bin")
+        Predicate::load_from("out/auth_predicate.bin")
             .unwrap()
             .with_provider(first_wallet.try_provider().unwrap().clone())
             .with_data(predicate_data);
@@ -672,7 +672,7 @@ async fn when_incorrect_predicate_address_passed() {
         .encode_data(predicate_address)
         .unwrap();
     let predicate: Predicate =
-        Predicate::load_from("out_for_sdk_harness_tests/auth_predicate.bin")
+        Predicate::load_from("out/auth_predicate.bin")
             .unwrap()
             .with_provider(first_wallet.try_provider().unwrap().clone())
             .with_data(predicate_data);
@@ -751,7 +751,7 @@ async fn can_get_predicate_address_in_message() {
         .encode_data(predicate_address)
         .unwrap();
     let predicate: Predicate =
-        Predicate::load_from("out_for_sdk_harness_tests/auth_predicate.bin")
+        Predicate::load_from("out/auth_predicate.bin")
             .unwrap()
             .with_provider(wallet.try_provider().unwrap().clone())
             .with_data(predicate_data);

--- a/test/src/sdk-harness/test_projects/block/mod.rs
+++ b/test/src/sdk-harness/test_projects/block/mod.rs
@@ -4,14 +4,14 @@ use tokio::time::{sleep, Duration};
 
 abigen!(Contract(
     name = "BlockTestContract",
-    abi = "out_for_sdk_harness_tests/block-abi.json"
+    abi = "out/block-abi.json"
 ));
 
 async fn get_block_instance() -> (BlockTestContract<Wallet>, ContractId, Provider) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let provider = wallet.provider();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/block.bin",
+        "out/block.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/call_frames/mod.rs
+++ b/test/src/sdk-harness/test_projects/call_frames/mod.rs
@@ -2,13 +2,13 @@ use fuels::{prelude::*, types::ContractId};
 
 abigen!(Contract(
     name = "CallFramesTestContract",
-    abi = "out_for_sdk_harness_tests/call_frames-abi.json"
+    abi = "out/call_frames-abi.json"
 ));
 
 async fn get_call_frames_instance() -> (CallFramesTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/call_frames.bin",
+        "out/call_frames.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/mod.rs
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/mod.rs
@@ -8,13 +8,13 @@ async fn contract_uses_default_configurables() -> Result<()> {
     abigen!(Contract(
         name = "MyContract",
         abi =
-            "out_for_sdk_harness_tests/configurables_in_contract-abi.json"
+            "out/configurables_in_contract-abi.json"
     ));
 
     let wallet = launch_provider_and_get_wallet().await.unwrap();
 
     let contract_id = Contract::load_from(
-        "out_for_sdk_harness_tests/configurables_in_contract.bin",
+        "out/configurables_in_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -57,7 +57,7 @@ async fn contract_configurables() -> Result<()> {
     abigen!(Contract(
         name = "MyContract",
         abi =
-            "out_for_sdk_harness_tests/configurables_in_contract-abi.json"
+            "out/configurables_in_contract-abi.json"
     ));
 
     let wallet = launch_provider_and_get_wallet().await.unwrap();
@@ -79,7 +79,7 @@ async fn contract_configurables() -> Result<()> {
         .with_MY_CONTRACT_ID(new_contract_id.clone())?;
 
     let contract_id = Contract::load_from(
-        "out_for_sdk_harness_tests/configurables_in_contract.bin",
+        "out/configurables_in_contract.bin",
         LoadConfiguration::default().with_configurables(configurables),
     )?
     .deploy(&wallet, TxPolicies::default())

--- a/test/src/sdk-harness/test_projects/configurables_in_script/mod.rs
+++ b/test/src/sdk-harness/test_projects/configurables_in_script/mod.rs
@@ -7,11 +7,11 @@ use fuels::{prelude::*, types::SizedAsciiString};
 async fn script_uses_default_configurables() -> Result<()> {
     abigen!(Script(
         name = "MyScript",
-        abi = "out_for_sdk_harness_tests/configurables_in_script-abi.json"
+        abi = "out/configurables_in_script-abi.json"
     ));
 
     let wallet = launch_provider_and_get_wallet().await.unwrap();
-    let bin_path = "out_for_sdk_harness_tests/configurables_in_script.bin";
+    let bin_path = "out/configurables_in_script.bin";
     let instance = MyScript::new(wallet, bin_path);
 
     let response = instance.main().call().await?;
@@ -40,11 +40,11 @@ async fn script_uses_default_configurables() -> Result<()> {
 async fn script_configurables() -> Result<()> {
     abigen!(Script(
         name = "MyScript",
-        abi = "out_for_sdk_harness_tests/configurables_in_script-abi.json"
+        abi = "out/configurables_in_script-abi.json"
     ));
 
     let wallet = launch_provider_and_get_wallet().await.unwrap();
-    let bin_path = "out_for_sdk_harness_tests/configurables_in_script.bin";
+    let bin_path = "out/configurables_in_script.bin";
     let instance = MyScript::new(wallet, bin_path);
 
     let new_str: SizedAsciiString<4> = "FUEL".try_into()?;

--- a/test/src/sdk-harness/test_projects/context/mod.rs
+++ b/test/src/sdk-harness/test_projects/context/mod.rs
@@ -8,15 +8,15 @@ use fuels::{
 abigen!(
     Contract(
         name = "TestContextContract",
-        abi = "out_for_sdk_harness_tests/context-abi.json",
+        abi = "out/context-abi.json",
     ),
     Contract(
         name = "TestContextCallerContract",
-        abi = "out_for_sdk_harness_tests/context_caller_contract-abi.json",
+        abi = "out/context_caller_contract-abi.json",
     ),
     Contract(
         name = "FuelCoin",
-        abi = "out_for_sdk_harness_tests/asset_ops-abi.json"
+        abi = "out/asset_ops-abi.json"
     )
 );
 
@@ -28,7 +28,7 @@ async fn get_contracts() -> (
 ) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id_1 = Contract::load_from(
-        "out_for_sdk_harness_tests/context.bin",
+        "out/context.bin",
         LoadConfiguration::default(),
     )
     .unwrap()
@@ -37,7 +37,7 @@ async fn get_contracts() -> (
     .unwrap()
     .contract_id;
     let id_2 = Contract::load_from(
-        "out_for_sdk_harness_tests/context_caller_contract.bin",
+        "out/context_caller_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/contract_bytecode/mod.rs
+++ b/test/src/sdk-harness/test_projects/contract_bytecode/mod.rs
@@ -3,7 +3,7 @@ use fuels::{prelude::*, types::Bits256};
 
 abigen!(Contract(
     name = "ContractBytecodeTest",
-    abi = "out_for_sdk_harness_tests/contract_bytecode-abi.json"
+    abi = "out/contract_bytecode-abi.json"
 ));
 
 #[tokio::test]
@@ -22,7 +22,7 @@ async fn can_get_bytecode_root() {
         .value;
 
     let contract_bytecode =
-        std::fs::read("out_for_sdk_harness_tests/contract_bytecode.bin").unwrap();
+        std::fs::read("out/contract_bytecode.bin").unwrap();
     let expected_bytecode_root = Bits256(*FuelsTxContract::root_from_code(contract_bytecode));
 
     assert_eq!(expected_bytecode_root, bytecode_root);
@@ -32,7 +32,7 @@ async fn get_test_contract_instance(
     wallet: Wallet,
 ) -> (ContractBytecodeTest<Wallet>, ContractId) {
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/contract_bytecode.bin",
+        "out/contract_bytecode.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/ec_recover/mod.rs
+++ b/test/src/sdk-harness/test_projects/ec_recover/mod.rs
@@ -8,7 +8,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 
 abigen!(Contract(
     name = "EcRecoverContract",
-    abi = "out_for_sdk_harness_tests/ec_recover-abi.json"
+    abi = "out/ec_recover-abi.json"
 ));
 
 async fn setup_env() -> Result<(
@@ -43,7 +43,7 @@ async fn setup_env() -> Result<(
     let wallet = Wallet::new(signer, provider);
 
     let contract_id = Contract::load_from(
-        "out_for_sdk_harness_tests/ec_recover.bin",
+        "out/ec_recover.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/ec_recover_and_match_predicate/mod.rs
+++ b/test/src/sdk-harness/test_projects/ec_recover_and_match_predicate/mod.rs
@@ -8,7 +8,7 @@ use fuels::{
 abigen!(
     Predicate(
         name = "TestPredicate",
-        abi = "out_for_sdk_harness_tests/ec_recover_and_match_predicate-abi.json"
+        abi = "out/ec_recover_and_match_predicate-abi.json"
     )
 );
 
@@ -76,7 +76,7 @@ async fn ec_recover_and_match_predicate_test() -> Result<()> {
 
     let predicate_data = TestPredicateEncoder::default().encode_data(signatures)?;
     let code_path =
-        "out_for_sdk_harness_tests/ec_recover_and_match_predicate.bin";
+        "out/ec_recover_and_match_predicate.bin";
 
     let predicate = Predicate::load_from(code_path)?
         .with_data(predicate_data)

--- a/test/src/sdk-harness/test_projects/events/mod.rs
+++ b/test/src/sdk-harness/test_projects/events/mod.rs
@@ -6,11 +6,11 @@ use fuels::prelude::*;
 async fn emits_indexed_events() -> Result<()> {
     abigen!(Script(
         name = "Events",
-        abi = "out_for_sdk_harness_tests/events-abi.json",
+        abi = "out/events-abi.json",
     ));
 
     let wallet = launch_provider_and_get_wallet().await.unwrap();
-    let bin_path = "out_for_sdk_harness_tests/events.bin";
+    let bin_path = "out/events.bin";
     let instance = Events::new(wallet.clone(), bin_path);
 
     let response = instance.main().call().await?;

--- a/test/src/sdk-harness/test_projects/evm/mod.rs
+++ b/test/src/sdk-harness/test_projects/evm/mod.rs
@@ -5,13 +5,13 @@ use fuels::{
 
 abigen!(Contract(
     name = "EvmTestContract",
-    abi = "out_for_sdk_harness_tests/evm-abi.json"
+    abi = "out/evm-abi.json"
 ));
 
 async fn get_evm_test_instance() -> (EvmTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/evm.bin",
+        "out/evm.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/evm_ec_recover/mod.rs
+++ b/test/src/sdk-harness/test_projects/evm_ec_recover/mod.rs
@@ -12,7 +12,7 @@ use sha3::{Digest, Keccak256};
 
 abigen!(Contract(
     name = "EvmEcRecoverContract",
-    abi = "out_for_sdk_harness_tests/evm_ec_recover-abi.json"
+    abi = "out/evm_ec_recover-abi.json"
 ));
 
 fn keccak_hash<B>(data: B) -> Bytes32
@@ -67,7 +67,7 @@ async fn setup_env() -> Result<(
     let wallet = Wallet::new(signer, provider);
 
     let contract_id = Contract::load_from(
-        "out_for_sdk_harness_tests/evm_ec_recover.bin",
+        "out/evm_ec_recover.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/exponentiation/mod.rs
+++ b/test/src/sdk-harness/test_projects/exponentiation/mod.rs
@@ -3,7 +3,7 @@ use fuels::types::ContractId;
 
 abigen!(Contract(
     name = "TestPowContract",
-    abi = "out_for_sdk_harness_tests/pow-abi.json"
+    abi = "out/pow-abi.json"
 ));
 
 #[tokio::test]
@@ -108,7 +108,7 @@ async fn overflowing_pow_u8_panics_max() {
 
 async fn get_pow_test_instance(wallet: Wallet) -> (TestPowContract<Wallet>, ContractId) {
     let pow_id = Contract::load_from(
-        "out_for_sdk_harness_tests/pow.bin",
+        "out/pow.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/generics_in_abi/mod.rs
+++ b/test/src/sdk-harness/test_projects/generics_in_abi/mod.rs
@@ -2,13 +2,13 @@ use fuels::{prelude::*, types::Bits256};
 
 abigen!(Contract(
     name = "GenericsInAbiTestContract",
-    abi = "out_for_sdk_harness_tests/generics_in_abi-abi.json"
+    abi = "out/generics_in_abi-abi.json"
 ));
 
 async fn get_generics_in_abi_instance() -> (GenericsInAbiTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/generics_in_abi.bin",
+        "out/generics_in_abi.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/logging/mod.rs
+++ b/test/src/sdk-harness/test_projects/logging/mod.rs
@@ -4,11 +4,11 @@ use fuels::prelude::*;
 async fn run_valid() -> Result<()> {
     abigen!(Script(
         name = "Logging",
-        abi = "out_for_sdk_harness_tests/logging-abi.json",
+        abi = "out/logging-abi.json",
     ));
 
     let wallet = launch_provider_and_get_wallet().await.unwrap();
-    let bin_path = "out_for_sdk_harness_tests/logging.bin";
+    let bin_path = "out/logging.bin";
     let instance = Logging::new(wallet.clone(), bin_path);
 
     let response = instance.main().call().await?;

--- a/test/src/sdk-harness/test_projects/low_level_call/mod.rs
+++ b/test/src/sdk-harness/test_projects/low_level_call/mod.rs
@@ -23,11 +23,11 @@ abigen!(
     Contract(
         name = "TestContract",
         abi =
-            "out_for_sdk_harness_tests/low_level_callee_contract-abi.json"
+            "out/low_level_callee_contract-abi.json"
     ),
     Script(
         name = "TestScript",
-        abi = "out_for_sdk_harness_tests/low_level_call-abi.json"
+        abi = "out/low_level_call-abi.json"
     )
 );
 
@@ -41,7 +41,7 @@ async fn low_level_call(
     // Build the script instance
     let script_instance = TestScript::new(
         wallet,
-        "out_for_sdk_harness_tests/low_level_call.bin",
+        "out/low_level_call.bin",
     );
 
     // Add the contract being called to the inputs and outputs
@@ -90,7 +90,7 @@ async fn get_contract_instance() -> (TestContract<Wallet>, ContractId, Wallet) {
     let wallet = wallets.pop().unwrap();
 
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/low_level_callee_contract.bin",
+        "out/low_level_callee_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/messages/mod.rs
+++ b/test/src/sdk-harness/test_projects/messages/mod.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, types::Bits256};
 
 abigen!(Contract(
     name = "TestMessagesContract",
-    abi = "out_for_sdk_harness_tests/messages-abi.json"
+    abi = "out/messages-abi.json"
 ));
 
 async fn get_messages_contract_instance() -> (TestMessagesContract<Wallet>, ContractId, Wallet) {
@@ -20,7 +20,7 @@ async fn get_messages_contract_instance() -> (TestMessagesContract<Wallet>, Cont
         .await
         .unwrap();
     let messages_contract_id = Contract::load_from(
-        "out_for_sdk_harness_tests/messages.bin",
+        "out/messages.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/methods/mod.rs
+++ b/test/src/sdk-harness/test_projects/methods/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "MethodsContract",
-    abi = "out_for_sdk_harness_tests/methods_contract-abi.json",
+    abi = "out/methods_contract-abi.json",
 ));
 
 #[tokio::test]
@@ -27,7 +27,7 @@ async fn run_methods_test() {
 
 async fn get_methods_instance(wallet: Wallet) -> MethodsContract<Wallet> {
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/methods_contract.bin",
+        "out/methods_contract.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/option_field_order/mod.rs
+++ b/test/src/sdk-harness/test_projects/option_field_order/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "MyContract",
-    abi = "out_for_sdk_harness_tests/option_field_order-abi.json"
+    abi = "out/option_field_order-abi.json"
 ));
 
 #[tokio::test]
@@ -15,7 +15,7 @@ async fn setup() -> MyContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
 
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/option_field_order.bin",
+        "out/option_field_order.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/option_in_abi/mod.rs
+++ b/test/src/sdk-harness/test_projects/option_in_abi/mod.rs
@@ -3,13 +3,13 @@ use std::str::FromStr;
 
 abigen!(Contract(
     name = "OptionInAbiTestContract",
-    abi = "out_for_sdk_harness_tests/option_in_abi-abi.json"
+    abi = "out/option_in_abi-abi.json"
 ));
 
 async fn get_option_in_abi_instance() -> (OptionInAbiTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/option_in_abi.bin",
+        "out/option_in_abi.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/parsing_logs/mod.rs
+++ b/test/src/sdk-harness/test_projects/parsing_logs/mod.rs
@@ -5,13 +5,13 @@ use fuels::{
 
 abigen!(Contract(
     name = "ParsingLogsTestContract",
-    abi = "out_for_sdk_harness_tests/parsing_logs-abi.json"
+    abi = "out/parsing_logs-abi.json"
 ));
 
 async fn get_parsing_logs_instance() -> (ParsingLogsTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/parsing_logs.bin",
+        "out/parsing_logs.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/predicate_data_simple/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_data_simple/mod.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 async fn setup() -> (Vec<u8>, Address, Wallet, u64, AssetId) {
     let predicate_code =
-        std::fs::read("out_for_sdk_harness_tests/predicate_data_simple.bin")
+        std::fs::read("out/predicate_data_simple.bin")
             .unwrap();
     let predicate_address = fuel_tx::Input::predicate_owner(&predicate_code);
 

--- a/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 async fn setup() -> (Vec<u8>, Address, Wallet, u64, AssetId) {
     let predicate_code =
-        std::fs::read("out_for_sdk_harness_tests/predicate_data_struct.bin")
+        std::fs::read("out/predicate_data_struct.bin")
             .unwrap();
     let predicate_address = fuel_tx::Input::predicate_owner(&predicate_code);
 

--- a/test/src/sdk-harness/test_projects/predicate_panic_expression/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_panic_expression/mod.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 async fn setup() -> (Vec<u8>, Address, Wallet, u64, AssetId) {
     let predicate_code = std::fs::read(
-        "out_for_sdk_harness_tests/predicate_panic_expression.bin",
+        "out/predicate_panic_expression.bin",
     )
     .unwrap();
     let predicate_address = fuel_tx::Input::predicate_owner(&predicate_code);

--- a/test/src/sdk-harness/test_projects/private_struct_fields_in_storage_and_abi/mod.rs
+++ b/test/src/sdk-harness/test_projects/private_struct_fields_in_storage_and_abi/mod.rs
@@ -2,14 +2,14 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestPrivateStructFieldsInStorageAndAbi",
-    abi = "out_for_sdk_harness_tests/private_struct_fields_in_storage_and_abi-abi.json",
+    abi = "out/private_struct_fields_in_storage_and_abi-abi.json",
 ));
 
 async fn test_storage_private_struct_fields_instance(
 ) -> TestPrivateStructFieldsInStorageAndAbi<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/private_struct_fields_in_storage_and_abi.bin",
+        "out/private_struct_fields_in_storage_and_abi.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/registers/mod.rs
+++ b/test/src/sdk-harness/test_projects/registers/mod.rs
@@ -3,7 +3,7 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestRegistersContract",
-    abi = "out_for_sdk_harness_tests/registers-abi.json",
+    abi = "out/registers-abi.json",
 ));
 
 // Compile contract, create node and deploy contract, returning TestRegistersContract contract instance
@@ -13,7 +13,7 @@ abigen!(Contract(
 async fn deploy_test_registers_instance() -> TestRegistersContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/registers.bin",
+        "out/registers.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/result_in_abi/mod.rs
+++ b/test/src/sdk-harness/test_projects/result_in_abi/mod.rs
@@ -3,13 +3,13 @@ use std::str::FromStr;
 
 abigen!(Contract(
     name = "ResultInAbiTestContract",
-    abi = "out_for_sdk_harness_tests/result_in_abi-abi.json"
+    abi = "out/result_in_abi-abi.json"
 ));
 
 async fn get_result_in_abi_instance() -> (ResultInAbiTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/result_in_abi.bin",
+        "out/result_in_abi.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/result_option_expect/mod.rs
+++ b/test/src/sdk-harness/test_projects/result_option_expect/mod.rs
@@ -2,13 +2,13 @@ use fuels::{accounts::wallet::Wallet, prelude::*};
 
 abigen!(Contract(
     name = "ExpectTestingContract",
-    abi = "out_for_sdk_harness_tests/result_option_expect-abi.json"
+    abi = "out/result_option_expect-abi.json"
 ));
 
 async fn setup() -> (ExpectTestingContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/result_option_expect.bin",
+        "out/result_option_expect.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/run_external_proxy/mod.rs
+++ b/test/src/sdk-harness/test_projects/run_external_proxy/mod.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, types::Bits256};
 
 abigen!(Contract(
     name = "RunExternalProxyContract",
-    abi = "out_for_sdk_harness_tests/run_external_proxy-abi.json",
+    abi = "out/run_external_proxy-abi.json",
 ));
 
 #[tokio::test]
@@ -10,7 +10,7 @@ async fn run_external_can_proxy_call() {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
 
     let target_id = Contract::load_from(
-        "out_for_sdk_harness_tests/run_external_target.bin",
+        "out/run_external_target.bin",
         LoadConfiguration::default()
             .with_storage_configuration(StorageConfiguration::default().with_autoload(false)),
     )
@@ -24,7 +24,7 @@ async fn run_external_can_proxy_call() {
         .with_TARGET(target_id.clone().into())
         .unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/run_external_proxy.bin",
+        "out/run_external_proxy.bin",
         LoadConfiguration::default().with_configurables(configurables),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/run_external_proxy_with_storage/mod.rs
+++ b/test/src/sdk-harness/test_projects/run_external_proxy_with_storage/mod.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, types::Bits256};
 
 abigen!(Contract(
     name = "RunExternalProxyContract",
-    abi = "out_for_sdk_harness_tests/run_external_proxy_with_storage-abi.json",
+    abi = "out/run_external_proxy_with_storage-abi.json",
 ));
 
 #[tokio::test]
@@ -10,10 +10,10 @@ async fn run_external_can_proxy_call() {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
 
     let storage_configuration =
-        StorageConfiguration::default().add_slot_overrides_from_file("out_for_sdk_harness_tests/run_external_target_with_storage-storage_slots.json").unwrap();
+        StorageConfiguration::default().add_slot_overrides_from_file("out/run_external_target_with_storage-storage_slots.json").unwrap();
 
     let target_id = Contract::load_from(
-        "out_for_sdk_harness_tests/run_external_target_with_storage.bin",
+        "out/run_external_target_with_storage.bin",
         LoadConfiguration::default()
             .with_storage_configuration(storage_configuration.clone()),
     )
@@ -27,7 +27,7 @@ async fn run_external_can_proxy_call() {
         .with_TARGET(target_id.clone().into())
         .unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/run_external_proxy_with_storage.bin",
+        "out/run_external_proxy_with_storage.bin",
         LoadConfiguration::default().with_configurables(configurables).with_storage_configuration(storage_configuration),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/script_bytecode/mod.rs
+++ b/test/src/sdk-harness/test_projects/script_bytecode/mod.rs
@@ -34,7 +34,7 @@ pub async fn run_compiled_script(binary_filepath: &str) -> Result<Vec<Receipt>, 
 async fn check_script_bytecode_hash() {
     // Calculate padded script hash (since memory is read in whole words, the bytecode will be padded)
     let mut script_bytecode =
-        std::fs::read("out_for_sdk_harness_tests/script_bytecode.bin")
+        std::fs::read("out/script_bytecode.bin")
             .unwrap()
             .to_vec();
     let padding = script_bytecode.len() % 8;
@@ -42,7 +42,7 @@ async fn check_script_bytecode_hash() {
     let script_hash = Hasher::hash(&script_bytecode); // This is the hard that must be hard-coded in the predicate
 
     // Run script and get the hash it returns
-    let path_to_bin = "out_for_sdk_harness_tests/script_bytecode.bin";
+    let path_to_bin = "out/script_bytecode.bin";
     let return_val = run_compiled_script(path_to_bin).await.unwrap();
     let script_hash_from_vm =
         unsafe { Bytes32::from_slice_unchecked(return_val[0].data().unwrap()) };

--- a/test/src/sdk-harness/test_projects/script_data/mod.rs
+++ b/test/src/sdk-harness/test_projects/script_data/mod.rs
@@ -21,7 +21,7 @@ async fn call_script(script_data: Vec<u8>) -> Result<Vec<Receipt>> {
     let mut tx =
         ScriptTransactionBuilder::prepare_transfer(wallet_coins, vec![], Default::default())
             .with_script(std::fs::read(
-                "out_for_sdk_harness_tests/script_data.bin",
+                "out/script_data.bin",
             )?)
             .with_script_data(script_data)
             .enable_burn(true);

--- a/test/src/sdk-harness/test_projects/storage/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage/mod.rs
@@ -5,13 +5,13 @@ use fuels::{
 
 abigen!(Contract(
     name = "TestStorageContract",
-    abi = "out_for_sdk_harness_tests/storage-abi.json",
+    abi = "out/storage-abi.json",
 ));
 
 async fn get_test_storage_instance() -> TestStorageContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage.bin",
+        "out/storage.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_access/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_access/mod.rs
@@ -2,13 +2,13 @@ use fuels::{prelude::*, types::Bits256};
 
 abigen!(Contract(
     name = "TestStorageAccessContract",
-    abi = "out_for_sdk_harness_tests/storage_access-abi.json",
+    abi = "out/storage_access-abi.json",
 ));
 
 async fn test_storage_access_instance() -> TestStorageAccessContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_access.bin",
+        "out/storage_access.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_bytes/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_bytes/mod.rs
@@ -2,14 +2,14 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestStorageBytesContract",
-    abi = "out_for_sdk_harness_tests/storage_bytes-abi.json",
+    abi = "out/storage_bytes-abi.json",
 ));
 
 async fn setup() -> TestStorageBytesContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
 
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_bytes.bin",
+        "out/storage_bytes.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_init/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_init/mod.rs
@@ -2,17 +2,17 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestStorageInitContract",
-    abi = "out_for_sdk_harness_tests/storage_init-abi.json",
+    abi = "out/storage_init-abi.json",
 ));
 
 async fn test_storage_init_instance() -> TestStorageInitContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_init.bin",
+        "out/storage_init.bin",
         LoadConfiguration::default().with_storage_configuration(
             StorageConfiguration::default()
                 .add_slot_overrides_from_file(
-                    "out_for_sdk_harness_tests/storage_init-storage_slots.json",
+                    "out/storage_init-storage_slots.json",
                 )
                 .unwrap(),
         ),

--- a/test/src/sdk-harness/test_projects/storage_map/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_map/mod.rs
@@ -7,13 +7,13 @@ pub mod try_insert;
 
 abigen!(Contract(
     name = "TestStorageMapContract",
-    abi = "out_for_sdk_harness_tests/storage_map-abi.json",
+    abi = "out/storage_map-abi.json",
 ));
 
 async fn test_storage_map_instance() -> TestStorageMapContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_map.bin",
+        "out/storage_map.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_map_nested/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_map_nested/mod.rs
@@ -2,13 +2,13 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestStorageMapNestedContract",
-    abi = "out_for_sdk_harness_tests/storage_map_nested-abi.json",
+    abi = "out/storage_map_nested-abi.json",
 ));
 
 async fn test_storage_map_nested_instance() -> TestStorageMapNestedContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_map_nested.bin",
+        "out/storage_map_nested.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_namespace/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_namespace/mod.rs
@@ -5,13 +5,13 @@ use fuels::{
 
 abigen!(Contract(
     name = "TestStorageContract",
-    abi = "out_for_sdk_harness_tests/storage-namespace-abi.json",
+    abi = "out/storage-namespace-abi.json",
 ));
 
 async fn get_test_storage_instance() -> TestStorageContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_namespace.bin",
+        "out/storage_namespace.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_string/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_string/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestStorageStringContract",
-    abi = "out_for_sdk_harness_tests/storage_string-abi.json",
+    abi = "out/storage_string-abi.json",
 ));
 
 async fn setup() -> TestStorageStringContract<Wallet> {
@@ -17,7 +17,7 @@ async fn setup() -> TestStorageStringContract<Wallet> {
     .unwrap();
     let wallet = wallets.pop().unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_string.bin",
+        "out/storage_string.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_array.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_array.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_array_vec,
-    "out_for_sdk_harness_tests/svec_array-abi.json",
+    "out/svec_array-abi.json",
     "array",
     [u8; 3],
     [1; 3],

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_b256.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_b256.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_b256_vec,
-    "out_for_sdk_harness_tests/svec_b256-abi.json",
+    "out/svec_b256-abi.json",
     "b256",
     ::fuels::types::Bits256,
     ::fuels::types::Bits256([1; 32]),

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_bool.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_bool.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_bool_vec,
-    "out_for_sdk_harness_tests/svec_bool-abi.json",
+    "out/svec_bool-abi.json",
     "bool",
     bool,
     true,

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_enum.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_enum.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_enum_vec,
-    "out_for_sdk_harness_tests/svec_enum-abi.json",
+    "out/svec_enum-abi.json",
     "enum",
     TestEnum,
     TestEnum::A(true),

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_str.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_str.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_str_vec,
-    "out_for_sdk_harness_tests/svec_str-abi.json",
+    "out/svec_str-abi.json",
     "str",
     ::fuels::types::SizedAsciiString::<4>,
     ::fuels::types::SizedAsciiString::<4>::new("yeet".to_string()).unwrap(),

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_struct.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_struct.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_struct_vec,
-    "out_for_sdk_harness_tests/svec_struct-abi.json",
+    "out/svec_struct-abi.json",
     "struct",
     TestStruct,
     TestStruct { a: true, b: 1 },

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_tuple.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_tuple.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_tuple_vec,
-    "out_for_sdk_harness_tests/svec_tuple-abi.json",
+    "out/svec_tuple-abi.json",
     "tuple",
     (u8, u8, u8),
     (1, 1, 1),

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_u16.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_u16.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_u16_vec,
-    "out_for_sdk_harness_tests/svec_u16-abi.json",
+    "out/svec_u16-abi.json",
     "u16",
     u16,
     1u16,

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_u32.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_u32.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_u32_vec,
-    "out_for_sdk_harness_tests/svec_u32-abi.json",
+    "out/svec_u32-abi.json",
     "u32",
     u32,
     1u32,

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_u64.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_u64.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_u64_vec,
-    "out_for_sdk_harness_tests/svec_u64-abi.json",
+    "out/svec_u64-abi.json",
     "u64",
     u64,
     1u64,

--- a/test/src/sdk-harness/test_projects/storage_vec/svec_u8.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/svec_u8.rs
@@ -1,6 +1,6 @@
 testgen!(
     test_u8_vec,
-    "out_for_sdk_harness_tests/svec_u8-abi.json",
+    "out/svec_u8-abi.json",
     "u8",
     u8,
     1u8,

--- a/test/src/sdk-harness/test_projects/storage_vec/testgen.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/testgen.rs
@@ -33,14 +33,14 @@ macro_rules! testgen {
                     let wallet = launch_provider_and_get_wallet().await.unwrap();
                     let id = Contract::load_from(
                         &format!(
-                            "out_for_sdk_harness_tests/svec_{}.bin",
+                            "out/svec_{}.bin",
                             $type_label,
                         ),
                         LoadConfiguration::default()
                         .with_storage_configuration(StorageConfiguration::default()
                             .add_slot_overrides_from_file(
                                 &format!(
-                                    "out_for_sdk_harness_tests/svec_{}-storage_slots.json",
+                                    "out/svec_{}-storage_slots.json",
                                     $type_label,
                                 )
                             )

--- a/test/src/sdk-harness/test_projects/storage_vec_nested/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec_nested/mod.rs
@@ -2,13 +2,13 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestStorageVecNestedContract",
-    abi = "out_for_sdk_harness_tests/storage_vec_nested-abi.json",
+    abi = "out/storage_vec_nested-abi.json",
 ));
 
 async fn test_storage_vec_nested_instance() -> TestStorageVecNestedContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_vec_nested.bin",
+        "out/storage_vec_nested.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/mod.rs
@@ -2,14 +2,14 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestStorageVecOfStorageStringContract",
-    abi = "out_for_sdk_harness_tests/storage_vec_of_storage_string-abi.json",
+    abi = "out/storage_vec_of_storage_string-abi.json",
 ));
 
 async fn test_storage_vec_of_storage_string_instance(
 ) -> TestStorageVecOfStorageStringContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_vec_of_storage_string.bin",
+        "out/storage_vec_of_storage_string.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/storage_vec_to_vec/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec_to_vec/mod.rs
@@ -2,13 +2,13 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "TestStorageVecToVecContract",
-    abi = "out_for_sdk_harness_tests/storage_vec_to_vec-abi.json",
+    abi = "out/storage_vec_to_vec-abi.json",
 ));
 
 async fn test_storage_vec_to_vec_instance() -> TestStorageVecToVecContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/storage_vec_to_vec.bin",
+        "out/storage_vec_to_vec.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/string_slice/mod.rs
+++ b/test/src/sdk-harness/test_projects/string_slice/mod.rs
@@ -9,14 +9,20 @@ use fuels::{
 };
 use std::str::FromStr;
 
-abigen!(Contract(
-    name = "TestStringSlicePredicate",
-    abi = "out_for_sdk_harness_tests/string_slice_predicate-abi.json",
-));
+abigen!(
+    Contract(
+        name = "TestStringSlicePredicate",
+        abi = "out/string_slice_predicate-abi.json",
+    ),
+    Script(
+        name = "TestScript",
+        abi = "out/script_string_slice-abi.json"
+    )
+);
 
 async fn setup() -> (Vec<u8>, Address, Wallet, u64, AssetId) {
     let predicate_code = std::fs::read(
-        "out_for_sdk_harness_tests/string_slice_predicate.bin",
+        "out/string_slice_predicate.bin",
     )
     .unwrap();
     let predicate_address = fuel_tx::Input::predicate_owner(&predicate_code);
@@ -166,17 +172,14 @@ async fn test_string_slice_predicate() {
 
 #[tokio::test]
 async fn script_string_slice() -> Result<()> {
-    setup_program_test!(
-        Wallets("wallet"),
-        Abigen(Script(
-            name = "MyScript",
-            project = "test_projects/string_slice/script_string_slice",
-        )),
-        LoadScript(
-            name = "script_instance",
-            script = "MyScript",
-            wallet = "wallet"
-        )
+    let mut wallets = launch_custom_provider_and_get_wallets(WalletsConfig::default(), None, None)
+        .await
+        .unwrap();
+    let wallet = wallets.pop().unwrap();
+
+    let script_instance = TestScript::new(
+        wallet,
+        "out/script_string_slice.bin",
     );
 
     let response = script_instance

--- a/test/src/sdk-harness/test_projects/superabi/mod.rs
+++ b/test/src/sdk-harness/test_projects/superabi/mod.rs
@@ -2,13 +2,13 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "SuperAbiTestContract",
-    abi = "out_for_sdk_harness_tests/superabi-abi.json"
+    abi = "out/superabi-abi.json"
 ));
 
 async fn get_superabi_instance() -> SuperAbiTestContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/superabi.bin",
+        "out/superabi.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/superabi_supertrait/mod.rs
+++ b/test/src/sdk-harness/test_projects/superabi_supertrait/mod.rs
@@ -2,13 +2,13 @@ use fuels::prelude::*;
 
 abigen!(Contract(
     name = "SuperAbiSuperTraitTestContract",
-    abi = "out_for_sdk_harness_tests/superabi_supertrait-abi.json"
+    abi = "out/superabi_supertrait-abi.json"
 ));
 
 async fn get_superabi_supertrait_instance() -> SuperAbiSuperTraitTestContract<Wallet> {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/superabi_supertrait.bin",
+        "out/superabi_supertrait.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/time/mod.rs
+++ b/test/src/sdk-harness/test_projects/time/mod.rs
@@ -4,14 +4,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 abigen!(Contract(
     name = "TimeTestContract",
-    abi = "out_for_sdk_harness_tests/time-abi.json"
+    abi = "out/time-abi.json"
 ));
 
 async fn get_block_instance() -> (TimeTestContract<Wallet>, ContractId, Provider) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let provider = wallet.provider();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/time.bin",
+        "out/time.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -11,22 +11,22 @@ use fuels::{
 use std::fs;
 
 const MESSAGE_DATA: [u8; 3] = [1u8, 2u8, 3u8];
-const TX_CONTRACT_BYTECODE_PATH: &str = "out_for_sdk_harness_tests/tx_contract.bin";
+const TX_CONTRACT_BYTECODE_PATH: &str = "out/tx_contract.bin";
 const TX_OUTPUT_PREDICATE_BYTECODE_PATH: &str =
-    "out_for_sdk_harness_tests/tx_output_predicate.bin";
+    "out/tx_output_predicate.bin";
 const TX_OUTPUT_CONTRACT_BYTECODE_PATH: &str =
-    "out_for_sdk_harness_tests/tx_output_contract.bin";
-const TX_FIELDS_PREDICATE_BYTECODE_PATH: &str = "out_for_sdk_harness_tests/tx_fields.bin";
+    "out/tx_output_contract.bin";
+const TX_FIELDS_PREDICATE_BYTECODE_PATH: &str = "out/tx_fields.bin";
 const TX_CONTRACT_CREATION_PREDICATE_BYTECODE_PATH: &str =
-    "out_for_sdk_harness_tests/tx_output_contract_creation_predicate.bin";
+    "out/tx_output_contract_creation_predicate.bin";
 const TX_TYPE_PREDICATE_BYTECODE_PATH: &str =
-    "out_for_sdk_harness_tests/tx_type_predicate.bin";
+    "out/tx_type_predicate.bin";
 const TX_WITNESS_PREDICATE_BYTECODE_PATH: &str =
-    "out_for_sdk_harness_tests/tx_witness_predicate.bin";
+    "out/tx_witness_predicate.bin";
 const TX_INPUT_COUNT_PREDICATE_BYTECODE_PATH: &str =
-    "out_for_sdk_harness_tests/tx_input_count_predicate.bin";
+    "out/tx_input_count_predicate.bin";
 const TX_OUTPUT_COUNT_PREDICATE_BYTECODE_PATH: &str =
-    "out_for_sdk_harness_tests/tx_output_count_predicate.bin";
+    "out/tx_output_count_predicate.bin";
 
 use crate::tx_fields::Output as SwayOutput;
 use crate::tx_fields::Transaction as SwayTransaction;
@@ -34,35 +34,35 @@ use crate::tx_fields::Transaction as SwayTransaction;
 abigen!(
     Contract(
         name = "TxContractTest",
-        abi = "out_for_sdk_harness_tests/tx_contract-abi.json",
+        abi = "out/tx_contract-abi.json",
     ),
     Contract(
         name = "TxOutputContract",
-        abi = "out_for_sdk_harness_tests/tx_output_contract-abi.json",
+        abi = "out/tx_output_contract-abi.json",
     ),
     Predicate(
         name = "TestPredicate",
-        abi = "out_for_sdk_harness_tests/tx_fields-abi.json"
+        abi = "out/tx_fields-abi.json"
     ),
     Predicate(
         name = "TestOutputPredicate",
-        abi = "out_for_sdk_harness_tests/tx_output_predicate-abi.json"
+        abi = "out/tx_output_predicate-abi.json"
     ),
     Predicate(
         name = "TestTxTypePredicate",
-        abi = "out_for_sdk_harness_tests/tx_type_predicate-abi.json"
+        abi = "out/tx_type_predicate-abi.json"
     ),
     Predicate(
         name = "TestTxWitnessPredicate",
-        abi = "out_for_sdk_harness_tests/tx_witness_predicate-abi.json"
+        abi = "out/tx_witness_predicate-abi.json"
     ),
     Predicate(
         name = "TestTxInputCountPredicate",
-        abi = "out_for_sdk_harness_tests/tx_input_count_predicate-abi.json"
+        abi = "out/tx_input_count_predicate-abi.json"
     ),
     Predicate(
         name = "TestTxOutputCountPredicate",
-        abi = "out_for_sdk_harness_tests/tx_output_count_predicate-abi.json"
+        abi = "out/tx_output_count_predicate-abi.json"
     )
 );
 

--- a/test/src/sdk-harness/test_projects/type_aliases/mod.rs
+++ b/test/src/sdk-harness/test_projects/type_aliases/mod.rs
@@ -5,13 +5,13 @@ use fuels::{
 
 abigen!(Contract(
     name = "TypeAliasesTestContract",
-    abi = "out_for_sdk_harness_tests/type_aliases-abi.json"
+    abi = "out/type_aliases-abi.json"
 ));
 
 async fn get_type_aliases_instance() -> (TypeAliasesTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/type_aliases.bin",
+        "out/type_aliases.bin",
         LoadConfiguration::default(),
     )
     .unwrap()

--- a/test/src/sdk-harness/test_projects/vec_in_abi/mod.rs
+++ b/test/src/sdk-harness/test_projects/vec_in_abi/mod.rs
@@ -3,13 +3,13 @@ use std::str::FromStr;
 
 abigen!(Contract(
     name = "VecInAbiTestContract",
-    abi = "out_for_sdk_harness_tests/vec_in_abi-abi.json"
+    abi = "out/vec_in_abi-abi.json"
 ));
 
 async fn get_vec_in_abi_instance() -> (VecInAbiTestContract<Wallet>, ContractId) {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
     let id = Contract::load_from(
-        "out_for_sdk_harness_tests/vec_in_abi.bin",
+        "out/vec_in_abi.bin",
         LoadConfiguration::default(),
     )
     .unwrap()


### PR DESCRIPTION
## Description

This PR improves execution times and increases coverage of `cargo-test-lib-std` and `forc-unit-tests` CI tests by:
- removing unnecessarily `forc test` runs on `./test/src/sdk-harness` Sway projects. They do not contain any Sway unit tests. In general, SDK harness tests are ment to be replace with in-language tests over time and are not actively expanded. We do not expect any unit tests to ever be added to those projects.
- adding running SDK harness tests on Sway projects compiled in `debug` mode. Currently, unlike in-language tests that test both `debug` and `release` outputs, SDK harness tests test only `release` versions. The `can_get_predicate_address` test use a hardcoded predicate address of a `release` predicate version. That's why they are skipped `--skip can_get_predicate_address` when running tests on projects compiled in `release` mode.
- removing redundant `forc-unit-tests` runs with `--experimental const_generics` because the feature is enabled by default and those tests are the same as the ones already run without that flag.
- adding running SDK harness and in-language tests for `str_array_no_padding` experimental feature.

Enabling SDK harness and in-language tests for `str_array_no_padding` exposed two failing tests that are now adjusted for the new `str[N]` memory layout.

To enable SDK harness tests for both `debug` and `release` builds, the build outputs of _all projects_ are moved to the common `out` folder. `forc build <workspace>` does not allow setting `--output-directory` having variables like project name. Having a single common out directory is not an issue because project names must be unique. This is guaranteed by the fact they are all in the same workspace. Workspaces do not allow their members having the same `name` even if they are situated in different folders.

The usage of the `setup_program_test!` macro in one test is change to using `abigen!` approach, because the project must be compiled in release mode for `Abigen` command to work in `setup_program_test!` and we want to test both `debug` and `release` mode.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.