### PR TITLE
perf: cache successor params to avoid O(P×A) cloning in arg demotion

### DIFF
--- a/sway-ir/src/optimize/arg_demotion.rs
+++ b/sway-ir/src/optimize/arg_demotion.rs
@@ -280,9 +280,10 @@ fn demote_block_signature(context: &mut Context, function: &Function, block: Blo
 
     let preds = block.pred_iter(context).copied().collect::<Vec<Block>>();
     for pred in preds {
+        let params = pred.get_succ_params(context, &block);
         for (arg_idx, _arg_val, arg_var) in &arg_vars {
             // Get the value which is being passed to the block at this index.
-            let arg_val = pred.get_succ_params(context, &block)[*arg_idx];
+            let arg_val = params[*arg_idx];
 
             // Insert a `get_local` and `store` for each candidate argument and insert them at the
             // end of this block, before the terminator.


### PR DESCRIPTION
`demote_block_signature` called `get_succ_params()` inside a nested loop over predecessors and demotable arguments. Each call cloned the entire arguments vector just to access a single element by index. With P predecessors, A demotable args, and N total args, this resulted in P×A×N unnecessary Value copies instead of P×N.

Moved `get_succ_params()` call outside the inner loop and cache the result, reducing vector cloning from O(P×A) to O(P) per block.