### PR TITLE
fix: statically forbid `__revert` intrinsic in predicates

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -10,7 +10,7 @@ use sway_types::{integer_bits::IntegerBits, Spanned};
 use crate::{
     engine_threading::*,
     language::{
-        parsed::{Expression, ExpressionKind},
+        parsed::{Expression, ExpressionKind, TreeType},
         ty::{self, TyIntrinsicFunctionKind},
         Literal,
     },
@@ -1735,7 +1735,7 @@ fn type_check_shift_binary_op(
 
 /// Signature: `__revert(code: u64)`
 /// Description: Reverts with error code `code`.
-/// Constraints: None.
+/// Constraints: Not allowed in predicates (predicates must return bool, not panic).
 fn type_check_revert(
     handler: &Handler,
     mut ctx: TypeCheckContext,
@@ -1745,6 +1745,16 @@ fn type_check_revert(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
+
+    // Forbid __revert in predicates: predicates must evaluate to true/false,
+    // not abort execution. Using revert() in a predicate causes a runtime panic
+    // which should be caught at compile time instead. (Closes #5986)
+    if ctx.kind() == TreeType::Predicate {
+        return Err(handler.emit_err(CompileError::DisallowedIntrinsicInPredicate {
+            intrinsic: kind.to_string(),
+            span,
+        }));
+    }
 
     if arguments.len() != 1 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_revert/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_revert/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "predicate_revert"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_revert/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_revert/src/main.sw
@@ -1,0 +1,8 @@
+predicate;
+
+fn main() -> bool {
+    // This should produce a compile error: __revert is not allowed in predicates.
+    // Predicates must evaluate to true/false, not abort execution.
+    __revert(42);
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_revert/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_revert/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Using intrinsic "__revert" in a predicate is not allowed.


### PR DESCRIPTION
## Description

Closes #5986

Predicates must evaluate to `true`/`false` — they should not abort execution via revert. Currently, using `revert()` or `__revert()` in a predicate causes a runtime panic rather than a compile-time error.

## Changes

- Added a `TreeType::Predicate` check in `type_check_revert()` (semantic analysis level)
- Emits `DisallowedIntrinsicInPredicate` error when `__revert` is used in a predicate
- Added `should_fail` test: `predicate_revert`

## Why this approach vs #7046

The previous attempt (#7046) blocked the RVRT opcode at the assembly level, which was too blunt — it would break `unwrap()` and other legitimate internal uses. As @xunilrj noted, most uses of `revert` in predicates come from `unwrap()`.

This approach targets the `__revert` **intrinsic** specifically at the **semantic analysis** level:
- Catches explicit `__revert()` and `revert()` calls (since `revert()` in stdlib calls `__revert`)
- Leaves the RVRT opcode available for compiler-generated code (match exhaustiveness, etc.)
- Error fires early during type checking, not late during IR generation

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.