### PR TITLE
Fix redundant ops

### DIFF
--- a/sway-core/src/asm_generation/fuel/optimizations/constant_propagate.rs
+++ b/sway-core/src/asm_generation/fuel/optimizations/constant_propagate.rs
@@ -587,11 +587,11 @@ pub fn checked_nth_root(target: u64, nth_root: u64) -> Option<u64> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use expect_test::expect;
 
-    fn optimise(
+    pub fn optimise(
         ops: impl IntoIterator<Item = Op>,
         f: impl FnOnce(AbstractInstructionSet) -> AbstractInstructionSet,
     ) {

--- a/sway-core/src/asm_generation/fuel/optimizations/misc.rs
+++ b/sway-core/src/asm_generation/fuel/optimizations/misc.rs
@@ -94,7 +94,10 @@ impl AbstractInstructionSet {
         self
     }
 
-    pub(crate) fn remove_redundant_ops(mut self, mut log: impl FnMut(&str),) -> AbstractInstructionSet {
+    pub(crate) fn remove_redundant_ops(
+        mut self,
+        mut log: impl FnMut(&str),
+    ) -> AbstractInstructionSet {
         let mut new_ops = Vec::with_capacity(self.ops.len());
 
         let mut ops = self.ops.iter().peekable();
@@ -112,7 +115,10 @@ impl AbstractInstructionSet {
             // We also need to be sure op is redundant regarding const registers.
             let remove = if remove {
                 if let Some(next_op) = ops.peek() {
-                    op.def_const_registers().intersection(&next_op.use_registers()).count() == 0
+                    op.def_const_registers()
+                        .intersection(&next_op.use_registers())
+                        .count()
+                        == 0
                 } else {
                     // last instruction, we can remove it
                     true
@@ -133,7 +139,6 @@ impl AbstractInstructionSet {
         self
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/sway-core/src/asm_generation/fuel/optimizations/misc.rs
+++ b/sway-core/src/asm_generation/fuel/optimizations/misc.rs
@@ -128,10 +128,10 @@ impl AbstractInstructionSet {
             };
 
             if !remove {
-                log(&format!("    keeping: {}\n", op));
+                log(&format!("keeping: {}\n", op));
                 new_ops.push(op.clone())
             } else {
-                log(&format!("    removing: {}\n", op));
+                log(&format!("removing: {}\n", op));
             }
         }
 
@@ -170,17 +170,17 @@ mod tests {
         );
 
         expect![[r#"
-                removing: noop                                    ; 0
-                keeping: noop                                    ; 1
-                keeping: move $r0 $err                           ; 2
-                keeping: noop                                    ; 3
-                keeping: move $r0 $of                            ; 4
-                removing: move $r0 $r0                            ; 5
-                keeping: move $r1 $r1                            ; 6
-                keeping: move $r0 $err                           ; 7
-                keeping: move $r2 $r2                            ; 8
-                keeping: move $r0 $of                            ; 9
-        "#]]
+removing: noop                                    ; 0
+keeping: noop                                    ; 1
+keeping: move $r0 $err                           ; 2
+keeping: noop                                    ; 3
+keeping: move $r0 $of                            ; 4
+removing: move $r0 $r0                            ; 5
+keeping: move $r1 $r1                            ; 6
+keeping: move $r0 $err                           ; 7
+keeping: move $r2 $r2                            ; 8
+keeping: move $r0 $of                            ; 9
+"#]]
         .assert_eq(&str);
     }
 }

--- a/sway-core/src/asm_generation/fuel/optimizations/misc.rs
+++ b/sway-core/src/asm_generation/fuel/optimizations/misc.rs
@@ -113,23 +113,20 @@ impl AbstractInstructionSet {
             };
 
             // We also need to be sure op is redundant regarding const registers.
-            let remove = if remove {
-                if let Some(next_op) = ops.peek() {
-                    op.def_const_registers()
-                        .intersection(&next_op.use_registers())
-                        .count()
-                        == 0
-                } else {
-                    // last instruction, we can remove it
-                    true
-                }
-            } else {
-                false
-            };
+            let remove = remove
+                && ops
+                    .peek()
+                    .map(|next_op| {
+                        op.def_const_registers()
+                            .intersection(&next_op.use_registers())
+                            .count()
+                            == 0
+                    })
+                    .unwrap_or(true);
 
             if !remove {
                 log(&format!("keeping: {}\n", op));
-                new_ops.push(op.clone())
+                new_ops.push(op.clone());
             } else {
                 log(&format!("removing: {}\n", op));
             }

--- a/sway-core/src/asm_generation/fuel/optimizations/misc.rs
+++ b/sway-core/src/asm_generation/fuel/optimizations/misc.rs
@@ -81,7 +81,7 @@ impl AbstractInstructionSet {
                 break;
             }
 
-            // Replace the dead moves with NOPs, as it's cheaper.
+            // Replace the dead moves with NOOPs, as it's cheaper.
             for idx in dead_moves {
                 self.ops[idx] = Op {
                     opcode: Either::Left(VirtualOp::NOOP),
@@ -94,12 +94,11 @@ impl AbstractInstructionSet {
         self
     }
 
-    pub(crate) fn remove_redundant_ops(mut self) -> AbstractInstructionSet {
-        self.ops.retain(|op| {
-            // It is easier to think in terms of operations we want to remove
-            // than the operations we want to retain ;-)
-            #[allow(clippy::match_like_matches_macro)]
-            // Keep the `match` for adding more ops in the future.
+    pub(crate) fn remove_redundant_ops(mut self, mut log: impl FnMut(&str),) -> AbstractInstructionSet {
+        let mut new_ops = Vec::with_capacity(self.ops.len());
+
+        let mut ops = self.ops.iter().peekable();
+        while let Some(op) = ops.next() {
             let remove = match &op.opcode {
                 Either::Left(VirtualOp::NOOP) => true,
                 Either::Left(VirtualOp::MOVE(a, b)) => a == b,
@@ -110,9 +109,73 @@ impl AbstractInstructionSet {
                 _ => false,
             };
 
-            !remove
-        });
+            // We also need to be sure op is redundant regarding const registers.
+            let remove = if remove {
+                if let Some(next_op) = ops.peek() {
+                    op.def_const_registers().intersection(&next_op.use_registers()).count() == 0
+                } else {
+                    // last instruction, we can remove it
+                    true
+                }
+            } else {
+                false
+            };
 
+            if !remove {
+                log(&format!("    keeping: {}\n", op));
+                new_ops.push(op.clone())
+            } else {
+                log(&format!("    removing: {}\n", op));
+            }
+        }
+
+        self.ops = new_ops;
         self
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+
+    #[test]
+    fn remove_redundant_ops() {
+        let mut str = String::new();
+        let capture = |s: &str| {
+            str.push_str(s);
+        };
+        super::super::constant_propagate::tests::optimise(
+            [
+                // NOOP
+                VirtualOp::noop().into(),
+                VirtualOp::noop().into(),
+                VirtualOp::r#move("0", "err").into(),
+                VirtualOp::noop().into(),
+                VirtualOp::r#move("0", "of").into(),
+                // MOVE with same registers
+                VirtualOp::r#move("0", "0").into(),
+                VirtualOp::r#move("1", "1").into(),
+                VirtualOp::r#move("0", "err").into(),
+                VirtualOp::r#move("2", "2").into(),
+                VirtualOp::r#move("0", "of").into(),
+            ],
+            |ops| ops.remove_redundant_ops(capture),
+        );
+
+        expect![[r#"
+                removing: noop                                    ; 0
+                keeping: noop                                    ; 1
+                keeping: move $r0 $err                           ; 2
+                keeping: noop                                    ; 3
+                keeping: move $r0 $of                            ; 4
+                removing: move $r0 $r0                            ; 5
+                keeping: move $r1 $r1                            ; 6
+                keeping: move $r0 $err                           ; 7
+                keeping: move $r2 $r2                            ; 8
+                keeping: move $r0 $of                            ; 9
+        "#]]
+        .assert_eq(&str);
     }
 }

--- a/sway-core/src/asm_generation/fuel/optimizations/mod.rs
+++ b/sway-core/src/asm_generation/fuel/optimizations/mod.rs
@@ -32,7 +32,7 @@ impl AbstractInstructionSet {
                 .simplify_cfg()
                 .remove_sequential_jumps()
                 .remove_redundant_moves()
-                .remove_redundant_ops(),
+                .remove_redundant_ops(log_nothing),
             // On release builds we can do more iterations
             OptLevel::Opt1 => {
                 for _ in 0..MAX_OPT_ROUNDS {

--- a/sway-core/src/asm_lang/virtual_ops.rs
+++ b/sway-core/src/asm_lang/virtual_ops.rs
@@ -282,6 +282,10 @@ pub(crate) enum VirtualOp {
 }
 
 impl VirtualOp {
+    pub fn noop() -> VirtualOp {
+        VirtualOp::NOOP
+    }
+
     pub fn r#move(a: impl Into<VirtualRegister>, b: impl Into<VirtualRegister>) -> VirtualOp {
         VirtualOp::MOVE(a.into(), b.into())
     }

--- a/sway-core/src/asm_lang/virtual_register.rs
+++ b/sway-core/src/asm_lang/virtual_register.rs
@@ -12,7 +12,11 @@ pub enum VirtualRegister {
 
 impl From<&str> for VirtualRegister {
     fn from(value: &str) -> Self {
-        VirtualRegister::Virtual(value.to_string())
+        if let Some(r) = ConstantRegister::parse_register_name(value) {
+            VirtualRegister::Constant(r)
+        } else {
+            VirtualRegister::Virtual(value.to_string())
+        }
     }
 }
 


### PR DESCRIPTION
## Description

We have been considering any `NOOP`, and others, as redundant, but in reality they are only redundant if their const def registers are not read by the immediate op.

This PR takes this into consideration.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
