### PR TITLE
docs: update contributing guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Available recipes:
 
 We welcome contributions to Sway!
 
-Please see the [Contributing To Sway](https://fuellabs.github.io/sway/master/book/reference/contributing_to_sway.html) section of the Sway book for guidelines and instructions to help you get started.
+Please see the [Contributing To Sway](https://docs.fuel.network/docs/sway/reference/contributing_to_sway/) section of the Sway book for guidelines and instructions to help you get started.


### PR DESCRIPTION
## Description
Updates the README contributing guidelines link to the current Fuel docs URL.

Fixes #3558.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have verified the updated link returns HTTP 200

## Test Plan
- `python3` HEAD request to `https://docs.fuel.network/docs/sway/reference/contributing_to_sway/` returns HTTP 200
- `git diff --check`
