### PR TITLE
sway-core: Clarify error for self used without a self parameter

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -732,6 +732,15 @@ impl ty::TyExpression {
                     span,
                 }
             }
+            // `self` and `Self` are inserted into the namespace as a generic type parameter
+            // (`GenericTypeForFunctionScope`). When `self` is used as a value but the enclosing
+            // function has no `self` parameter, resolution falls through to that type parameter.
+            // Reporting it as "actually a generic type parameter" is misleading, so emit a
+            // dedicated error pointing at the missing `self` parameter instead.
+            Some(ty::TyDecl::GenericTypeForFunctionScope(_)) if name.as_str() == "self" => {
+                let err = handler.emit_err(CompileError::SelfParameterNotAvailable { span });
+                ty::TyExpression::error(err, name.span(), engines)
+            }
             Some(a) => {
                 let err = handler.emit_err(CompileError::NotAVariable {
                     name: name.clone(),

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -83,6 +83,10 @@ pub enum CompileError {
         what_it_is: &'static str,
         span: Span,
     },
+    #[error(
+        "\"self\" is not available here because the enclosing function does not have a \"self\" parameter."
+    )]
+    SelfParameterNotAvailable { span: Span },
     #[error("{feature} is currently not implemented.")]
     Unimplemented {
         /// The description of the unimplemented feature,
@@ -1261,6 +1265,7 @@ impl Spanned for CompileError {
             ModuleDepGraphCyclicReference { .. } => Span::dummy(),
             UnknownVariable { span, .. } => span.clone(),
             NotAVariable { span, .. } => span.clone(),
+            SelfParameterNotAvailable { span, .. } => span.clone(),
             Unimplemented { span, .. } => span.clone(),
             TypeError(err) => err.span(),
             ParseError { span, .. } => span.clone(),

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'self_used_without_self_parameter'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "self_used_without_self_parameter"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/src/main.sw
@@ -3,8 +3,11 @@ library;
 struct S {}
 
 impl S {
-    fn use_self() {
+    fn use_self_method() {
         let _ = self.x();
+    }
+
+    fn use_self_value() {
         let _ = self;
     }
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/src/main.sw
@@ -1,0 +1,14 @@
+library;
+
+struct S {}
+
+impl S {
+    fn use_self() {
+        let _ = self.x();
+        let _ = self;
+    }
+
+    fn x(self) -> u64 {
+        0
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_used_without_self_parameter/test.toml
@@ -1,0 +1,7 @@
+category = "fail"
+
+# check: $()let _ = self.x();
+# nextln: $()"self" is not available here because the enclosing function does not have a "self" parameter.
+
+# check: $()let _ = self;
+# nextln: $()"self" is not available here because the enclosing function does not have a "self" parameter.


### PR DESCRIPTION
Closes #7645

Using `self` as a value inside a method that has no `self` parameter reported "Identifier \"self\" was used as a variable, but it is actually a generic type parameter." That is misleading: `self` is a keyword, not a user generic. It happens because both `self` and `Self` get inserted into the namespace as the injected `Self` type parameter, so resolution falls through to it once no real `self` parameter shadows the name.

Special-case that resolution and emit a new `SelfParameterNotAvailable` error pointing at the missing `self` parameter. `Self` and methods that do take `self` are unaffected, since a real `self` parameter resolves to a variable. Adds a should_fail test covering both the method-receiver and bare-value uses.
