### PR TITLE
ir-gen: Fix ICE when reading an indexed ref mut array element

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -5276,12 +5276,32 @@ impl<'a> FnCompiler<'a> {
         index_expr: &ty::TyExpression,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<TerminatorValue, CompileError> {
-        let prefix_value = return_on_termination_or_extract!(self.compile_expression_to_memory(
-            context,
-            md_mgr,
-            prefix_expr
-        )?)
+        let mut prefix_value = return_on_termination_or_extract!(self
+            .compile_expression_to_memory(context, md_mgr, prefix_expr)?)
         .expect_memory();
+
+        // When the prefix is a reference (e.g. a `ref mut self` argument), the compiled value
+        // is a pointer to the reference, i.e. a pointer to a pointer to the indexed aggregate.
+        // We need to dereference it, peeling off the extra levels of indirection, until we
+        // reach the pointer that actually points to the array or slice.
+        while let Some(TypeContent::TypedPointer(pointee)) = prefix_value
+            .get_type(context)
+            .map(|ty| ty.get_content(context))
+        {
+            if matches!(
+                pointee.get_content(context),
+                TypeContent::TypedPointer(_) | TypeContent::Pointer
+            ) {
+                prefix_value = self
+                    .current_block
+                    .append(context)
+                    .load(prefix_value)
+                    .add_metadatum(context, span_md_idx);
+            } else {
+                break;
+            }
+        }
+
         let prefix_type = prefix_value.get_type(context).unwrap();
 
         let index_value = return_on_termination_or_extract!(
@@ -5300,7 +5320,10 @@ impl<'a> FnCompiler<'a> {
                     prefix_value,
                     index_value,
                 ),
-                _ => todo!(),
+                _ => Err(CompileError::Internal(
+                    "Unsupported array value for index expression.",
+                    prefix_expr.span.clone(),
+                )),
             },
             TypeContent::TypedSlice(..) => self.compile_indexing_slices(
                 context,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -5276,8 +5276,9 @@ impl<'a> FnCompiler<'a> {
         index_expr: &ty::TyExpression,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<TerminatorValue, CompileError> {
-        let mut prefix_value = return_on_termination_or_extract!(self
-            .compile_expression_to_memory(context, md_mgr, prefix_expr)?)
+        let mut prefix_value = return_on_termination_or_extract!(
+            self.compile_expression_to_memory(context, md_mgr, prefix_expr)?
+        )
         .expect_memory();
 
         // When the prefix is a reference (e.g. a `ref mut self` argument), the compiled value

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics_array_in_reassignments/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics_array_in_reassignments/src/main.sw
@@ -33,8 +33,7 @@ where
         let mut i = 0;
         while i < N {
             self[i] = default;
-            // TODO: Uncomment this `assert_eq` once https://github.com/FuelLabs/sway/issues/7602 is fixed.
-            // assert_eq(self[i], default);
+            assert_eq(self[i], default);
             i += 1;
         }
     }


### PR DESCRIPTION
Closes #7602

Reading an element of a `ref mut` array argument, like `self[i]` inside an `impl ... for [T; N]` method, crashed the compiler. A `ref mut` argument is already a pointer in IR, and the argument gets stored into a local on entry, so by the time the index-read code runs the prefix is a pointer to a pointer to the array. That shape wasn't handled and fell into a `todo!()`. Writing through the same `self[i]` worked because the reassignment path already dereferences `ref mut` arguments.

The index-read path now peels off the extra pointer indirection before indexing, the way reassignment does, and the previously disabled `assert_eq(self[i], default)` line in the const-generics reassignment test is back on.