### PR TITLE
sway-core: don't panic when add_edge_from_current is called with empty node_stack

### DIFF
--- a/sway-core/src/semantic_analysis/type_check_analysis.rs
+++ b/sway-core/src/semantic_analysis/type_check_analysis.rs
@@ -61,7 +61,14 @@ impl TypeCheckAnalysisContext<'_> {
     }
 
     pub fn add_edge_from_current(&mut self, to: TyNodeDepGraphNodeId, edge: TyNodeDepGraphEdge) {
-        let from = *self.node_stack.last().unwrap();
+        // node_stack can be empty when an analysis path is reached outside a
+        // top-level item — e.g. an associated const initializer that uses an
+        // intrinsic such as `__size_of::<V>()` (#7615) is visited before any
+        // node is pushed for it. With no current node there's no edge to add;
+        // skip rather than panicking.
+        let Some(&from) = self.node_stack.last() else {
+            return;
+        };
         if !self.dep_graph.contains_edge(from, to) {
             self.dep_graph.add_edge(from, to, edge);
         }


### PR DESCRIPTION
Fixes #7615.

`add_edge_from_current` unwrapped `self.node_stack.last()`. The stack is empty when an analysis path is reached outside a top-level item — for example, an associated const initialized to `__size_of::<V>()` is visited before any node is pushed for it. The result is a compiler panic that blocks the dynamic-storage `StorageVec<V>` work in #7614. Bail out via `let Some(&from) = ... else { return; }` instead — there's no current node to draw an edge from, so skipping is the right behaviour.