### PR TITLE
Implement chunk-based dynamic storage `StorageVec`

### DIFF
--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1165,13 +1165,38 @@ fn offset_calculator<T>(index: u64) -> u64 {
     (index * size_in_bytes) / 8
 }
 
-// A dynamic-slot-based `StorageVec` has two distinctive modes
+// A chunked-dynamic-slot-based `StorageVec` has two distinctive modes
 // of operations and storage access:
 //
 // 1. Storing non-zero-sized types
-//    E.g., `StorageVec<u64>`. In this mode, the whole content
-//    of the storage vec is stored in a single dynamic slot at `self.field_id`
-//    and all the `StorageVec` methods are fully supported.
+//    E.g., `StorageVec<u64>`. In this mode, elements are spread across one or
+//    more dynamic storage slots, each holding at most `CHUNK_MAX_SIZE` bytes of
+//    element data. Every element is **fully contained within a single slot** —
+//    no element ever straddles a slot boundary.
+//
+//    All slots hold the same maximum number of elements:
+//      `elems_per_slot = CHUNK_MAX_SIZE / size_of::<V>()` (floor division)
+//
+//    The first slot is at `self.field_id()` and has the following layout:
+//      `[u64 len (8 bytes) | V[0] | V[1] | ... | V[elems_per_slot - 1] ]`
+//    Its total size is `8 + CHUNK_MAX_SIZE` bytes: 8 bytes for the length
+//    header followed by up to `CHUNK_MAX_SIZE` bytes of element data.
+//
+//    Subsequent slots are at `self.field_id() + 1`, `self.field_id() + 2`, etc.
+//    (computed via `add_u64_to_b256`), and each holds the same `elems_per_slot`
+//    elements starting at byte offset 0.
+//
+//    Given the element at `index`:
+//      `chunk_number      = index / elems_per_slot`
+//      `index_in_chunk    = index % elems_per_slot`
+//      slot key           = `self.field_id() + chunk_number` (via `add_u64_to_b256`)
+//      byte offset in slot = `(8 if chunk_number == 0 else 0) + index_in_chunk * size_of::<V>()`
+//
+//    Methods that shrink the vector (`pop`, `resize`) **do not zero out the residual
+//    element bytes** beyond the new length. Those bytes remain in storage but are
+//    logically non-existent and will be overwritten by future `push`/`resize` calls.
+//
+//    All `StorageVec` methods are fully supported.
 //
 // 2. Storing nested storage types (zero-sized types)
 //    E.g., `StorageVec<StorageVec<u64>>`. In this mode, the `self.field_id`
@@ -1185,24 +1210,28 @@ fn offset_calculator<T>(index: u64) -> u64 {
 // different storage access patterns, in terms of reading and writing,
 // depending on `V` being a storage type or not.
 //
-// E.g., `push` requires a read and a write when `V` is a nested storage type,
-// and otherwise only a `write`. If we choose `#[storage(read, write)]` as the
-// purity attribute, we will get a warning that `read` is not needed, if `push`
-// is called for non-storage types.
-//
 // This is because the purity warnings are generated at the end of the compilation
 // pipeline.
 //
-// Currently, the only way to avoid purity warnings when `V` is a nested storage type
-// is the following:
-// - we omit `read` in `#[storage]` attributes and leave only `write`. The purity
-//   attributes will reflect only the "When `V` is a Nested Storage Type" part of
-//   the method doc-comment.
-// - for methods that are not supported at all for nested types, like, e.g. `set`,
-//   we add a dummy `let _ = __state_clear(b256::zero(), 0);` call to simulate `write`
-//   access. This is a workaround, but currently we don't have better options.
-//   The real issue here is the problematic duality of the original `StorageVec` API,
-//   which currently cannot be expressed via type system and trait constraints.
+// For methods that are not supported at all for nested types, like, e.g. `set`,
+// the dead code in the `STORES_STORAGE_TYPE = true` branch is eliminated by the
+// compiler. To prevent purity warnings when such methods are instantiated for
+// nested storage types, we add a dummy `let _ = __state_preload(b256::zero())` call to
+// simulate read access, and a dummy `let _ = __state_clear(b256::zero(), 0)` call
+// to simulate write access. This is a workaround, but currently we don't have
+// better options. The real issue here is the problematic duality of the original
+// `StorageVec` API, which currently cannot be expressed via type system and trait
+// constraints.
+
+/// Maximum number of bytes of element data stored per storage slot by the chunked `StorageVec`.
+/// Every slot — including slot 0 — holds at most `CHUNK_MAX_SIZE` bytes of element data, so
+/// all slots have the same element capacity of `CHUNK_MAX_SIZE / size_of::<V>()` elements.
+///
+/// Slot 0 additionally stores an 8-byte `u64` length header before the element area, making
+/// its total size `8 + CHUNK_MAX_SIZE` bytes.
+#[cfg(experimental_dynamic_storage = true)]
+const CHUNK_MAX_SIZE: u64 = 1024;
+
 #[cfg(experimental_dynamic_storage = true)]
 impl<V> StorageKey<StorageVec<V>> {
     // TODO: We should have only one `STORES_STORAGE_TYPE` constant
@@ -1221,6 +1250,47 @@ impl<V> StorageKey<StorageVec<V>> {
     // /// True if the `StorageVec` stores a storage type, i.e., if `V` is a storage type.
     // const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
+    /// Returns the storage slot key and byte offset within that slot for the element at `index`.
+    ///
+    /// Elements are packed into consecutive storage slots. Every slot holds the same
+    /// maximum number of elements — `CHUNK_MAX_SIZE / size_of::<V>()` — and each
+    /// element is **fully contained within its slot** (no cross-boundary elements).
+    ///
+    /// - Slot 0 (`self.field_id()`):
+    ///     `[u64 len (8 bytes) | V[0] .. V[elems_per_slot - 1]]`
+    ///     Max slot size: `8 + CHUNK_MAX_SIZE` bytes.
+    /// - Slot N (`self.field_id() + N`, N ≥ 1):
+    ///     `[V[N*elems_per_slot] .. V[(N+1)*elems_per_slot - 1]]`
+    ///     Max slot size: `CHUNK_MAX_SIZE` bytes.
+    ///
+    /// This method does not perform storage access; it only computes storage slot keys and offsets.
+    fn get_slot_and_offset_of_elem(self, index: u64) -> (b256, u64) {
+        const SIZE_OF_V: u64 = __size_of::<V>();
+
+        // Number of elements that fit in each slot's element area.
+        // All slots share the same capacity because slot 0's element area is also
+        // CHUNK_MAX_SIZE bytes (its extra 8-byte header is in addition to that).
+        const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
+
+        let chunk_number = index / ELEMS_PER_SLOT;
+        let index_in_chunk = index % ELEMS_PER_SLOT;
+
+        // Slot 0's element area begins at byte 8 (after the length header).
+        // All other slots' element areas begin at byte 0.
+        let offset_in_slot = index_in_chunk * SIZE_OF_V + if chunk_number == 0 {
+            8
+        } else {
+            0
+        };
+
+        let mut slot = self.field_id();
+        if chunk_number > 0 {
+            add_u64_to_b256(slot, chunk_number);
+        }
+
+        (slot, offset_in_slot)
+    }
+
     /// Appends `value` to the end of the vector.
     ///
     /// # Arguments
@@ -1231,13 +1301,13 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// ## When `V` is a Non-storage Type
     ///
-    /// * Internal preloads: `1` (to preload current content)
-    /// * Writes: `1`            (to append the `value`)
+    /// * Reads: `1`    (vector's length)
+    /// * Writes: `2`   (vector's length and new element)
     ///
     /// ## When `V` is a Nested Storage Type
     ///
-    /// * Reads: `1`    (to get the vector's length)
-    /// * Writes: `1`   (to write the new, increased, vector's length)
+    /// * Reads: `1`    (vector's length)
+    /// * Writes: `1`   (new, increased, vector's length)
     ///
     /// # Examples
     ///
@@ -1258,18 +1328,33 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(0, storage.vec_of_vec.get(0).unwrap().len());
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn push(self, value: V) {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
+
+        let len = self.len();
+        let new_len = len + 1;
 
         if STORES_STORAGE_TYPE {
             // Nothing to actually store. We just need to increment
             // the vector's length. It is `get` that will return the
             // proper `StorageKey` for the nested storage type `V`.
-            let len = read_slot::<u64>(self.field_id(), 0).unwrap_or(0);
-            write_slot(self.field_id(), len + 1);
+            __state_store_slot(self.field_id(), __addr_of(new_len), 8);
         } else {
-            append_slot(self.field_id(), value);
+            const SIZE_OF_V: u64 = __size_of::<V>();
+
+            // Update the length header first.
+            //
+            // We must update the length header (the first 8 bytes of slot 0) **before**
+            // writing the element. If the slot was previously unused, `__state_update_slot`
+            // requires the offset to be within the currently used size. Writing the length
+            // first establishes those 8 bytes so subsequent updates to the same slot at
+            // offset ≥ 8 are valid.
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
+
+            // Compute which slot and offset to write the new element.
+            let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len);
+            __state_update_slot(elem_slot, __addr_of(value), elem_offset, SIZE_OF_V);
         }
     }
 
@@ -1283,7 +1368,10 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// > **_WARNING:_** **If `V` is a nested storage type, `pop` will reduce the vector length and
     /// remove the last element _from the vector_, but the content of the nested storage type
-    /// will remain in the storage.
+    /// will remain in the storage.**
+    ///
+    /// The residual bytes of the removed element remain in storage but are logically non-existent
+    /// and will be overwritten by future `push` calls.
     ///
     /// # Returns
     ///
@@ -1293,14 +1381,13 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// ## When `V` is a Non-storage Type
     ///
-    /// * Preloads: `1` (to get the vector's length)
-    /// * Reads: `1`    (to read the current content)
-    /// * Writes: `1`   (to write the truncated content)
+    /// * Reads: `2`    (vector's length and the last element)
+    /// * Writes: `1`   (vector's length)
     ///
     /// ## When `V` is a Nested Storage Type
     ///
-    /// * Reads: `1`    (to get the vector's length)
-    /// * Writes: `1`   (to write the new, decreased, vector's length)
+    /// * Reads: `1`    (vector's length)
+    /// * Writes: `1`   (new, decreased, vector's length)
     ///
     /// # Examples
     ///
@@ -1328,33 +1415,28 @@ impl<V> StorageKey<StorageVec<V>> {
             return None;
         }
 
+        let new_len = len - 1;
+
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // Reducing len by 1, effectively removing the last item.
             // Note that the value stored in the nested storage type
             // **does not get removed from storage**.
-            write_slot(self.field_id(), len - 1);
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
             None
         } else {
             const SIZE_OF_V: u64 = __size_of::<V>();
 
-            let len_in_bytes = len * SIZE_OF_V;
-            let new_len_in_bytes = len_in_bytes - SIZE_OF_V;
+            // 1. Read the last element from its chunk slot before decrementing the length.
+            let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len - 1);
+            let last_element = read_slot::<V>(elem_slot, elem_offset);
 
-            // 1. Get the current slot content.
-            let content_ptr = alloc_bytes(len_in_bytes);
-            let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
+            // 2. Decrement the length header in slot 0. The last element's bytes remain in the
+            //    slot as residual but are logically removed; they will be overwritten on the next push.
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
 
-            // 2. Truncate the slot content.
-            // Not that if the `new_len_in_bytes` is zero, the slot will still
-            // remain occupied but with an empty content. This fits the semantic
-            // of the empty `StorageVec` so there is no need for an additional
-            // check for zero and clearing the slot as a special case.
-            __state_store_slot(self.field_id(), content_ptr, new_len_in_bytes);
-
-            // 3. Return the last element.
-            Some(content_ptr.add::<u8>(new_len_in_bytes).read::<V>())
+            last_element
         }
     }
 
@@ -1372,11 +1454,11 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// ## When `V` is a Non-storage Type
     ///
-    /// * Preloads: `1` (to get the vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// ## When `V` is a Nested Storage Type
     ///
-    /// * Reads: `1`    (to get the vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// # Examples
     ///
@@ -1404,19 +1486,19 @@ impl<V> StorageKey<StorageVec<V>> {
 
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
-        let (offset, field_id) = if STORES_STORAGE_TYPE {
+        let (field_id, offset) = if STORES_STORAGE_TYPE {
             // For nested storage types, we want to use a unique `field_id`
             // set to `sha256((index, self.field_id())` to ensure every
             // nested storage type element will use it and store its content
             // in a different slot.
-            (0, sha256((index, self.field_id())))
+            (sha256((index, self.field_id())), 0)
         } else {
-            // For non-zero-sized types, we know that their values are
-            // stored in the `self.field_id()` slot.
-            (index * __size_of::<V>(), self.field_id())
+            // For non-zero-sized types, their values are stored across chunk slots.
+            // `get_slot_and_offset_of_elem` computes the exact slot and byte offset.
+            self.get_slot_and_offset_of_elem(index)
         };
 
-        Some(StorageKey::<V>::new(self.field_id(), offset, field_id))
+        Some(StorageKey::<V>::new(field_id, offset, field_id))
     }
 
     /// Removes the element at the given `index` and moves all the elements at the following indices
@@ -1425,6 +1507,9 @@ impl<V> StorageKey<StorageVec<V>> {
     /// # Additional Information
     ///
     /// **This method is not supported for nested storage types and will panic if `V` is a nested storage type.**
+    ///
+    /// The residual bytes of the original last element remain in its chunk slot but are logically
+    /// removed and will be overwritten by future `push` calls.
     ///
     /// # Arguments
     ///
@@ -1441,9 +1526,27 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get vector's length)
-    /// * Loads: `1` (to read current slot content)
-    /// * Writes: `1` (to write truncated content)
+    /// Shifting operates slot-by-slot using a single storage read per affected slot,
+    /// so accesses scale with the number of chunk slots containing elements to shift,
+    /// not with `len - index`.
+    ///
+    /// Let `k = floor((len - 1) / elems_per_slot) - floor(index / elems_per_slot)` be
+    /// the number of chunk slots that follow the removed element's slot, where
+    /// `elems_per_slot = CHUNK_MAX_SIZE / size_of::<V>()`.
+    ///
+    /// * Reads: `2`          (vector's length and removed element)
+    /// * Reads: at most `1`  (tail of the removed element's slot for the intra-slot shift;
+    ///                        skipped when the removed element is the last in its slot)
+    /// * Reads: `k`          (one read per subsequent slot, loading all its elements at once)
+    /// * Writes: at most `1` (shifted tail written back; paired with the read above)
+    /// * Writes: `k`         (first element of each subsequent slot promoted to the freed
+    ///                        tail position of the previous slot)
+    /// * Writes: at most `k` (remaining elements of each subsequent slot shifted left;
+    ///                        skipped when the slot has only one element)
+    /// * Writes: `1`         (vector's length)
+    ///
+    /// Total: at most `3k + 4` storage operations,
+    /// where `k ≤ ceil((len - index) / elems_per_slot) - 1`.
     ///
     /// # Examples
     ///
@@ -1463,19 +1566,18 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert(storage.vec.len() == 2);
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn remove(self, index: u64) -> V {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // This workaround for satisfying the `#[storage]` attribute
             // is explained in the comment above this `StorageVec` impl.
+            let _ = __state_preload(b256::zero());
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
-            const SIZE_OF_V: u64 = __size_of::<V>();
-
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
+            let len = self.len();
 
             if index >= len {
                 panic StorageVecError::IndexOutOfBounds(OutOfBounds {
@@ -1484,37 +1586,96 @@ impl<V> StorageKey<StorageVec<V>> {
                 });
             }
 
-            let len_in_bytes = len * SIZE_OF_V;
-            let index_offset = index * SIZE_OF_V;
-            let new_len_in_bytes = len_in_bytes - SIZE_OF_V;
+            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+            const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
 
-            // 1. Read current slot content.
-            let content_ptr = alloc_bytes(len_in_bytes);
-            let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
+            let removed_chunk = index / ELEMS_PER_SLOT;
+            let last_chunk = (len - 1) / ELEMS_PER_SLOT;
 
-            // 2. Read the element to be removed before overriding the content.
-            let removed_element = content_ptr.add::<u8>(index_offset).read::<V>();
+            // Slot 0's element area starts at byte 8 (after the length header);
+            // all other slots' element areas start at byte 0.
+            let removed_slot_elem_start: u64 = if removed_chunk == 0 { 8 } else { 0 };
 
-            // 3. Shift everything after `index` one element to the left.
-            let content_after_removed_len = len_in_bytes - index_offset - SIZE_OF_V;
-            if content_after_removed_len > 0 {
-                // We first have to copy the trailing content to a new location,
-                // because memory copying requires non-overlapping memory locations.
-                let content_after_removed_ptr = alloc_bytes(content_after_removed_len);
-                content_ptr
-                    .add::<u8>(index_offset + SIZE_OF_V)
-                    .copy_bytes_to(content_after_removed_ptr, content_after_removed_len);
+            let (removed_slot, removed_offset) = self.get_slot_and_offset_of_elem(index);
 
-                // Finally, copy the copy of the trailing content back into the original content.
-                content_after_removed_ptr.copy_bytes_to(
-                    content_ptr
-                        .add::<u8>(index_offset),
-                    content_after_removed_len,
-                );
+            // Allocate one reusable buffer large enough for `ELEMS_PER_SLOT` elements.
+            // This buffer will be used for all storage reads:
+            //  - intra-slot left shifts of remaining elements
+            //  - cross-slot element transfers
+            //  - reading the removed element
+            //
+            // Note that, if we are removing the last element, there will be no shifts and no cross-slot transfers,
+            // so we would only need a buffer of one element size.
+            // Similarly, if we are removing an element from the last chunk, we only need to shift the remaining
+            // elements in that chunk, so we only need a buffer for those remaining elements.
+            //
+            // But considering the cost of `aloc` compared to the cost of extra `if` checks and
+            // additional arithmetic, it is gas and bytecode size cheaper to just always allocate the buffer
+            // for the worst case of shifting a full slot.
+            let buf = alloc_bytes(ELEMS_PER_SLOT * SIZE_OF_V);
+
+            // 1. Read the removed element.
+            let _ = __state_load_slot(removed_slot, buf, removed_offset, SIZE_OF_V);
+            let removed_element = buf.read::<V>();
+
+            // 2. Shift the elements that follow the removed element within its slot one
+            //    position to the left.
+            let end_of_removed_slot_data: u64 = removed_slot_elem_start + if removed_chunk < last_chunk {
+                // Full slot.
+                ELEMS_PER_SLOT * SIZE_OF_V
+            } else {
+                // Partial last slot: only the elements that actually exist.
+                (len - removed_chunk * ELEMS_PER_SLOT) * SIZE_OF_V
+            };
+            let bytes_after_removed = end_of_removed_slot_data - (removed_offset + SIZE_OF_V);
+            if bytes_after_removed > 0 {
+                let _ = __state_load_slot(removed_slot, buf, removed_offset + SIZE_OF_V, bytes_after_removed);
+                __state_update_slot(removed_slot, buf, removed_offset, bytes_after_removed);
             }
 
-            // 4. Write new content without the removed element to storage.
-            __state_store_slot(self.field_id(), content_ptr, new_len_in_bytes);
+            // 3. For each slot that comes after the removed slot:
+            //      a. Move its first element into the freed tail position of the previous slot.
+            //      b. Shift its remaining elements one position to the left within the slot.
+            //
+            // The byte offset of the "last element position" in the previous slot:
+            // for the first iteration the previous slot is `removed_slot`, so its element
+            // area starts at `removed_slot_elem_start`; for all later iterations the previous
+            // slot has chunk >= 1, so its element area starts at 0.
+            let mut prev_slot = removed_slot;
+            let mut prev_slot_last_elem_offset = removed_slot_elem_start + (ELEMS_PER_SLOT - 1) * SIZE_OF_V;
+            let mut chunk = removed_chunk + 1;
+            while chunk <= last_chunk {
+                let mut cur_slot = self.field_id();
+                add_u64_to_b256(cur_slot, chunk);
+
+                let elems_in_cur_slot: u64 = if chunk < last_chunk {
+                    ELEMS_PER_SLOT
+                } else {
+                    len - chunk * ELEMS_PER_SLOT
+                };
+
+                // a. Load all the elements contained in the current slot.
+                let _ = __state_load_slot(cur_slot, buf, 0, elems_in_cur_slot * SIZE_OF_V);
+
+                // b. Move the first element of cur_slot into the freed tail of prev_slot.
+                __state_update_slot(prev_slot, buf, prev_slot_last_elem_offset, SIZE_OF_V);
+
+                // c. Shift the remaining elements of cur_slot one position to the left.
+                let remaining_bytes = (elems_in_cur_slot - 1) * SIZE_OF_V;
+                if remaining_bytes > 0 {
+                    __state_update_slot(cur_slot, buf.add::<u8>(SIZE_OF_V), 0, remaining_bytes);
+                }
+
+                prev_slot = cur_slot;
+                // All slots with chunk >= 1 have their element area starting at byte 0,
+                // so the last-element offset for every subsequent previous slot is the same.
+                prev_slot_last_elem_offset = (ELEMS_PER_SLOT - 1) * SIZE_OF_V;
+                chunk += 1;
+            }
+
+            // 4. Update the length header.
+            let new_len = len - 1;
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
 
             removed_element
         }
@@ -1528,6 +1689,9 @@ impl<V> StorageKey<StorageVec<V>> {
     /// **This method is not supported for nested storage types and will panic if `V` is a nested storage type.**
     ///
     /// If `index` is the index of the last element, the last element will be returned and removed from the vector.
+    ///
+    /// The residual bytes of the original last element remain in its chunk slot but are logically
+    /// removed and will be overwritten by future `push` calls.
     ///
     /// # Arguments
     ///
@@ -1544,9 +1708,8 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get vector's length)
-    /// * Loads: `1` (to read current slot content)
-    /// * Writes: `1` (to write content with the last element placed at `index`, truncated by one element)
+    /// * Reads: `3`    (vector's length, element at `index`, and last element; last element read skipped if `index` is already the last)
+    /// * Writes: `2`   (element at `index` overwritten with the last element, and vector's length; element write skipped if `index` is the last)
     ///
     /// # Examples
     ///
@@ -1568,19 +1731,20 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(2, storage.vec.len()); // The last element is removed.
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn swap_remove(self, index: u64) -> V {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // This workaround for satisfying the `#[storage]` attribute
             // is explained in the comment above this `StorageVec` impl.
+            let _ = __state_preload(b256::zero());
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
             const SIZE_OF_V: u64 = __size_of::<V>();
 
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
+            let len = self.len();
 
             if index >= len {
                 panic StorageVecError::IndexOutOfBounds(OutOfBounds {
@@ -1589,25 +1753,24 @@ impl<V> StorageKey<StorageVec<V>> {
                 });
             }
 
-            let len_in_bytes = len * SIZE_OF_V;
-            let index_offset = index * SIZE_OF_V;
-            let new_len_in_bytes = len_in_bytes - SIZE_OF_V;
+            // 1. Read the element to be removed.
+            let (index_elem_slot, index_elem_offset) = self.get_slot_and_offset_of_elem(index);
+            let elem_ptr = alloc_bytes(SIZE_OF_V);
+            let _ = __state_load_slot(index_elem_slot, elem_ptr, index_elem_offset, SIZE_OF_V);
+            let removed_element = elem_ptr.read::<V>();
 
-            // 1. Read current slot content.
-            let content_ptr = alloc_bytes(len_in_bytes);
-            let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
-
-            // 2. Read the element to be replaced/removed before overriding the content.
-            let removed_element = content_ptr.add::<u8>(index_offset).read::<V>();
-
-            // 3. Overwrite element at `index` with the last element (only if `index` is not already the last).
+            // 2. Overwrite element at `index` with the last element (only if `index` is not the last).
             if index != len - 1 {
-                let last_element_ptr = content_ptr.add::<u8>(new_len_in_bytes);
-                last_element_ptr.copy_bytes_to(content_ptr.add::<u8>(index_offset), SIZE_OF_V);
+                let (last_elem_slot, last_elem_offset) = self.get_slot_and_offset_of_elem(len - 1);
+                // Reuse `elem_ptr` since `removed_element` is already copied to a local.
+                let _ = __state_load_slot(last_elem_slot, elem_ptr, last_elem_offset, SIZE_OF_V);
+                __state_update_slot(index_elem_slot, elem_ptr, index_elem_offset, SIZE_OF_V);
             }
 
-            // 4. Write new content without the last element to storage.
-            __state_store_slot(self.field_id(), content_ptr, new_len_in_bytes);
+            // 3. Update the length header.
+            // The original last element's bytes remain as residual but are logically removed.
+            let new_len = len - 1;
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
 
             removed_element
         }
@@ -1631,8 +1794,8 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get the vector's length)
-    /// * Writes: `1`
+    /// * Reads: `1`    (vector's length)
+    /// * Writes: `1`   (update the element in its chunk slot)
     ///
     /// # Examples
     ///
@@ -1652,19 +1815,21 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(15, set_value);
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn set(self, index: u64, value: V) {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // This workaround for satisfying the `#[storage]` attribute
             // is explained in the comment above this `StorageVec` impl.
+            let _ = __state_preload(b256::zero());
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
             const SIZE_OF_V: u64 = __size_of::<V>();
 
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
+            let len = self.len();
+
             if index >= len {
                 panic StorageVecError::IndexOutOfBounds(OutOfBounds {
                     length: len,
@@ -1672,13 +1837,9 @@ impl<V> StorageKey<StorageVec<V>> {
                 });
             }
 
-            __state_update_slot(
-                self
-                    .field_id(),
-                __addr_of::<V>(value),
-                index * SIZE_OF_V,
-                SIZE_OF_V,
-            );
+            // Write the value into the appropriate chunk slot at the computed byte offset.
+            let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(index);
+            __state_update_slot(elem_slot, __addr_of(value), elem_offset, SIZE_OF_V);
         }
     }
 
@@ -1704,9 +1865,29 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get vector's length)
-    /// * Loads: `0` in case of an append at the end, or `1` if inserting
-    /// * Writes: `1` in case of an append at the end, or `2` if inserting
+    /// Shifting operates slot-by-slot using a single storage read per affected slot,
+    /// so accesses scale with the number of chunk slots containing elements to shift,
+    /// not with `len - index`.
+    ///
+    /// Let `k = floor(len / elems_per_slot) - floor(index / elems_per_slot)` be
+    /// the number of chunk slots following (and including) the insert slot that
+    /// contain elements to shift, where `elems_per_slot = CHUNK_MAX_SIZE / size_of::<V>()`.
+    ///
+    /// ## When appending (`index == len`)
+    ///
+    /// * Writes: `2`   (vector's length and new element)
+    ///
+    /// ## When inserting in the middle (`index < len`)
+    ///
+    /// * Reads: `1`          (vector's length)
+    /// * Reads: `k`          (one read per affected slot, loading all its elements at once)
+    /// * Writes: `1`         (vector's length)
+    /// * Writes: `k`         (last element of each slot promoted to the first position of the next slot)
+    /// * Writes: at most `k` (remaining elements of each slot shifted right; skipped when the slot
+    ///                        has only one element, or the slot is the last and was partial)
+    /// * Writes: `1`         (new element at `index`)
+    ///
+    /// Total: at most `3k + 3` storage operations.
     ///
     /// # Examples
     ///
@@ -1728,19 +1909,19 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(15, storage.vec.get(2).unwrap().read());
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn insert(self, index: u64, value: V) {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // This workaround for satisfying the `#[storage]` attribute
             // is explained in the comment above this `StorageVec` impl.
+            let _ = __state_preload(b256::zero());
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
-            const SIZE_OF_V: u64 = __size_of::<V>();
+            let len = self.len();
 
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
             if index > len {
                 panic StorageVecError::IndexOutOfBounds(OutOfBounds {
                     length: len,
@@ -1748,36 +1929,117 @@ impl<V> StorageKey<StorageVec<V>> {
                 });
             }
 
-            if index == len {
-                append_slot(self.field_id(), value);
-            } else {
-                let len_in_bytes = len * SIZE_OF_V;
-                let index_offset = index * SIZE_OF_V;
+            // Update the length header first, before touching any elements.
+            let new_len = len + 1;
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
 
-                // 1. Get the current slot content.
-                let content_ptr = alloc_bytes(len_in_bytes);
-                let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
+            // Compute the insert position once; used both for shifting and for the final write.
+            let (insert_slot, insert_offset) = self.get_slot_and_offset_of_elem(index);
 
-                // 2. Write the `value` at `index`.
-                __state_update_slot(
-                    self
-                        .field_id(),
-                    __addr_of::<V>(value),
-                    index_offset,
-                    SIZE_OF_V,
-                );
+            if index < len {
+                const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+                const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
 
-                // 3. Write the previous content that should come after the inserted `value`.
-                let content_after_index_ptr = content_ptr.add::<u8>(index_offset);
-                let content_after_index_len = len_in_bytes - index_offset;
-                __state_update_slot(
-                    self
-                        .field_id(),
-                    content_after_index_ptr,
-                    index_offset + SIZE_OF_V,
-                    content_after_index_len,
-                );
+                let insert_chunk = index / ELEMS_PER_SLOT;
+                let old_last_chunk = (len - 1) / ELEMS_PER_SLOT;
+                let new_last_chunk = len / ELEMS_PER_SLOT;
+
+                // One reusable buffer large enough for a full slot's elements.
+                let buf = alloc_bytes(ELEMS_PER_SLOT * SIZE_OF_V);
+
+                if old_last_chunk > insert_chunk {
+                    // 1. Handle old_last_chunk.
+                    // Shift its elements right by 1 to make room at position 0 for the
+                    // carry element that will arrive from the preceding chunk.
+                    // old_last_chunk >= 1 (since old_last_chunk > insert_chunk >= 0),
+                    // so its element area starts at byte 0.
+                    let mut old_last_slot = self.field_id();
+                    add_u64_to_b256(old_last_slot, old_last_chunk);
+
+                    let elems_in_old_last = len - old_last_chunk * ELEMS_PER_SLOT;
+                    let _ = __state_load_slot(old_last_slot, buf, 0, elems_in_old_last * SIZE_OF_V);
+
+                    if new_last_chunk > old_last_chunk {
+                        // Sub-case A: old_last_chunk was full (elems_in_old_last == ELEMS_PER_SLOT).
+                        // Its last element overflows to the brand-new last chunk slot.
+                        let mut new_last_slot = self.field_id();
+                        add_u64_to_b256(new_last_slot, new_last_chunk);
+
+                        let remaining_bytes = (ELEMS_PER_SLOT - 1) * SIZE_OF_V;
+                        __state_store_slot(new_last_slot, buf.add::<u8>(remaining_bytes), SIZE_OF_V);
+                        if remaining_bytes > 0 {
+                            __state_update_slot(old_last_slot, buf, SIZE_OF_V, remaining_bytes);
+                        }
+                    } else {
+                        // Sub-case B: old_last_chunk was partial. All elements shift right
+                        // within the slot; position 0 is freed for the carry from the preceding chunk.
+                        __state_update_slot(old_last_slot, buf, SIZE_OF_V, elems_in_old_last * SIZE_OF_V);
+                    }
+
+                    // 2. Loop from old_last_chunk-1 down to insert_chunk+1.
+                    // Each of these chunks is full (ELEMS_PER_SLOT elements, since they precede
+                    // old_last_chunk). Load all elements, move the last to next_slot[0], shift
+                    // the rest right within the current slot.
+                    // old_last_chunk >= 1 ensures old_last_chunk - 1 does not underflow.
+                    let mut next_slot = old_last_slot;
+                    let mut chunk = old_last_chunk - 1;
+                    while chunk > insert_chunk {
+                        // chunk >= 1 (since chunk > insert_chunk >= 0),
+                        // guarantees that element area always starts at byte 0.
+                        let mut cur_slot = self.field_id();
+                        add_u64_to_b256(cur_slot, chunk);
+
+                        let _ = __state_load_slot(cur_slot, buf, 0, ELEMS_PER_SLOT * SIZE_OF_V);
+
+                        let remaining_bytes = (ELEMS_PER_SLOT - 1) * SIZE_OF_V;
+                        __state_update_slot(next_slot, buf.add::<u8>(remaining_bytes), 0, SIZE_OF_V);
+                        if remaining_bytes > 0 {
+                            __state_update_slot(cur_slot, buf, SIZE_OF_V, remaining_bytes);
+                        }
+                        next_slot = cur_slot;
+                        chunk -= 1;
+                    }
+
+                    // 3. Handle insert_chunk.
+                    // insert_chunk is full (ELEMS_PER_SLOT elements, since insert_chunk < old_last_chunk).
+                    // Load the elements from index onward, move the last to next_slot[0],
+                    // shift the rest right within insert_slot.
+                    let index_in_chunk = index % ELEMS_PER_SLOT;
+                    let elems_to_shift = ELEMS_PER_SLOT - index_in_chunk;
+                    let _ = __state_load_slot(insert_slot, buf, insert_offset, elems_to_shift * SIZE_OF_V);
+
+                    let remaining_bytes = (elems_to_shift - 1) * SIZE_OF_V;
+                    __state_update_slot(next_slot, buf.add::<u8>(remaining_bytes), 0, SIZE_OF_V);
+                    if remaining_bytes > 0 {
+                        __state_update_slot(insert_slot, buf, insert_offset + SIZE_OF_V, remaining_bytes);
+                    }
+                } else {
+                    // old_last_chunk == insert_chunk.
+                    let index_in_chunk = index % ELEMS_PER_SLOT;
+                    let elems_in_insert_chunk = len - insert_chunk * ELEMS_PER_SLOT;
+                    let elems_to_shift = elems_in_insert_chunk - index_in_chunk;
+                    let _ = __state_load_slot(insert_slot, buf, insert_offset, elems_to_shift * SIZE_OF_V);
+                    if new_last_chunk > insert_chunk {
+                        // The insert chunk was full (len is a multiple of ELEMS_PER_SLOT), so the
+                        // last element overflows into the brand-new next chunk.
+                        let mut new_last_slot = self.field_id();
+                        add_u64_to_b256(new_last_slot, new_last_chunk);
+
+                        let remaining_bytes = (elems_to_shift - 1) * SIZE_OF_V;
+                        __state_store_slot(new_last_slot, buf.add::<u8>(remaining_bytes), SIZE_OF_V);
+                        if remaining_bytes > 0 {
+                            __state_update_slot(insert_slot, buf, insert_offset + SIZE_OF_V, remaining_bytes);
+                        }
+                    } else {
+                        // The insert chunk was partial; all elements stay within insert_slot.
+                        __state_update_slot(insert_slot, buf, insert_offset + SIZE_OF_V, elems_to_shift * SIZE_OF_V);
+                    }
+                }
             }
+
+            // Write the new value at the insert position.
+            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+            __state_update_slot(insert_slot, __addr_of(value), insert_offset, SIZE_OF_V);
         }
     }
 
@@ -1791,11 +2053,11 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// ## When `V` is a Non-storage Type
     ///
-    /// * Preloads: `1` (to get the vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// ## When `V` is a Nested Storage Type
     ///
-    /// * Reads: `1`    (to get the vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// # Examples
     ///
@@ -1816,13 +2078,10 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read)]
     pub fn len(self) -> u64 {
-        const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
-
-        if STORES_STORAGE_TYPE {
-            read_slot::<u64>(self.field_id(), 0).unwrap_or(0)
-        } else {
-            __state_preload(self.field_id()) / __size_of::<V>()
-        }
+        // The length is stored as a `u64` at byte offset 0 in slot 0 (`self.field_id()`).
+        // `__state_load_word` with offset 0 reads the first word (8 bytes) of the slot.
+        // If the slot was never written, it returns 0, which correctly represents an empty vector.
+        __state_load_word(self.field_id(), 0)
     }
 
     /// Returns true if the vector is empty, otherwise false.
@@ -1835,11 +2094,11 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// ## When `V` is a Non-storage Type
     ///
-    /// * Preloads: `1` (to get the vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// ## When `V` is a Nested Storage Type
     ///
-    /// * Reads: `1`    (to get the vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// # Examples
     ///
@@ -1870,7 +2129,7 @@ impl<V> StorageKey<StorageVec<V>> {
     /// **This method is not supported for nested storage types and will panic if `V` is a nested storage type.**
     ///
     /// If `element1_index` and `element2_index` are equal, this method does not read from or write into the storage,
-    /// aside from preloading the vectors length.
+    /// aside from reading the vector's length.
     ///
     /// # Arguments
     ///
@@ -1884,9 +2143,8 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get the vector's length)
-    /// * Loads: `1` (to read current slot content when the indices differ)
-    /// * Writes: `1` (to write the swapped content when the indices differ)
+    /// * Reads: `3`    (vector's length and the two elements; element reads skipped if the indices are equal)
+    /// * Writes: `2`   (the swapped elements; skipped if the indices are equal)
     ///
     /// # Examples
     ///
@@ -1908,19 +2166,20 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(5, storage.vec.get(2).unwrap().read());
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn swap(self, element1_index: u64, element2_index: u64) {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // This workaround for satisfying the `#[storage]` attribute
             // is explained in the comment above this `StorageVec` impl.
+            let _ = __state_preload(b256::zero());
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
             const SIZE_OF_V: u64 = __size_of::<V>();
 
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
+            let len = self.len();
 
             if element1_index >= len {
                 panic StorageVecError::IndexOutOfBounds(OutOfBounds {
@@ -1940,25 +2199,17 @@ impl<V> StorageKey<StorageVec<V>> {
                 return;
             }
 
-            let len_in_bytes = len * SIZE_OF_V;
-            let element1_offset = element1_index * SIZE_OF_V;
-            let element2_offset = element2_index * SIZE_OF_V;
+            let (slot1, offset1) = self.get_slot_and_offset_of_elem(element1_index);
+            let (slot2, offset2) = self.get_slot_and_offset_of_elem(element2_index);
 
-            let content_ptr = alloc_bytes(len_in_bytes);
-            let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
+            let elem1_ptr = alloc_bytes(SIZE_OF_V);
+            let _ = __state_load_slot(slot1, elem1_ptr, offset1, SIZE_OF_V);
 
-            // Copy first element to a temporary.
-            let element1_value_ptr = alloc_bytes(SIZE_OF_V);
-            content_ptr
-                .add::<u8>(element1_offset)
-                .copy_bytes_to(element1_value_ptr, SIZE_OF_V);
+            let elem2_ptr = alloc_bytes(SIZE_OF_V);
+            let _ = __state_load_slot(slot2, elem2_ptr, offset2, SIZE_OF_V);
 
-            content_ptr
-                .add::<u8>(element2_offset)
-                .copy_bytes_to(content_ptr.add::<u8>(element1_offset), SIZE_OF_V);
-            element1_value_ptr.copy_bytes_to(content_ptr.add::<u8>(element2_offset), SIZE_OF_V);
-
-            __state_store_slot(self.field_id(), content_ptr, len_in_bytes);
+            __state_update_slot(slot1, elem2_ptr, offset1, SIZE_OF_V);
+            __state_update_slot(slot2, elem1_ptr, offset2, SIZE_OF_V);
         }
     }
 
@@ -1971,7 +2222,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Reads: `1` (to get vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// # Examples
     ///
@@ -1996,19 +2247,18 @@ impl<V> StorageKey<StorageVec<V>> {
 
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
-        let field_id = if STORES_STORAGE_TYPE {
+        let (slot, offset, field_id) = if STORES_STORAGE_TYPE {
             // Nested storage types are stored at a unique `field_id`
-            // set to `sha256((<index>, self.field_id())` to ensure every
+            // set to `sha256((0, self.field_id())` to ensure every
             // nested storage type element will use it and store its content
-            // in a different slot.
-            sha256((0, self.field_id()))
+            // in a different slot. The offset within that dedicated slot is 0.
+            (self.field_id(), 0, sha256((0, self.field_id())))
         } else {
-            // For non-zero-sized types, their values are
-            // stored in the `self.field_id()` slot.
-            self.field_id()
+            // Element 0 is always in slot 0 at byte offset 8 (after the length header).
+            (self.field_id(), 8, self.field_id())
         };
 
-        Some(StorageKey::<V>::new(self.field_id(), 0, field_id))
+        Some(StorageKey::<V>::new(slot, offset, field_id))
     }
 
     /// Returns the last element of the vector, or `None` if it is empty.
@@ -2020,7 +2270,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Reads: `1` (to get vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// # Examples
     ///
@@ -2046,19 +2296,16 @@ impl<V> StorageKey<StorageVec<V>> {
 
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
-        let (offset, field_id) = if STORES_STORAGE_TYPE {
+        let (slot, offset, field_id) = if STORES_STORAGE_TYPE {
             // Nested storage types are stored at a unique `field_id`
-            // set to `sha256((<index>, self.field_id())` to ensure every
-            // nested storage type element will use it and store its content
-            // in a different slot.
-            (0, sha256((len - 1, self.field_id())))
+            // set to `sha256((len - 1, self.field_id())`.
+            (self.field_id(), 0, sha256((len - 1, self.field_id())))
         } else {
-            // For non-zero-sized types, their values are
-            // stored in the `self.field_id()` slot.
-            ((len - 1) * __size_of::<V>(), self.field_id())
+            let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len - 1);
+            (elem_slot, elem_offset, elem_slot)
         };
 
-        Some(StorageKey::<V>::new(self.field_id(), offset, field_id))
+        Some(StorageKey::<V>::new(slot, offset, field_id))
     }
 
     /// Reverses the order of elements in the vector, in place.
@@ -2073,9 +2320,17 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get vector's length)
-    /// * Loads: `1` when `self.len() >= 2`, otherwise `0`
-    /// * Writes: `1` when `self.len() >= 2`, otherwise `0`
+    /// * Reads: `1`    (vector's length)
+    ///
+    /// When all elements fit in the first chunk slot (i.e. `len <= elems_per_slot`,
+    /// where `elems_per_slot = CHUNK_MAX_SIZE / size_of::<V>()`):
+    ///
+    /// * Reads: `1`    (load the entire element area)
+    /// * Writes: `1`   (write the reversed element area back)
+    ///
+    /// Otherwise:
+    ///
+    /// * Reads + Writes: `2 * floor(len / 2)` (one read and one write per element in each swapped pair)
     ///
     /// # Examples
     ///
@@ -2096,52 +2351,71 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(5, storage.vec.get(2).unwrap().read());
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn reverse(self) {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // This workaround for satisfying the `#[storage]` attribute
             // is explained in the comment above this `StorageVec` impl.
+            let _ = __state_preload(b256::zero());
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
             const SIZE_OF_V: u64 = __size_of::<V>();
+            const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
 
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
+            let len = self.len();
 
             if len < 2 {
                 return;
             }
 
-            let len_in_bytes = len * SIZE_OF_V;
-            let content_ptr = alloc_bytes(len_in_bytes);
-            let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
+            if len <= ELEMS_PER_SLOT {
+                // All elements live in slot 0 (element area starts at byte 8).
+                // Load the whole area, reverse it in memory, write it back in one shot.
+                let slot = self.field_id();
+                let elem_bytes = len * SIZE_OF_V;
+                let buf = alloc_bytes(elem_bytes);
+                let temp = alloc_bytes(SIZE_OF_V);
+                let _ = __state_load_slot(slot, buf, 8, elem_bytes);
 
-            // Allocate a temporary for swaps.
-            let tmp_ptr = alloc_bytes(SIZE_OF_V);
+                // Reverse in memory: swap element pairs from the outside in.
+                let mut left = 0u64;
+                let mut right = len - 1;
+                while left < right {
+                    let left_ptr = buf.add::<u8>(left * SIZE_OF_V);
+                    let right_ptr = buf.add::<u8>(right * SIZE_OF_V);
+                    left_ptr.copy_to::<u8>(temp, SIZE_OF_V);
+                    right_ptr.copy_to::<u8>(left_ptr, SIZE_OF_V);
+                    temp.copy_to::<u8>(right_ptr, SIZE_OF_V);
+                    left += 1;
+                    right -= 1;
+                }
 
-            let mid = len / 2;
-            let mut i = 0;
-            while i < mid {
-                let left_offset = i * SIZE_OF_V;
-                let right_offset = (len - i - 1) * SIZE_OF_V;
+                __state_update_slot(slot, buf, 8, elem_bytes);
+            } else {
+                // Elements span multiple slots: swap element pairs one by one.
+                let left_ptr = alloc_bytes(SIZE_OF_V);
+                let right_ptr = alloc_bytes(SIZE_OF_V);
 
-                // tmp <- left.
-                content_ptr.add::<u8>(left_offset).copy_bytes_to(tmp_ptr, SIZE_OF_V);
+                let mid = len / 2;
+                let mut i = 0;
+                while i < mid {
+                    let j = len - i - 1;
 
-                // right -> left.
-                content_ptr
-                    .add::<u8>(right_offset)
-                    .copy_bytes_to(content_ptr.add::<u8>(left_offset), SIZE_OF_V);
+                    let (left_slot, left_offset) = self.get_slot_and_offset_of_elem(i);
+                    let (right_slot, right_offset) = self.get_slot_and_offset_of_elem(j);
 
-                // tmp -> right.
-                tmp_ptr.copy_bytes_to(content_ptr.add::<u8>(right_offset), SIZE_OF_V);
+                    let _ = __state_load_slot(left_slot, left_ptr, left_offset, SIZE_OF_V);
+                    let _ = __state_load_slot(right_slot, right_ptr, right_offset, SIZE_OF_V);
 
-                i += 1;
+                    __state_update_slot(left_slot, right_ptr, left_offset, SIZE_OF_V);
+                    __state_update_slot(right_slot, left_ptr, right_offset, SIZE_OF_V);
+
+                    i += 1;
+                }
             }
-
-            __state_store_slot(self.field_id(), content_ptr, len_in_bytes);
         }
     }
 
@@ -2161,8 +2435,11 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get vector's length)
-    /// * Writes: `1` if `self.len() > 0`, otherwise `0`
+    /// Let `N = ceil(len / elems_per_slot)` be the number of chunk slots in use, where
+    /// `elems_per_slot = CHUNK_MAX_SIZE / size_of::<V>()`.
+    ///
+    /// * Reads: `1`    (vector's length)
+    /// * Writes: `N`   (one write per chunk slot)
     ///
     /// # Examples
     ///
@@ -2175,7 +2452,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(5);
     ///     storage.vec.push(10);
     ///     storage.vec.push(15);
-
+    ///
     ///     storage.vec.fill(20);
     ///
     ///     assert_eq(20, storage.vec.get(0).unwrap().read());
@@ -2183,36 +2460,67 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(20, storage.vec.get(2).unwrap().read());
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn fill(self, value: V) {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         if STORES_STORAGE_TYPE {
             // This workaround for satisfying the `#[storage]` attribute
             // is explained in the comment above this `StorageVec` impl.
+            let _ = __state_preload(b256::zero());
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
             const SIZE_OF_V: u64 = __size_of::<V>();
+            const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
 
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
+            let len = self.len();
 
             if len == 0 {
                 return;
             }
 
-            let len_in_bytes = len * SIZE_OF_V;
-            let content_ptr = alloc_bytes(len_in_bytes);
+            let last_chunk = (len - 1) / ELEMS_PER_SLOT;
 
-            let value_ptr = __addr_of::<V>(value);
-
-            let mut i = 0;
-            while i < len {
-                value_ptr.copy_bytes_to(content_ptr.add::<u8>(i * SIZE_OF_V), SIZE_OF_V);
+            // Build a full-slot buffer filled with `value` repeated ELEMS_PER_SLOT times.
+            // This lets us write each chunk slot in a single call.
+            let buf = alloc_bytes(ELEMS_PER_SLOT * SIZE_OF_V);
+            let value_ptr = __addr_of(value);
+            let mut i = 0u64;
+            while i < ELEMS_PER_SLOT {
+                value_ptr.copy_to::<u8>(buf.add::<u8>(i * SIZE_OF_V), SIZE_OF_V);
                 i += 1;
             }
 
-            __state_store_slot(self.field_id(), content_ptr, len_in_bytes);
+            // Chunk 0: element area starts at byte 8 (after the length header), so we
+            // must use __state_update_slot to avoid clobbering the header.
+            // If chunk 0 is also the last chunk, write only the elements that exist.
+            let elems_in_chunk0: u64 = if last_chunk == 0 {
+                len
+            } else {
+                ELEMS_PER_SLOT
+            };
+            __state_update_slot(self.field_id(), buf, 8, elems_in_chunk0 * SIZE_OF_V);
+
+            if last_chunk > 0 {
+                // Chunks 1 through last_chunk-1 (if any):
+                // all are full, so we can write them in a single call each.
+                let mut chunk = 1u64;
+                while chunk < last_chunk {
+                    let mut slot = self.field_id();
+                    add_u64_to_b256(slot, chunk);
+
+                    __state_store_slot(slot, buf, ELEMS_PER_SLOT * SIZE_OF_V);
+                    chunk += 1;
+                }
+
+                // Last chunk: may be partial.
+                let mut last_slot = self.field_id();
+                add_u64_to_b256(last_slot, last_chunk);
+
+                let elems_in_last = len - last_chunk * ELEMS_PER_SLOT;
+                __state_store_slot(last_slot, buf, elems_in_last * SIZE_OF_V);
+            }
         }
     }
 
@@ -2228,6 +2536,9 @@ impl<V> StorageKey<StorageVec<V>> {
     /// `resize` will reduce the vector length and remove the remaining elements _from the vector_,
     /// but the nested content of those removed elements will remain in the storage.**
     ///
+    /// When shrinking, the residual bytes of removed elements remain in their chunk slots but are
+    /// logically non-existent and will be overwritten by future `push`/`resize` calls.
+    ///
     /// # Arguments
     ///
     /// * `new_len`: [u64] - The new length to expand or truncate to.
@@ -2237,9 +2548,15 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// ## When `V` is a Non-storage Type
     ///
-    /// * Preloads: `1` (to get vector's length)
-    /// * Loads: `1` when `new_len < len`, or when `new_len > len && len > 0`; otherwise `0`
-    /// * Writes: `1` when `new_len != len`; otherwise `0`
+    /// ### When shrinking (`new_len < len`) or unchanged (`new_len == len`)
+    ///
+    /// * Reads: `1`    (vector's length)
+    /// * Writes: `1`   (vector's length)
+    ///
+    /// ### When growing (`new_len > len`)
+    ///
+    /// * Reads: `1`    (vector's length)
+    /// * Writes: up to `new_len - len + 1`   (vector's length and one write per new element)
     ///
     /// ## When `V` is a Nested Storage Type
     ///
@@ -2271,7 +2588,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     assert_eq(None, storage.vec.get(3));
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     pub fn resize(self, new_len: u64, value: V) {
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
@@ -2279,47 +2596,43 @@ impl<V> StorageKey<StorageVec<V>> {
             // For nested storage types, we only adjust the length.
             // The eventual existing content of the nested storage types
             // is not touched, matching the behavior of `push` and `pop`.
-            write_slot(self.field_id(), new_len);
+            // Add a dummy preload to satisfy the `#[storage(read, write)]` attribute
+            // for this branch (see the comment above this `StorageVec` impl).
+            let _ = __state_preload(b256::zero());
+            __state_store_slot(self.field_id(), __addr_of(new_len), 8);
         } else {
             const SIZE_OF_V: u64 = __size_of::<V>();
 
-            let len = __state_preload(self.field_id()) / SIZE_OF_V;
+            let len = self.len();
 
-            if new_len == len {
-                return;
-            }
+            // Update the length header first, before writing any new elements.
+            //
+            // We must update the length header (the first 8 bytes of slot 0) **before**
+            // writing new elements. If slot 0 was previously unused, `__state_update_slot`
+            // requires the offset to be within the currently used size. Writing the length
+            // first establishes those 8 bytes so subsequent element writes are valid.
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
 
-            let len_in_bytes = len * SIZE_OF_V;
-            let new_len_in_bytes = new_len * SIZE_OF_V;
-
-            let content_ptr = alloc_bytes(new_len_in_bytes);
-
-            if new_len < len {
-                // Truncation keeps the prefix and drops the tail.
-                // We need to load only the prefix part, `new_len_in_bytes`.
-                let _ = __state_load_slot(self.field_id(), content_ptr, 0, new_len_in_bytes);
-            } else {
-                // Growth keeps existing content and fills the tail in-memory before the write.
-                // We need to load all the existing content, `len_in_bytes`.
-                if len_in_bytes > 0 {
-                    let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
-                }
-
-                let value_ptr = __addr_of::<V>(value);
+            if new_len > len {
+                // Growing: write the `value` into each newly added element position.
                 let mut i = len;
                 while i < new_len {
-                    value_ptr.copy_bytes_to(content_ptr.add::<u8>(i * SIZE_OF_V), SIZE_OF_V);
+                    let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(i);
+                    __state_update_slot(elem_slot, __addr_of(value), elem_offset, SIZE_OF_V);
                     i += 1;
                 }
             }
-
-            __state_store_slot(self.field_id(), content_ptr, new_len_in_bytes);
+            // If shrinking, only the length header update (done above) is needed.
+            // Residual bytes of removed elements remain in their chunk slots but are
+            // logically non-existent and will be overwritten on the next push/resize.
         }
     }
 
     /// Stores given `vec` as a `StorageVec`.
     ///
     /// # Additional Information
+    ///
+    /// This will overwrite any existing values in the `StorageVec`.
     ///
     /// **This method is not supported for nested storage types and will panic if `V` is a nested storage type.**
     ///
@@ -2333,7 +2646,12 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Writes: `1`
+    /// Elements are written to chunk slots in bulk. Every slot holds at most
+    /// `CHUNK_MAX_SIZE / size_of::<V>()` elements. The first slot additionally stores the
+    /// vector's length before the element area.
+    ///
+    /// * Writes: `ceil(len / (CHUNK_MAX_SIZE / size_of::<V>()))` slots
+    ///   (at least 1 even when `len == 0`, because the vector's length is always written)
     ///
     /// # Examples
     ///
@@ -2365,8 +2683,54 @@ impl<V> StorageKey<StorageVec<V>> {
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
-            let (ptr, len) = vec.as_raw_slice().into_parts();
-            __state_store_slot(self.field_id(), ptr, len);
+
+            let len = vec.len();
+
+            // Write the length header first so that subsequent `__state_update_slot` calls
+            // targeting slot 0 at offset ≥ 8 have a valid base.
+            __state_update_slot(self.field_id(), __addr_of(len), 0, 8);
+
+            if len == 0 {
+                return;
+            }
+
+            let (elements_ptr, elements_bytes) = vec.as_raw_slice().into_parts();
+
+            // Every slot holds the same number of elements. The element area of each
+            // slot is CHUNK_MAX_SIZE bytes, so `slot_elem_bytes` is the maximum byte
+            // count for that area. Note: `slot_elem_bytes <= CHUNK_MAX_SIZE` always,
+            // since we floor-divide then multiply back.
+            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+            const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
+            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
+
+            if elements_bytes <= SLOT_ELEM_BYTES {
+                // All elements fit in the first slot (after the 8-byte header).
+                __state_update_slot(self.field_id(), elements_ptr, 8, elements_bytes);
+            } else {
+                // Write the first slot's full element area into slot 0 (at byte offset 8).
+                __state_update_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES);
+
+                // Write the remaining elements into subsequent chunk slots.
+                let mut bytes_written = SLOT_ELEM_BYTES;
+                let mut chunk_number: u64 = 1;
+                while bytes_written < elements_bytes {
+                    let remaining_bytes = elements_bytes - bytes_written;
+                    let chunk_bytes = if remaining_bytes > SLOT_ELEM_BYTES {
+                        SLOT_ELEM_BYTES
+                    } else {
+                        remaining_bytes
+                    };
+
+                    let mut chunk_slot = self.field_id();
+                    add_u64_to_b256(chunk_slot, chunk_number);
+
+                    __state_store_slot(chunk_slot, elements_ptr.add::<u8>(bytes_written), chunk_bytes);
+
+                    bytes_written += chunk_bytes;
+                    chunk_number += 1;
+                }
+            }
         }
     }
 
@@ -2386,8 +2750,9 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// * Preloads: `1` (to get vector's length)
-    /// * Reads: `1`
+    /// * Reads: `1 + ceil(len / (CHUNK_MAX_SIZE / size_of::<V>()))`
+    ///   (one for the vector's length, plus one per chunk slot with element data;
+    ///    element reads skipped when the vector is empty)
     ///
     /// # Examples
     ///
@@ -2421,14 +2786,48 @@ impl<V> StorageKey<StorageVec<V>> {
             let _ = __state_preload(self.field_id());
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
-            let len_in_bytes = __state_preload(self.field_id());
-            if len_in_bytes == 0 {
-                Vec::new()
-            } else {
-                let content_ptr = alloc_bytes(len_in_bytes);
-                let _ = __state_load_slot(self.field_id(), content_ptr, 0, len_in_bytes);
-                Vec::from(raw_slice::from_parts::<V>(content_ptr, len_in_bytes / __size_of::<V>()))
+            let len = self.len();
+
+            if len == 0 {
+                return Vec::new();
             }
+
+            // Every slot holds the same number of elements (same calculation as in `store_vec`).
+            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+            const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
+            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
+
+            let elements_bytes = len * SIZE_OF_V;
+            let elements_ptr = alloc_bytes(elements_bytes);
+
+            if elements_bytes <= SLOT_ELEM_BYTES {
+                // All elements fit in the first slot (starting at byte offset 8).
+                let _ = __state_load_slot(self.field_id(), elements_ptr, 8, elements_bytes);
+            } else {
+                // Load the first slot's full element area from slot 0 (starting at byte offset 8).
+                let _ = __state_load_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES);
+
+                // Load the remaining elements from subsequent chunk slots.
+                let mut bytes_read = SLOT_ELEM_BYTES;
+                let mut chunk_number: u64 = 1;
+                while bytes_read < elements_bytes {
+                    let chunk_bytes = if elements_bytes - bytes_read > SLOT_ELEM_BYTES {
+                        SLOT_ELEM_BYTES
+                    } else {
+                        elements_bytes - bytes_read
+                    };
+
+                    let mut chunk_slot = self.field_id();
+                    add_u64_to_b256(chunk_slot, chunk_number);
+
+                    let _ = __state_load_slot(chunk_slot, elements_ptr.add::<u8>(bytes_read), 0, chunk_bytes);
+
+                    bytes_read += chunk_bytes;
+                    chunk_number += 1;
+                }
+            }
+
+            Vec::from(raw_slice::from_parts::<V>(elements_ptr, len))
         }
     }
 
@@ -2440,13 +2839,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Number of Storage Accesses
     ///
-    /// ## When `V` is a Non-storage Type
-    ///
-    /// * Preloads: `1` (to get the vector's length)
-    ///
-    /// ## When `V` is a Nested Storage Type
-    ///
-    /// * Reads: `1`    (to get the vector's length)
+    /// * Reads: `1`    (vector's length)
     ///
     /// # Examples
     ///
@@ -2496,22 +2889,30 @@ impl<V> Iterator for StorageVecIter<V> {
 
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
-        let (offset, field_id) = if STORES_STORAGE_TYPE {
-            // For nested storage types, we know that they use a unique `field_id`
-            // set to `sha256((self.index, storage_vec_field_id)` that ensurs every
-            // nested storage type element will use it and store its content
-            // in a different slot.
-            (0, sha256((self.index, storage_vec_field_id)))
+        let (slot, offset, field_id) = if STORES_STORAGE_TYPE {
+            // For nested storage types, each element has a unique `field_id`
+            // set to `sha256((index, storage_vec_field_id))` to ensure each
+            // nested storage type element stores its content in a different slot.
+            (storage_vec_field_id, 0, sha256((self.index, storage_vec_field_id)))
         } else {
-            // For non-zero-sized types, we know that their values are
-            // stored in the `self.field_id()` slot.
-            (self.index * __size_of::<V>(), storage_vec_field_id)
+            // For non-zero-sized types, values are spread across chunk slots.
+            // Compute the exact slot and byte offset via `get_slot_and_offset_of_elem`.
+            let (elem_slot, elem_offset) = self.values.get_slot_and_offset_of_elem(self.index);
+            (elem_slot, elem_offset, elem_slot)
         };
 
-        let result = Some(StorageKey::<V>::new(storage_vec_field_id, offset, field_id));
+        let result = Some(StorageKey::<V>::new(slot, offset, field_id));
 
         self.index += 1;
 
         result
+    }
+}
+
+#[cfg(experimental_dynamic_storage = true)]
+#[inline(always)]
+fn add_u64_to_b256(ref mut num: b256, val: u64) {
+    asm(num: num, val: val) {
+        wqop num num val i0;
     }
 }

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1284,7 +1284,6 @@ impl<V> StorageKey<StorageVec<V>> {
         } else {
             offset_in_slot + 8
         };
-
         (slot, offset_in_slot)
     }
 

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1490,7 +1490,8 @@ impl<V> StorageKey<StorageVec<V>> {
             // set to `sha256((index, self.field_id())` to ensure every
             // nested storage type element will use it and store its content
             // in a different slot.
-            (self.field_id(), 0, sha256((index, self.field_id())))
+            let field_id = self.field_id();
+            (field_id, 0, sha256((index, field_id)))
         } else {
             // For non-zero-sized types, their values are stored across chunk slots.
             // `get_slot_and_offset_of_elem` computes the exact slot and byte offset.
@@ -1651,8 +1652,9 @@ impl<V> StorageKey<StorageVec<V>> {
             let mut prev_slot = removed_slot;
             let mut prev_slot_last_elem_offset = removed_slot_elem_start + (ELEMS_PER_SLOT - 1) * SIZE_OF_V;
             let mut chunk = removed_chunk + 1;
+            let field_id = self.field_id();
             while chunk <= last_chunk {
-                let mut cur_slot = self.field_id();
+                let mut cur_slot = field_id;
                 add_u64_to_b256(cur_slot, chunk);
 
                 let elems_in_cur_slot: u64 = if chunk < last_chunk {
@@ -1682,7 +1684,7 @@ impl<V> StorageKey<StorageVec<V>> {
 
             // 4. Update the length header.
             let new_len = len - 1;
-            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
+            __state_update_slot(field_id, __addr_of(new_len), 0, 8);
 
             removed_element
         }
@@ -1928,6 +1930,7 @@ impl<V> StorageKey<StorageVec<V>> {
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
             let len = self.len();
+            let field_id = self.field_id();
 
             if index > len {
                 panic StorageVecError::IndexOutOfBounds(OutOfBounds {
@@ -1938,7 +1941,7 @@ impl<V> StorageKey<StorageVec<V>> {
 
             // Update the length header first, before touching any elements.
             let new_len = len + 1;
-            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
+            __state_update_slot(field_id, __addr_of(new_len), 0, 8);
 
             // Compute the insert position once; used both for shifting and for the final write.
             let (insert_slot, insert_offset) = self.get_slot_and_offset_of_elem(index);
@@ -1962,7 +1965,7 @@ impl<V> StorageKey<StorageVec<V>> {
                     // carry element that will arrive from the preceding chunk.
                     // old_last_chunk >= 1 (since old_last_chunk > insert_chunk >= 0),
                     // so its element area starts at byte 0.
-                    let mut old_last_slot = self.field_id();
+                    let mut old_last_slot = field_id;
                     add_u64_to_b256(old_last_slot, old_last_chunk);
 
                     let elems_in_old_last = len - old_last_chunk * ELEMS_PER_SLOT;
@@ -1971,7 +1974,7 @@ impl<V> StorageKey<StorageVec<V>> {
                     if new_last_chunk > old_last_chunk {
                         // Sub-case A: old_last_chunk was full (elems_in_old_last == ELEMS_PER_SLOT).
                         // Its last element overflows to the brand-new last chunk slot.
-                        let mut new_last_slot = self.field_id();
+                        let mut new_last_slot = field_id;
                         add_u64_to_b256(new_last_slot, new_last_chunk);
 
                         let remaining_bytes = (ELEMS_PER_SLOT - 1) * SIZE_OF_V;
@@ -1995,7 +1998,7 @@ impl<V> StorageKey<StorageVec<V>> {
                     while chunk > insert_chunk {
                         // chunk >= 1 (since chunk > insert_chunk >= 0),
                         // guarantees that element area always starts at byte 0.
-                        let mut cur_slot = self.field_id();
+                        let mut cur_slot = field_id;
                         add_u64_to_b256(cur_slot, chunk);
 
                         let _ = __state_load_slot(cur_slot, buf, 0, ELEMS_PER_SLOT * SIZE_OF_V);
@@ -2031,7 +2034,7 @@ impl<V> StorageKey<StorageVec<V>> {
                     if new_last_chunk > insert_chunk {
                         // The insert chunk was full (len is a multiple of ELEMS_PER_SLOT), so the
                         // last element overflows into the brand-new next chunk.
-                        let mut new_last_slot = self.field_id();
+                        let mut new_last_slot = field_id;
                         add_u64_to_b256(new_last_slot, new_last_chunk);
 
                         let remaining_bytes = (elems_to_shift - 1) * SIZE_OF_V;
@@ -2263,15 +2266,16 @@ impl<V> StorageKey<StorageVec<V>> {
 
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
+        let field_id = self.field_id();
         let (slot, offset, field_id) = if STORES_STORAGE_TYPE {
             // Nested storage types are stored at a unique `field_id`
             // set to `sha256((0, self.field_id())` to ensure every
             // nested storage type element will use it and store its content
             // in a different slot. The offset within that dedicated slot is 0.
-            (self.field_id(), 0, sha256((0, self.field_id())))
+            (field_id, 0, sha256((0, field_id)))
         } else {
             // Element 0 is always in slot 0 at byte offset 8 (after the length header).
-            (self.field_id(), 8, self.field_id())
+            (field_id, 8, field_id)
         };
 
         Some(StorageKey::<V>::new(slot, offset, field_id))
@@ -2315,7 +2319,8 @@ impl<V> StorageKey<StorageVec<V>> {
         let (slot, offset, field_id) = if STORES_STORAGE_TYPE {
             // Nested storage types are stored at a unique `field_id`
             // set to `sha256((len - 1, self.field_id())`.
-            (self.field_id(), 0, sha256((len - 1, self.field_id())))
+            let field_id = self.field_id();
+            (field_id, 0, sha256((len - 1, field_id)))
         } else {
             let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len - 1);
             (elem_slot, elem_offset, elem_slot)
@@ -2508,6 +2513,8 @@ impl<V> StorageKey<StorageVec<V>> {
                 i += 1;
             }
 
+            let field_id = self.field_id();
+
             // Chunk 0: element area starts at byte 8 (after the length header), so we
             // must use __state_update_slot to avoid clobbering the header.
             // If chunk 0 is also the last chunk, write only the elements that exist.
@@ -2516,14 +2523,14 @@ impl<V> StorageKey<StorageVec<V>> {
             } else {
                 ELEMS_PER_SLOT
             };
-            __state_update_slot(self.field_id(), buf, 8, elems_in_chunk0 * SIZE_OF_V);
+            __state_update_slot(field_id, buf, 8, elems_in_chunk0 * SIZE_OF_V);
 
             if last_chunk > 0 {
                 // Chunks 1 through last_chunk-1 (if any):
                 // all are full, so we can write them in a single call each.
                 let mut chunk = 1u64;
                 while chunk < last_chunk {
-                    let mut slot = self.field_id();
+                    let mut slot = field_id;
                     add_u64_to_b256(slot, chunk);
 
                     __state_store_slot(slot, buf, ELEMS_PER_SLOT * SIZE_OF_V);
@@ -2531,7 +2538,7 @@ impl<V> StorageKey<StorageVec<V>> {
                 }
 
                 // Last chunk: may be partial.
-                let mut last_slot = self.field_id();
+                let mut last_slot = field_id;
                 add_u64_to_b256(last_slot, last_chunk);
 
                 let elems_in_last = len - last_chunk * ELEMS_PER_SLOT;
@@ -2700,10 +2707,11 @@ impl<V> StorageKey<StorageVec<V>> {
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
             let len = vec.len();
+            let field_id = self.field_id();
 
             // Write the length header first so that subsequent `__state_update_slot` calls
             // targeting slot 0 at offset ≥ 8 have a valid base.
-            __state_update_slot(self.field_id(), __addr_of(len), 0, 8);
+            __state_update_slot(field_id, __addr_of(len), 0, 8);
 
             if len == 0 {
                 return;
@@ -2718,11 +2726,13 @@ impl<V> StorageKey<StorageVec<V>> {
 //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
             const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
-            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V; // All elements fit in the first slot (after the 8-byte header).
+            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
+
+            // All elements fit in the first slot (after the 8-byte header).
             if elements_bytes <= SLOT_ELEM_BYTES {
-                __state_update_slot(self.field_id(), elements_ptr, 8, elements_bytes);
+                __state_update_slot(field_id, elements_ptr, 8, elements_bytes);
             } else { // Write the first slot's full element area into slot 0 (at byte offset 8).
-                __state_update_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES); // Write the remaining elements into subsequent chunk slots.
+                __state_update_slot(field_id, elements_ptr, 8, SLOT_ELEM_BYTES); // Write the remaining elements into subsequent chunk slots.
                 let mut bytes_written = SLOT_ELEM_BYTES;
                 let mut chunk_number: u64 = 1;
                 while bytes_written < elements_bytes {
@@ -2733,7 +2743,7 @@ impl<V> StorageKey<StorageVec<V>> {
                         remaining_bytes
                     };
 
-                    let mut chunk_slot = self.field_id();
+                    let mut chunk_slot = field_id;
                     add_u64_to_b256(chunk_slot, chunk_number);
 
                     __state_store_slot(
@@ -2819,12 +2829,13 @@ impl<V> StorageKey<StorageVec<V>> {
             let elements_bytes = len * SIZE_OF_V;
             let elements_ptr = alloc_bytes(elements_bytes);
 
+            let field_id = self.field_id();
             if elements_bytes <= SLOT_ELEM_BYTES {
                 // All elements fit in the first slot (starting at byte offset 8).
-                let _ = __state_load_slot(self.field_id(), elements_ptr, 8, elements_bytes);
+                let _ = __state_load_slot(field_id, elements_ptr, 8, elements_bytes);
             } else {
                 // Load the first slot's full element area from slot 0 (starting at byte offset 8).
-                let _ = __state_load_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES);
+                let _ = __state_load_slot(field_id, elements_ptr, 8, SLOT_ELEM_BYTES);
 
                 // Load the remaining elements from subsequent chunk slots.
                 let mut bytes_read = SLOT_ELEM_BYTES;
@@ -2836,7 +2847,7 @@ impl<V> StorageKey<StorageVec<V>> {
                         elements_bytes - bytes_read
                     };
 
-                    let mut chunk_slot = self.field_id();
+                    let mut chunk_slot = field_id;
                     add_u64_to_b256(chunk_slot, chunk_number);
 
                     let _ = __state_load_slot(

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1586,7 +1586,9 @@ impl<V> StorageKey<StorageVec<V>> {
                 });
             }
 
-            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+            // TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
+            //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
+            const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
 
             let removed_chunk = index / ELEMS_PER_SLOT;
@@ -1937,7 +1939,9 @@ impl<V> StorageKey<StorageVec<V>> {
             let (insert_slot, insert_offset) = self.get_slot_and_offset_of_elem(index);
 
             if index < len {
-                const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+                // TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
+                //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
+                const SIZE_OF_V: u64 = __size_of::<V>();
                 const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
 
                 let insert_chunk = index / ELEMS_PER_SLOT;
@@ -2038,7 +2042,9 @@ impl<V> StorageKey<StorageVec<V>> {
             }
 
             // Write the new value at the insert position.
-            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+            // TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
+            //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
+            const SIZE_OF_V: u64 = __size_of::<V>();
             __state_update_slot(insert_slot, __addr_of(value), insert_offset, SIZE_OF_V);
         }
     }
@@ -2700,7 +2706,10 @@ impl<V> StorageKey<StorageVec<V>> {
             // slot is CHUNK_MAX_SIZE bytes, so `slot_elem_bytes` is the maximum byte
             // count for that area. Note: `slot_elem_bytes <= CHUNK_MAX_SIZE` always,
             // since we floor-divide then multiply back.
-            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+
+            // TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
+            //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
+            const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
             const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
 
@@ -2793,7 +2802,10 @@ impl<V> StorageKey<StorageVec<V>> {
             }
 
             // Every slot holds the same number of elements (same calculation as in `store_vec`).
-            const SIZE_OF_V: u64 = __size_of::<V>(); // TODO-IG!: Report this bug.
+
+            // TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
+            //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
+            const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
             const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
 

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1277,17 +1277,12 @@ impl<V> StorageKey<StorageVec<V>> {
 
         // Slot 0's element area begins at byte 8 (after the length header).
         // All other slots' element areas begin at byte 0.
-        let offset_in_slot = index_in_chunk * SIZE_OF_V + if chunk_number == 0 {
-            8
-        } else {
-            0
-        };
+        let offset_in_slot = index_in_chunk * SIZE_OF_V + if chunk_number == 0 { 8 } else { 0 };
 
         let mut slot = self.field_id();
         if chunk_number > 0 {
             add_u64_to_b256(slot, chunk_number);
         }
-
         (slot, offset_in_slot)
     }
 
@@ -1350,9 +1345,7 @@ impl<V> StorageKey<StorageVec<V>> {
             // requires the offset to be within the currently used size. Writing the length
             // first establishes those 8 bytes so subsequent updates to the same slot at
             // offset ≥ 8 are valid.
-            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
-
-            // Compute which slot and offset to write the new element.
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8); // Compute which slot and offset to write the new element.
             let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len);
             __state_update_slot(elem_slot, __addr_of(value), elem_offset, SIZE_OF_V);
         }
@@ -1631,7 +1624,12 @@ impl<V> StorageKey<StorageVec<V>> {
             };
             let bytes_after_removed = end_of_removed_slot_data - (removed_offset + SIZE_OF_V);
             if bytes_after_removed > 0 {
-                let _ = __state_load_slot(removed_slot, buf, removed_offset + SIZE_OF_V, bytes_after_removed);
+                let _ = __state_load_slot(
+                    removed_slot,
+                    buf,
+                    removed_offset + SIZE_OF_V,
+                    bytes_after_removed,
+                );
                 __state_update_slot(removed_slot, buf, removed_offset, bytes_after_removed);
             }
 
@@ -2036,7 +2034,12 @@ impl<V> StorageKey<StorageVec<V>> {
                         }
                     } else {
                         // The insert chunk was partial; all elements stay within insert_slot.
-                        __state_update_slot(insert_slot, buf, insert_offset + SIZE_OF_V, elems_to_shift * SIZE_OF_V);
+                        __state_update_slot(
+                            insert_slot,
+                            buf,
+                            insert_offset + SIZE_OF_V,
+                            elems_to_shift * SIZE_OF_V,
+                        );
                     }
                 }
             }
@@ -2689,7 +2692,6 @@ impl<V> StorageKey<StorageVec<V>> {
             let _ = __state_clear(b256::zero(), 0);
             panic StorageVecError::MethodDoesNotSupportNestedStorageTypes;
         } else {
-
             let len = vec.len();
 
             // Write the length header first so that subsequent `__state_update_slot` calls
@@ -2700,27 +2702,20 @@ impl<V> StorageKey<StorageVec<V>> {
                 return;
             }
 
-            let (elements_ptr, elements_bytes) = vec.as_raw_slice().into_parts();
+            let (elements_ptr, elements_bytes) = vec.as_raw_slice().into_parts(); // Every slot holds the same number of elements. The element area of each
+// slot is CHUNK_MAX_SIZE bytes, so `slot_elem_bytes` is the maximum byte
+// count for that area. Note: `slot_elem_bytes <= CHUNK_MAX_SIZE` always,
+// since we floor-divide then multiply back.
 
-            // Every slot holds the same number of elements. The element area of each
-            // slot is CHUNK_MAX_SIZE bytes, so `slot_elem_bytes` is the maximum byte
-            // count for that area. Note: `slot_elem_bytes <= CHUNK_MAX_SIZE` always,
-            // since we floor-divide then multiply back.
-
-            // TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
-            //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
+// TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
+//       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
             const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
-            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
-
+            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V; // All elements fit in the first slot (after the 8-byte header).
             if elements_bytes <= SLOT_ELEM_BYTES {
-                // All elements fit in the first slot (after the 8-byte header).
                 __state_update_slot(self.field_id(), elements_ptr, 8, elements_bytes);
-            } else {
-                // Write the first slot's full element area into slot 0 (at byte offset 8).
-                __state_update_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES);
-
-                // Write the remaining elements into subsequent chunk slots.
+            } else { // Write the first slot's full element area into slot 0 (at byte offset 8).
+                __state_update_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES); // Write the remaining elements into subsequent chunk slots.
                 let mut bytes_written = SLOT_ELEM_BYTES;
                 let mut chunk_number: u64 = 1;
                 while bytes_written < elements_bytes {
@@ -2734,7 +2729,12 @@ impl<V> StorageKey<StorageVec<V>> {
                     let mut chunk_slot = self.field_id();
                     add_u64_to_b256(chunk_slot, chunk_number);
 
-                    __state_store_slot(chunk_slot, elements_ptr.add::<u8>(bytes_written), chunk_bytes);
+                    __state_store_slot(
+                        chunk_slot,
+                        elements_ptr
+                            .add::<u8>(bytes_written),
+                        chunk_bytes,
+                    );
 
                     bytes_written += chunk_bytes;
                     chunk_number += 1;
@@ -2832,7 +2832,13 @@ impl<V> StorageKey<StorageVec<V>> {
                     let mut chunk_slot = self.field_id();
                     add_u64_to_b256(chunk_slot, chunk_number);
 
-                    let _ = __state_load_slot(chunk_slot, elements_ptr.add::<u8>(bytes_read), 0, chunk_bytes);
+                    let _ = __state_load_slot(
+                        chunk_slot,
+                        elements_ptr
+                            .add::<u8>(bytes_read),
+                        0,
+                        chunk_bytes,
+                    );
 
                     bytes_read += chunk_bytes;
                     chunk_number += 1;

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -2726,8 +2726,7 @@ impl<V> StorageKey<StorageVec<V>> {
 //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
             const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
-            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
-// All elements fit in the first slot (after the 8-byte header).
+            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V; // All elements fit in the first slot (after the 8-byte header).
             if elements_bytes <= SLOT_ELEM_BYTES {
                 __state_update_slot(field_id, elements_ptr, 8, elements_bytes);
             } else { // Write the first slot's full element area into slot 0 (at byte offset 8).

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1480,19 +1480,20 @@ impl<V> StorageKey<StorageVec<V>> {
 
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
-        let (field_id, offset) = if STORES_STORAGE_TYPE {
+        let (slot, offset, field_id) = if STORES_STORAGE_TYPE {
             // For nested storage types, we want to use a unique `field_id`
             // set to `sha256((index, self.field_id())` to ensure every
             // nested storage type element will use it and store its content
             // in a different slot.
-            (sha256((index, self.field_id())), 0)
+            (self.field_id(), 0, sha256((index, self.field_id())))
         } else {
             // For non-zero-sized types, their values are stored across chunk slots.
             // `get_slot_and_offset_of_elem` computes the exact slot and byte offset.
-            self.get_slot_and_offset_of_elem(index)
+            let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(index);
+            (elem_slot, elem_offset, elem_slot)
         };
 
-        Some(StorageKey::<V>::new(field_id, offset, field_id))
+        Some(StorageKey::<V>::new(slot, offset, field_id))
     }
 
     /// Removes the element at the given `index` and moves all the elements at the following indices
@@ -2904,14 +2905,13 @@ impl<V> Iterator for StorageVecIter<V> {
             return None;
         }
 
-        let storage_vec_field_id = self.values.field_id();
-
         const STORES_STORAGE_TYPE: bool = __size_of::<V>() == 0;
 
         let (slot, offset, field_id) = if STORES_STORAGE_TYPE {
             // For nested storage types, each element has a unique `field_id`
             // set to `sha256((index, storage_vec_field_id))` to ensure each
             // nested storage type element stores its content in a different slot.
+            let storage_vec_field_id = self.values.field_id();
             (storage_vec_field_id, 0, sha256((self.index, storage_vec_field_id)))
         } else {
             // For non-zero-sized types, values are spread across chunk slots.

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -2727,8 +2727,7 @@ impl<V> StorageKey<StorageVec<V>> {
             const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
             const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
-
-            // All elements fit in the first slot (after the 8-byte header).
+// All elements fit in the first slot (after the 8-byte header).
             if elements_bytes <= SLOT_ELEM_BYTES {
                 __state_update_slot(field_id, elements_ptr, 8, elements_bytes);
             } else { // Write the first slot's full element area into slot 0 (at byte offset 8).

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1273,16 +1273,18 @@ impl<V> StorageKey<StorageVec<V>> {
         const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
 
         let chunk_number = index / ELEMS_PER_SLOT;
-        let index_in_chunk = index % ELEMS_PER_SLOT;
+        let offset_in_slot = (index % ELEMS_PER_SLOT) * SIZE_OF_V;
 
         // Slot 0's element area begins at byte 8 (after the length header).
         // All other slots' element areas begin at byte 0.
-        let offset_in_slot = index_in_chunk * SIZE_OF_V + if chunk_number == 0 { 8 } else { 0 };
-
         let mut slot = self.field_id();
-        if chunk_number > 0 {
+        let offset_in_slot = if chunk_number > 0 {
             add_u64_to_b256(slot, chunk_number);
-        }
+            offset_in_slot
+        } else {
+            offset_in_slot + 8
+        };
+
         (slot, offset_in_slot)
     }
 

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -65,6 +65,11 @@ pub struct StorageVec<V> {}
 ///  - `StorageVec<StorageMap<u64, b256>>`
 ///  - `StorageMap<u64, StorageVec<b256>>`
 ///
+/// **The size of `V` must be less than or equal to 1024 bytes.**
+/// Having size of `V` be larger than 1024 bytes is considered an
+/// undefined behavior and can lead to unexpected results, most
+/// likely to run-time reverts.
+///
 /// **Some `StorageVec` methods are not supported for
 /// nested storage types and will panic if used with nested
 /// storage types.** E.g., `StorageVec<StorageString>::remove`

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/generate_storage_vec_bench.sh
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/generate_storage_vec_bench.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ALL_SIZES=(8 24 32 56 72 88 96)
-COUNTS=(10 100 1000)
+COUNTS=(10 100 1000 5000)
 OPS=(push push_n_elems_into_empty_vec pop get set first last len is_empty swap swap_remove remove insert reverse fill resize_grow resize_shrink store_vec load_vec iter clear)
 
 # ── Size → type mapping ────────────────────────────────────────────
@@ -133,6 +133,12 @@ EOF
 
     # ── test.toml ───────────────────────────────────────────────────
     echo 'category = "unit_tests_pass"' > "$project_dir/test.toml"
+
+    # ── test.dynamic_storage.toml ────────────────────────────────────
+    {
+        echo 'category = "unit_tests_pass"'
+        echo 'experimental = { new_encoding = true, dynamic_storage = true }'
+    } > "$project_dir/test.dynamic_storage.toml"
 
     # ── src/main.sw ─────────────────────────────────────────────────
     {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/generate_storage_vec_bench.sh
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/generate_storage_vec_bench.sh
@@ -41,29 +41,68 @@ needs_stored_types() {
 
 # ── Helpers ─────────────────────────────────────────────────────────
 
-# Emit the populate loop (push N elements into storage.vec)
-emit_populate() {
-    local n="$1" default="$2"
-    cat <<SWAY
-        let mut i = 0;
-        while i < ${n} {
-            storage.vec.push(${default});
-            i += 1;
-        }
+# Emit the module-level populate helper functions, one per count.
+#
+# The populate loop is factored into `#[inline(never)]` helpers so that
+# every benchmark method pays exactly the same gas for populating the
+# vector. If the loop is written out in each method instead, the
+# optimizer can compile it slightly differently in different methods
+# (e.g. inlining `push` in some of them but not in others), which makes
+# the per-count baseline subtraction in bench_storage_vec.sh attribute
+# leftover O(N) populate cost to the measured operation.
+emit_populate_helpers() {
+    local default="$1"
+    local n
+    for n in "${COUNTS[@]}"; do
+        cat <<SWAY
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n${n}() {
+    let mut i = 0;
+    while i < ${n} {
+        storage.vec.push(${default});
+        i += 1;
+    }
+}
 SWAY
+    done
 }
 
-# Emit the heap-vec build loop (build Vec<T> of N elements on the heap)
-emit_vec_build() {
-    local n="$1" default="$2" type="$3"
-    cat <<SWAY
-        let mut v = Vec::<${type}>::new();
-        let mut i = 0;
-        while i < ${n} {
-            v.push(${default});
-            i += 1;
-        }
+# Emit the module-level heap-vec build helper functions, one per count.
+# Factored into `#[inline(never)]` helpers for the same reason as the
+# populate helpers: the store_vec baseline subtraction relies on the
+# build loop costing the same in every method.
+emit_vec_build_helpers() {
+    local default="$1" type="$2"
+    local n
+    for n in "${COUNTS[@]}"; do
+        cat <<SWAY
+
+#[inline(never)]
+fn build_vec_n${n}() -> Vec<${type}> {
+    let mut v = Vec::<${type}>::new();
+    let mut i = 0;
+    while i < ${n} {
+        v.push(${default});
+        i += 1;
+    }
+    v
+}
 SWAY
+    done
+}
+
+# Emit the populate call (push N elements into storage.vec)
+emit_populate() {
+    local n="$1"
+    echo "        populate_n${n}();"
+}
+
+# Emit the heap-vec build call (build Vec<T> of N elements on the heap)
+emit_vec_build() {
+    local n="$1"
+    echo "        let v = build_vec_n${n}();"
 }
 
 # Emit the operation-specific line(s) after the populate setup
@@ -152,6 +191,8 @@ EOF
         echo "storage {"
         echo "    vec: StorageVec<${type}> = StorageVec {},"
         echo "}"
+        emit_populate_helpers "$default"
+        emit_vec_build_helpers "$default" "$type"
         echo ""
         echo "impl Contract {"
 
@@ -168,7 +209,7 @@ EOF
             echo ""
             echo "    #[storage(read, write)]"
             echo "    fn baseline_n${n}() {"
-            emit_populate "$n" "$default"
+            emit_populate "$n"
             echo "    }"
         done
 
@@ -178,7 +219,7 @@ EOF
         for n in "${COUNTS[@]}"; do
             echo ""
             echo "    fn baseline_store_vec_n${n}() {"
-            emit_vec_build "$n" "$default" "$type"
+            emit_vec_build "$n"
             echo "    }"
         done
 
@@ -191,16 +232,16 @@ EOF
                 if [[ "$op" == "store_vec" ]]; then
                     echo "    #[storage(write)]"
                     echo "    fn ${op}_n${n}() {"
-                    emit_vec_build "$n" "$default" "$type"
+                    emit_vec_build "$n"
                     echo "        storage.vec.store_vec(v);"
                 elif [[ "$op" == "push_n_elems_into_empty_vec" ]]; then
                     echo "    #[storage(read, write)]"
                     echo "    fn ${op}_n${n}() {"
-                    emit_populate "$n" "$default"
+                    emit_populate "$n"
                 else
                     echo "    #[storage(read, write)]"
                     echo "    fn ${op}_n${n}() {"
-                    emit_populate "$n" "$default"
+                    emit_populate "$n"
                     emit_op_tail "$op" "$n" "$default"
                 fi
                 echo "    }"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields/src/main.sw
@@ -486,6 +486,9 @@ fn bench_struct32_clear() {
 
 // === Struct40 (40 bytes) ===
 
+// TODO: (INIT-STORAGE) Enable the read benchmarks once we implement
+//       initialization of dynamic storage slots for types larger than 32 bytes.
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct40_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -506,6 +509,7 @@ fn bench_struct40_clear() {
 
 // === Struct48 (48 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct48_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -526,6 +530,7 @@ fn bench_struct48_clear() {
 
 // === Struct56 (56 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct56_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -546,6 +551,7 @@ fn bench_struct56_clear() {
 
 // === Struct72 (72 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct72_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -565,7 +571,7 @@ fn bench_struct72_clear() {
 }
 
 // === Struct88 (88 bytes) ===
-
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct88_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -586,6 +592,7 @@ fn bench_struct88_clear() {
 
 // === Struct96 (96 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct96_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -606,6 +613,7 @@ fn bench_struct96_clear() {
 
 // === Struct184 (184 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct184_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -626,6 +634,7 @@ fn bench_struct184_clear() {
 
 // === Struct200 (200 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct200_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -646,6 +655,7 @@ fn bench_struct200_clear() {
 
 // === Struct224 (224 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct224_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);
@@ -666,6 +676,7 @@ fn bench_struct224_clear() {
 
 // === Struct552 (552 bytes) ===
 
+#[cfg(experimental_dynamic_storage = false)]
 #[test]
 fn bench_struct552_read() {
     let caller = abi(StorageFieldsAbi, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields/test.dynamic_storage.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields/test.dynamic_storage.toml
@@ -1,0 +1,2 @@
+category = "unit_tests_pass"
+experimental = { new_encoding = true, dynamic_storage = true }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields/test.dynamic_storage.toml.disabled
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields/test.dynamic_storage.toml.disabled
@@ -1,2 +1,0 @@
-category = "unit_tests_pass" # TODO: (INIT-STORAGE) Enable this test once storage initialization is implemented. 
-experimental = { new_encoding = true, dynamic_storage = true }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields_partial_access/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields_partial_access/src/main.sw
@@ -17,514 +17,638 @@ storage {
     t_struct552: Struct552 = STRUCT552_DEFAULT,
 }
 
+// TODO: (INIT-STORAGE) Remove this method once we have a way to initialize
+//       dynamic storage slots for types larger than 32 bytes.
+#[cfg(experimental_dynamic_storage = true)]
+#[storage(write)]
+#[inline(never)]
+fn populate_storage() {
+    storage.t_struct24.write(STRUCT24_DEFAULT);
+    storage.t_struct32.write(STRUCT32_DEFAULT);
+    storage.t_struct40.write(STRUCT40_DEFAULT);
+    storage.t_struct48.write(STRUCT48_DEFAULT);
+    storage.t_struct56.write(STRUCT56_DEFAULT);
+    storage.t_struct72.write(STRUCT72_DEFAULT);
+    storage.t_struct88.write(STRUCT88_DEFAULT);
+    storage.t_struct96.write(STRUCT96_DEFAULT);
+    storage.t_struct184.write(STRUCT184_DEFAULT);
+    storage.t_struct200.write(STRUCT200_DEFAULT);
+    storage.t_struct224.write(STRUCT224_DEFAULT);
+    storage.t_struct552.write(STRUCT552_DEFAULT);
+}
+
+#[cfg(experimental_dynamic_storage = false)]
+#[storage(write)]
+#[inline(always)]
+fn populate_storage() {
+    // No-op since storage is already initialized with default values.
+    if false {
+        // Dummy write to satisfy the write access requirement.
+        let _ = __state_store_word(b256::zero(), 0);
+    }
+}
+
 impl Contract {
     // To measure the baseline cost of a contract method call.
-    fn baseline() { }
+    #[storage(write)]
+    fn baseline() {
+        populate_storage();
+    }
 
     // Struct24 { a: u64, b: u64, c: u64 }
     // Partial: u64 (8 of 24)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct24_read_u64() {
+        populate_storage();
         let _ = storage.t_struct24.b.try_read();
     }
 
     #[storage(write)]
     fn struct24_write_u64() {
+        populate_storage();
         let _ = storage.t_struct24.b.write(0);
     }
 
     // Struct32 { a: u64, b: u64, c: u64, d: u64 }
     // Partial: u64 (8 of 32)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct32_read_u64() {
+        populate_storage();
         let _ = storage.t_struct32.b.try_read();
     }
 
     #[storage(write)]
     fn struct32_write_u64() {
+        populate_storage();
         let _ = storage.t_struct32.b.write(0);
     }
 
     // Struct40 { a: u64, b: u64, c: u64, d: u64, e: u64 }
     // Partial: u64 (8 of 40)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct40_read_u64() {
+        populate_storage();
         let _ = storage.t_struct40.b.try_read();
     }
 
     #[storage(write)]
     fn struct40_write_u64() {
+        populate_storage();
         let _ = storage.t_struct40.b.write(0);
     }
 
     // Struct48 { a: Struct24, b: Struct24 }
     // Partial: Struct24 (24 of 48)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct48_read_struct24() {
+        populate_storage();
         let _ = storage.t_struct48.b.try_read();
     }
 
     #[storage(write)]
     fn struct48_write_struct24() {
+        populate_storage();
         let _ = storage.t_struct48.b.write(STRUCT24_DEFAULT);
     }
 
     // Partial: Struct24.u64 (8 of 48)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct48_read_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct48.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct48_write_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct48.b.b.write(0);
     }
 
     // Struct56 { a: Struct24, b: Struct32 }
     // Partial: Struct24 (24 of 56)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct56_read_struct24() {
+        populate_storage();
         let _ = storage.t_struct56.a.try_read();
     }
 
     #[storage(write)]
     fn struct56_write_struct24() {
+        populate_storage();
         let _ = storage.t_struct56.a.write(STRUCT24_DEFAULT);
     }
 
     // Partial: Struct32 (32 of 56)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct56_read_struct32() {
+        populate_storage();
         let _ = storage.t_struct56.b.try_read();
     }
 
     #[storage(write)]
     fn struct56_write_struct32() {
+        populate_storage();
         let _ = storage.t_struct56.b.write(STRUCT32_DEFAULT);
     }
 
     // Partial: Struct24.u64 (8 of 56)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct56_read_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct56.a.b.try_read();
     }
 
     #[storage(write)]
     fn struct56_write_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct56.a.b.write(0);
     }
 
     // Partial: Struct32.u64 (8 of 56)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct56_read_struct32_u64() {
+        populate_storage();
         let _ = storage.t_struct56.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct56_write_struct32_u64() {
+        populate_storage();
         let _ = storage.t_struct56.b.b.write(0);
     }
 
     // Struct72 { a: Struct32, b: Struct40 }
     // Partial: Struct32 (32 of 72)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct72_read_struct32() {
+        populate_storage();
         let _ = storage.t_struct72.a.try_read();
     }
 
     #[storage(write)]
     fn struct72_write_struct32() {
+        populate_storage();
         let _ = storage.t_struct72.a.write(STRUCT32_DEFAULT);
     }
 
     // Partial: Struct40 (40 of 72)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct72_read_struct40() {
+        populate_storage();
         let _ = storage.t_struct72.b.try_read();
     }
 
     #[storage(write)]
     fn struct72_write_struct40() {
+        populate_storage();
         let _ = storage.t_struct72.b.write(STRUCT40_DEFAULT);
     }
 
     // Partial: Struct32.u64 (8 of 72)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct72_read_struct32_u64() {
+        populate_storage();
         let _ = storage.t_struct72.a.b.try_read();
     }
 
     #[storage(write)]
     fn struct72_write_struct32_u64() {
+        populate_storage();
         let _ = storage.t_struct72.a.b.write(0);
     }
 
     // Partial: Struct40.u64 (8 of 72)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct72_read_struct40_u64() {
+        populate_storage();
         let _ = storage.t_struct72.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct72_write_struct40_u64() {
+        populate_storage();
         let _ = storage.t_struct72.b.b.write(0);
     }
 
     // Struct88 { a: Struct40, b: Struct40, c: u64 }
     // Partial: Struct40 (40 of 88)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct88_read_struct40() {
+        populate_storage();
         let _ = storage.t_struct88.b.try_read();
     }
 
     #[storage(write)]
     fn struct88_write_struct40() {
+        populate_storage();
         let _ = storage.t_struct88.b.write(STRUCT40_DEFAULT);
     }
 
     // Partial: u64 (8 of 88)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct88_read_u64() {
+        populate_storage();
         let _ = storage.t_struct88.c.try_read();
     }
 
     #[storage(write)]
     fn struct88_write_u64() {
+        populate_storage();
         let _ = storage.t_struct88.c.write(0);
     }
 
     // Partial: Struct40.u64 (8 of 88)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct88_read_struct40_u64() {
+        populate_storage();
         let _ = storage.t_struct88.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct88_write_struct40_u64() {
+        populate_storage();
         let _ = storage.t_struct88.b.b.write(0);
     }
 
     // Struct96 { a: Struct48, b: Struct48 }
     // Partial: Struct48 (48 of 96)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct96_read_struct48() {
+        populate_storage();
         let _ = storage.t_struct96.b.try_read();
     }
 
     #[storage(write)]
     fn struct96_write_struct48() {
+        populate_storage();
         let _ = storage.t_struct96.b.write(STRUCT48_DEFAULT);
     }
 
     // Partial: Struct48.Struct24 (24 of 96)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct96_read_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct96.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct96_write_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct96.b.b.write(STRUCT24_DEFAULT);
     }
 
     // Partial: Struct48.Struct24.u64 (8 of 96)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct96_read_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct96.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct96_write_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct96.b.b.b.write(0);
     }
 
     // Struct184 { a: Struct96, b: Struct88 }
     // Partial: Struct96 (96 of 184)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct184_read_struct96() {
+        populate_storage();
         let _ = storage.t_struct184.a.try_read();
     }
 
     #[storage(write)]
     fn struct184_write_struct96() {
+        populate_storage();
         let _ = storage.t_struct184.a.write(STRUCT96_DEFAULT);
     }
 
     // Partial: Struct88 (88 of 184)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct184_read_struct88() {
+        populate_storage();
         let _ = storage.t_struct184.b.try_read();
     }
 
     #[storage(write)]
     fn struct184_write_struct88() {
+        populate_storage();
         let _ = storage.t_struct184.b.write(STRUCT88_DEFAULT);
     }
 
     // Partial: Struct96.Struct48 (48 of 184)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct184_read_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct184.a.b.try_read();
     }
 
     #[storage(write)]
     fn struct184_write_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct184.a.b.write(STRUCT48_DEFAULT);
     }
 
     // Partial: Struct88.Struct40 (40 of 184)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct184_read_struct88_struct40() {
+        populate_storage();
         let _ = storage.t_struct184.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct184_write_struct88_struct40() {
+        populate_storage();
         let _ = storage.t_struct184.b.b.write(STRUCT40_DEFAULT);
     }
 
     // Partial: Struct96.Struct48.Struct24 (24 of 184)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct184_read_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct184.a.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct184_write_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct184.a.b.b.write(STRUCT24_DEFAULT);
     }
 
     // Partial: Struct88.Struct40.u64 (8 of 184)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct184_read_struct88_struct40_u64() {
+        populate_storage();
         let _ = storage.t_struct184.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct184_write_struct88_struct40_u64() {
+        populate_storage();
         let _ = storage.t_struct184.b.b.b.write(0);
     }
 
     // Partial: Struct96.Struct48.Struct24.u64 (8 of 184)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct184_read_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct184.a.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct184_write_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct184.a.b.b.b.write(0);
     }
 
     // Struct200 { a: Struct96, b: Struct96, c: u64 }
     // Partial: Struct96 (96 of 200)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct200_read_struct96() {
+        populate_storage();
         let _ = storage.t_struct200.b.try_read();
     }
 
     #[storage(write)]
     fn struct200_write_struct96() {
+        populate_storage();
         let _ = storage.t_struct200.b.write(STRUCT96_DEFAULT);
     }
 
     // Partial: u64 (8 of 200)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct200_read_u64() {
+        populate_storage();
         let _ = storage.t_struct200.c.try_read();
     }
 
     #[storage(write)]
     fn struct200_write_u64() {
+        populate_storage();
         let _ = storage.t_struct200.c.write(0);
     }
 
     // Partial: Struct96.Struct48 (48 of 200)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct200_read_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct200.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct200_write_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct200.b.b.write(STRUCT48_DEFAULT);
     }
 
     // Partial: Struct96.Struct48.Struct24 (24 of 200)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct200_read_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct200.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct200_write_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct200.b.b.b.write(STRUCT24_DEFAULT);
     }
 
     // Partial: Struct96.Struct48.Struct24.u64 (8 of 200)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct200_read_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct200.b.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct200_write_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct200.b.b.b.b.write(0);
     }
 
     // Struct224 { a: Struct96, b: Struct96, c: Struct32 }
     // Partial: Struct96 (96 of 224)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct224_read_struct96() {
+        populate_storage();
         let _ = storage.t_struct224.b.try_read();
     }
 
     #[storage(write)]
     fn struct224_write_struct96() {
+        populate_storage();
         let _ = storage.t_struct224.b.write(STRUCT96_DEFAULT);
     }
 
     // Partial: Struct32 (32 of 224)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct224_read_struct32() {
+        populate_storage();
         let _ = storage.t_struct224.c.try_read();
     }
 
     #[storage(write)]
     fn struct224_write_struct32() {
+        populate_storage();
         let _ = storage.t_struct224.c.write(STRUCT32_DEFAULT);
     }
 
     // Partial: Struct96.Struct48 (48 of 224)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct224_read_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct224.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct224_write_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct224.b.b.write(STRUCT48_DEFAULT);
     }
 
     // Partial: Struct32.u64 (8 of 224)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct224_read_struct32_u64() {
+        populate_storage();
         let _ = storage.t_struct224.c.b.try_read();
     }
 
     #[storage(write)]
     fn struct224_write_struct32_u64() {
+        populate_storage();
         let _ = storage.t_struct224.c.b.write(0);
     }
 
     // Partial: Struct96.Struct48.Struct24 (24 of 224)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct224_read_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct224.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct224_write_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct224.b.b.b.write(STRUCT24_DEFAULT);
     }
 
     // Partial: Struct96.Struct48.Struct24.u64 (8 of 224)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct224_read_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct224.b.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct224_write_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct224.b.b.b.b.write(0);
     }
 
     // Struct552 { a: Struct224, b: Struct224, c: Struct96, d: u64 }
     // Partial: Struct224 (224 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_struct224() {
+        populate_storage();
         let _ = storage.t_struct552.b.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_struct224() {
+        populate_storage();
         let _ = storage.t_struct552.b.write(STRUCT224_DEFAULT);
     }
 
     // Partial: Struct96 (96 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_struct96() {
+        populate_storage();
         let _ = storage.t_struct552.c.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_struct96() {
+        populate_storage();
         let _ = storage.t_struct552.c.write(STRUCT96_DEFAULT);
     }
 
     // Partial: u64 (8 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_u64() {
+        populate_storage();
         let _ = storage.t_struct552.d.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_u64() {
+        populate_storage();
         let _ = storage.t_struct552.d.write(0);
     }
 
     // Partial: Struct224.Struct96 (96 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_struct224_struct96() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_struct224_struct96() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.write(STRUCT96_DEFAULT);
     }
 
     // Partial: Struct224.Struct32 (32 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_struct224_struct32() {
+        populate_storage();
         let _ = storage.t_struct552.b.c.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_struct224_struct32() {
+        populate_storage();
         let _ = storage.t_struct552.b.c.write(STRUCT32_DEFAULT);
     }
 
     // Partial: Struct224.Struct96.Struct48 (48 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_struct224_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_struct224_struct96_struct48() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.b.write(STRUCT48_DEFAULT);
     }
 
     // Partial: Struct224.Struct96.Struct48.Struct24 (24 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_struct224_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_struct224_struct96_struct48_struct24() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.b.b.write(STRUCT24_DEFAULT);
     }
 
     // Partial: Struct224.Struct96.Struct48.Struct24.u64 (8 of 552)
-    #[storage(read)]
+    #[storage(read, write)]
     fn struct552_read_struct224_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.b.b.b.try_read();
     }
 
     #[storage(write)]
     fn struct552_write_struct224_struct96_struct48_struct24_u64() {
+        populate_storage();
         let _ = storage.t_struct552.b.b.b.b.b.write(0);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields_partial_access/test.dynamic_storage.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields_partial_access/test.dynamic_storage.toml
@@ -1,0 +1,2 @@
+category = "unit_tests_pass"
+experimental = { new_encoding = true, dynamic_storage = true }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields_partial_access/test.dynamic_storage.toml.disabled
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_fields_partial_access/test.dynamic_storage.toml.disabled
@@ -1,2 +1,0 @@
-category = "unit_tests_pass" # TODO: (INIT-STORAGE) Enable this test once storage initialization is implemented.
-experimental = { new_encoding = true, dynamic_storage = true }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s24/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s24/src/main.sw
@@ -7,6 +7,90 @@ storage {
     vec: StorageVec<Struct24> = StorageVec {},
 }
 
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n10() {
+    let mut i = 0;
+    while i < 10 {
+        storage.vec.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n100() {
+    let mut i = 0;
+    while i < 100 {
+        storage.vec.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n1000() {
+    let mut i = 0;
+    while i < 1000 {
+        storage.vec.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n5000() {
+    let mut i = 0;
+    while i < 5000 {
+        storage.vec.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+fn build_vec_n10() -> Vec<Struct24> {
+    let mut v = Vec::<Struct24>::new();
+    let mut i = 0;
+    while i < 10 {
+        v.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n100() -> Vec<Struct24> {
+    let mut v = Vec::<Struct24>::new();
+    let mut i = 0;
+    while i < 100 {
+        v.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n1000() -> Vec<Struct24> {
+    let mut v = Vec::<Struct24>::new();
+    let mut i = 0;
+    while i < 1000 {
+        v.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n5000() -> Vec<Struct24> {
+    let mut v = Vec::<Struct24>::new();
+    let mut i = 0;
+    while i < 5000 {
+        v.push(STRUCT24_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
 impl Contract {
 
     // === Baseline (empty contract method call) ===
@@ -17,117 +101,65 @@ impl Contract {
 
     #[storage(read, write)]
     fn baseline_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn baseline_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn baseline_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn baseline_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
     }
 
     fn baseline_store_vec_n100() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
     }
 
     fn baseline_store_vec_n1000() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
     }
 
     fn baseline_store_vec_n5000() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
     }
 
     // === push ===
 
     #[storage(read, write)]
     fn push_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.push(STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.push(STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.push(STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.push(STRUCT24_DEFAULT);
     }
 
@@ -135,79 +167,47 @@ impl Contract {
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === pop ===
 
     #[storage(read, write)]
     fn pop_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.pop();
     }
 
@@ -215,41 +215,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn get_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.get(5).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.get(50).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.get(2500).unwrap().try_read();
     }
 
@@ -257,41 +241,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn set_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.set(5, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.set(50, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.set(500, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.set(2500, STRUCT24_DEFAULT);
     }
 
@@ -299,41 +267,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn first_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
@@ -341,41 +293,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn last_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
@@ -383,41 +319,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn len_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.len();
     }
 
@@ -425,41 +345,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn is_empty_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.is_empty();
     }
 
@@ -467,41 +371,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.swap(0, 9);
     }
 
     #[storage(read, write)]
     fn swap_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.swap(0, 99);
     }
 
     #[storage(read, write)]
     fn swap_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.swap(0, 999);
     }
 
     #[storage(read, write)]
     fn swap_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.swap(0, 4999);
     }
 
@@ -509,41 +397,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.swap_remove(5);
     }
 
     #[storage(read, write)]
     fn swap_remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.swap_remove(50);
     }
 
     #[storage(read, write)]
     fn swap_remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.swap_remove(500);
     }
 
     #[storage(read, write)]
     fn swap_remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.swap_remove(2500);
     }
 
@@ -551,41 +423,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.remove(5);
     }
 
     #[storage(read, write)]
     fn remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.remove(50);
     }
 
     #[storage(read, write)]
     fn remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.remove(500);
     }
 
     #[storage(read, write)]
     fn remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.remove(2500);
     }
 
@@ -593,41 +449,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn insert_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.insert(5, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.insert(50, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.insert(500, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.insert(2500, STRUCT24_DEFAULT);
     }
 
@@ -635,41 +475,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn reverse_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.reverse();
     }
 
@@ -677,41 +501,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn fill_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.fill(STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.fill(STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.fill(STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.fill(STRUCT24_DEFAULT);
     }
 
@@ -719,41 +527,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_grow_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(20, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(200, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(2000, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(10000, STRUCT24_DEFAULT);
     }
 
@@ -761,41 +553,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_shrink_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(5, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(50, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(500, STRUCT24_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(2500, STRUCT24_DEFAULT);
     }
 
@@ -803,45 +579,25 @@ impl Contract {
 
     #[storage(write)]
     fn store_vec_n10() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n100() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n1000() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n5000() {
-        let mut v = Vec::<Struct24>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
         storage.vec.store_vec(v);
     }
 
@@ -849,41 +605,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn load_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.load_vec();
     }
 
@@ -891,11 +631,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -903,11 +639,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -915,11 +647,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -927,11 +655,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -941,41 +665,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn clear_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT24_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.clear();
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s24/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s24/src/main.sw
@@ -42,6 +42,15 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn baseline_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+    }
+
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
@@ -66,6 +75,15 @@ impl Contract {
         let mut v = Vec::<Struct24>::new();
         let mut i = 0;
         while i < 1000 {
+            v.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+    }
+
+    fn baseline_store_vec_n5000() {
+        let mut v = Vec::<Struct24>::new();
+        let mut i = 0;
+        while i < 5000 {
             v.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -103,6 +121,16 @@ impl Contract {
         storage.vec.push(STRUCT24_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn push_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.push(STRUCT24_DEFAULT);
+    }
+
     // === push_n_elems_into_empty_vec ===
 
     #[storage(read, write)]
@@ -127,6 +155,15 @@ impl Contract {
     fn push_n_elems_into_empty_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+    }
+
+    #[storage(read, write)]
+    fn push_n_elems_into_empty_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -158,6 +195,16 @@ impl Contract {
     fn pop_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.pop();
+    }
+
+    #[storage(read, write)]
+    fn pop_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -196,6 +243,16 @@ impl Contract {
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn get_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.get(2500).unwrap().try_read();
+    }
+
     // === set ===
 
     #[storage(read, write)]
@@ -228,6 +285,16 @@ impl Contract {
         storage.vec.set(500, STRUCT24_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn set_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.set(2500, STRUCT24_DEFAULT);
+    }
+
     // === first ===
 
     #[storage(read, write)]
@@ -254,6 +321,16 @@ impl Contract {
     fn first_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.first().unwrap().try_read();
+    }
+
+    #[storage(read, write)]
+    fn first_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -292,6 +369,16 @@ impl Contract {
         let _ = storage.vec.last().unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn last_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.last().unwrap().try_read();
+    }
+
     // === len ===
 
     #[storage(read, write)]
@@ -318,6 +405,16 @@ impl Contract {
     fn len_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.len();
+    }
+
+    #[storage(read, write)]
+    fn len_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -356,6 +453,16 @@ impl Contract {
         let _ = storage.vec.is_empty();
     }
 
+    #[storage(read, write)]
+    fn is_empty_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.is_empty();
+    }
+
     // === swap ===
 
     #[storage(read, write)]
@@ -386,6 +493,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.swap(0, 999);
+    }
+
+    #[storage(read, write)]
+    fn swap_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.swap(0, 4999);
     }
 
     // === swap_remove ===
@@ -420,6 +537,16 @@ impl Contract {
         let _ = storage.vec.swap_remove(500);
     }
 
+    #[storage(read, write)]
+    fn swap_remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.swap_remove(2500);
+    }
+
     // === remove ===
 
     #[storage(read, write)]
@@ -450,6 +577,16 @@ impl Contract {
             i += 1;
         }
         let _ = storage.vec.remove(500);
+    }
+
+    #[storage(read, write)]
+    fn remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.remove(2500);
     }
 
     // === insert ===
@@ -484,6 +621,16 @@ impl Contract {
         storage.vec.insert(500, STRUCT24_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn insert_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.insert(2500, STRUCT24_DEFAULT);
+    }
+
     // === reverse ===
 
     #[storage(read, write)]
@@ -510,6 +657,16 @@ impl Contract {
     fn reverse_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.reverse();
+    }
+
+    #[storage(read, write)]
+    fn reverse_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -548,6 +705,16 @@ impl Contract {
         storage.vec.fill(STRUCT24_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn fill_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.fill(STRUCT24_DEFAULT);
+    }
+
     // === resize_grow ===
 
     #[storage(read, write)]
@@ -580,6 +747,16 @@ impl Contract {
         storage.vec.resize(2000, STRUCT24_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn resize_grow_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(10000, STRUCT24_DEFAULT);
+    }
+
     // === resize_shrink ===
 
     #[storage(read, write)]
@@ -610,6 +787,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.resize(500, STRUCT24_DEFAULT);
+    }
+
+    #[storage(read, write)]
+    fn resize_shrink_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(2500, STRUCT24_DEFAULT);
     }
 
     // === store_vec ===
@@ -647,6 +834,17 @@ impl Contract {
         storage.vec.store_vec(v);
     }
 
+    #[storage(write)]
+    fn store_vec_n5000() {
+        let mut v = Vec::<Struct24>::new();
+        let mut i = 0;
+        while i < 5000 {
+            v.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        storage.vec.store_vec(v);
+    }
+
     // === load_vec ===
 
     #[storage(read, write)]
@@ -673,6 +871,16 @@ impl Contract {
     fn load_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.load_vec();
+    }
+
+    #[storage(read, write)]
+    fn load_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -717,6 +925,18 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn iter_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        for elem in storage.vec.iter() {
+            let _ = elem.try_read();
+        }
+    }
+
     // === clear ===
 
     #[storage(read, write)]
@@ -743,6 +963,16 @@ impl Contract {
     fn clear_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT24_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.clear();
+    }
+
+    #[storage(read, write)]
+    fn clear_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT24_DEFAULT);
             i += 1;
         }
@@ -778,6 +1008,12 @@ fn bench_baseline_n1000() {
     caller.baseline_n1000();
 }
 
+#[test]
+fn bench_baseline_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.baseline_n5000();
+}
+
 // === Baseline tests (store_vec) ===
 
 #[test]
@@ -796,6 +1032,12 @@ fn bench_baseline_store_vec_n100() {
 fn bench_baseline_store_vec_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.baseline_store_vec_n1000();
+}
+
+#[test]
+fn bench_baseline_store_vec_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.baseline_store_vec_n5000();
 }
 
 // === push tests ===
@@ -818,6 +1060,12 @@ fn bench_push_n1000() {
     caller.push_n1000();
 }
 
+#[test]
+fn bench_push_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.push_n5000();
+}
+
 // === push_n_elems_into_empty_vec tests ===
 
 #[test]
@@ -836,6 +1084,12 @@ fn bench_push_n_elems_into_empty_vec_n100() {
 fn bench_push_n_elems_into_empty_vec_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.push_n_elems_into_empty_vec_n1000();
+}
+
+#[test]
+fn bench_push_n_elems_into_empty_vec_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.push_n_elems_into_empty_vec_n5000();
 }
 
 // === pop tests ===
@@ -858,6 +1112,12 @@ fn bench_pop_n1000() {
     caller.pop_n1000();
 }
 
+#[test]
+fn bench_pop_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.pop_n5000();
+}
+
 // === get tests ===
 
 #[test]
@@ -876,6 +1136,12 @@ fn bench_get_n100() {
 fn bench_get_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.get_n1000();
+}
+
+#[test]
+fn bench_get_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.get_n5000();
 }
 
 // === set tests ===
@@ -898,6 +1164,12 @@ fn bench_set_n1000() {
     caller.set_n1000();
 }
 
+#[test]
+fn bench_set_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.set_n5000();
+}
+
 // === first tests ===
 
 #[test]
@@ -916,6 +1188,12 @@ fn bench_first_n100() {
 fn bench_first_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.first_n1000();
+}
+
+#[test]
+fn bench_first_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.first_n5000();
 }
 
 // === last tests ===
@@ -938,6 +1216,12 @@ fn bench_last_n1000() {
     caller.last_n1000();
 }
 
+#[test]
+fn bench_last_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.last_n5000();
+}
+
 // === len tests ===
 
 #[test]
@@ -956,6 +1240,12 @@ fn bench_len_n100() {
 fn bench_len_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.len_n1000();
+}
+
+#[test]
+fn bench_len_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.len_n5000();
 }
 
 // === is_empty tests ===
@@ -978,6 +1268,12 @@ fn bench_is_empty_n1000() {
     caller.is_empty_n1000();
 }
 
+#[test]
+fn bench_is_empty_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.is_empty_n5000();
+}
+
 // === swap tests ===
 
 #[test]
@@ -996,6 +1292,12 @@ fn bench_swap_n100() {
 fn bench_swap_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.swap_n1000();
+}
+
+#[test]
+fn bench_swap_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.swap_n5000();
 }
 
 // === swap_remove tests ===
@@ -1018,6 +1320,12 @@ fn bench_swap_remove_n1000() {
     caller.swap_remove_n1000();
 }
 
+#[test]
+fn bench_swap_remove_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.swap_remove_n5000();
+}
+
 // === remove tests ===
 
 #[test]
@@ -1036,6 +1344,12 @@ fn bench_remove_n100() {
 fn bench_remove_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.remove_n1000();
+}
+
+#[test]
+fn bench_remove_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.remove_n5000();
 }
 
 // === insert tests ===
@@ -1058,6 +1372,12 @@ fn bench_insert_n1000() {
     caller.insert_n1000();
 }
 
+#[test]
+fn bench_insert_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.insert_n5000();
+}
+
 // === reverse tests ===
 
 #[test]
@@ -1076,6 +1396,12 @@ fn bench_reverse_n100() {
 fn bench_reverse_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.reverse_n1000();
+}
+
+#[test]
+fn bench_reverse_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.reverse_n5000();
 }
 
 // === fill tests ===
@@ -1098,6 +1424,12 @@ fn bench_fill_n1000() {
     caller.fill_n1000();
 }
 
+#[test]
+fn bench_fill_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.fill_n5000();
+}
+
 // === resize_grow tests ===
 
 #[test]
@@ -1116,6 +1448,12 @@ fn bench_resize_grow_n100() {
 fn bench_resize_grow_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.resize_grow_n1000();
+}
+
+#[test]
+fn bench_resize_grow_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.resize_grow_n5000();
 }
 
 // === resize_shrink tests ===
@@ -1138,6 +1476,12 @@ fn bench_resize_shrink_n1000() {
     caller.resize_shrink_n1000();
 }
 
+#[test]
+fn bench_resize_shrink_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.resize_shrink_n5000();
+}
+
 // === store_vec tests ===
 
 #[test]
@@ -1156,6 +1500,12 @@ fn bench_store_vec_n100() {
 fn bench_store_vec_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.store_vec_n1000();
+}
+
+#[test]
+fn bench_store_vec_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.store_vec_n5000();
 }
 
 // === load_vec tests ===
@@ -1178,6 +1528,12 @@ fn bench_load_vec_n1000() {
     caller.load_vec_n1000();
 }
 
+#[test]
+fn bench_load_vec_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.load_vec_n5000();
+}
+
 // === iter tests ===
 
 #[test]
@@ -1198,6 +1554,12 @@ fn bench_iter_n1000() {
     caller.iter_n1000();
 }
 
+#[test]
+fn bench_iter_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.iter_n5000();
+}
+
 // === clear tests ===
 
 #[test]
@@ -1216,5 +1578,11 @@ fn bench_clear_n100() {
 fn bench_clear_n1000() {
     let caller = abi(StorageVecS24Abi, CONTRACT_ID);
     caller.clear_n1000();
+}
+
+#[test]
+fn bench_clear_n5000() {
+    let caller = abi(StorageVecS24Abi, CONTRACT_ID);
+    caller.clear_n5000();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s32/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s32/src/main.sw
@@ -42,6 +42,15 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn baseline_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+    }
+
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
@@ -66,6 +75,15 @@ impl Contract {
         let mut v = Vec::<Struct32>::new();
         let mut i = 0;
         while i < 1000 {
+            v.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+    }
+
+    fn baseline_store_vec_n5000() {
+        let mut v = Vec::<Struct32>::new();
+        let mut i = 0;
+        while i < 5000 {
             v.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -103,6 +121,16 @@ impl Contract {
         storage.vec.push(STRUCT32_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn push_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.push(STRUCT32_DEFAULT);
+    }
+
     // === push_n_elems_into_empty_vec ===
 
     #[storage(read, write)]
@@ -127,6 +155,15 @@ impl Contract {
     fn push_n_elems_into_empty_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+    }
+
+    #[storage(read, write)]
+    fn push_n_elems_into_empty_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -158,6 +195,16 @@ impl Contract {
     fn pop_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.pop();
+    }
+
+    #[storage(read, write)]
+    fn pop_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -196,6 +243,16 @@ impl Contract {
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn get_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.get(2500).unwrap().try_read();
+    }
+
     // === set ===
 
     #[storage(read, write)]
@@ -228,6 +285,16 @@ impl Contract {
         storage.vec.set(500, STRUCT32_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn set_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.set(2500, STRUCT32_DEFAULT);
+    }
+
     // === first ===
 
     #[storage(read, write)]
@@ -254,6 +321,16 @@ impl Contract {
     fn first_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.first().unwrap().try_read();
+    }
+
+    #[storage(read, write)]
+    fn first_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -292,6 +369,16 @@ impl Contract {
         let _ = storage.vec.last().unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn last_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.last().unwrap().try_read();
+    }
+
     // === len ===
 
     #[storage(read, write)]
@@ -318,6 +405,16 @@ impl Contract {
     fn len_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.len();
+    }
+
+    #[storage(read, write)]
+    fn len_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -356,6 +453,16 @@ impl Contract {
         let _ = storage.vec.is_empty();
     }
 
+    #[storage(read, write)]
+    fn is_empty_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.is_empty();
+    }
+
     // === swap ===
 
     #[storage(read, write)]
@@ -386,6 +493,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.swap(0, 999);
+    }
+
+    #[storage(read, write)]
+    fn swap_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.swap(0, 4999);
     }
 
     // === swap_remove ===
@@ -420,6 +537,16 @@ impl Contract {
         let _ = storage.vec.swap_remove(500);
     }
 
+    #[storage(read, write)]
+    fn swap_remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.swap_remove(2500);
+    }
+
     // === remove ===
 
     #[storage(read, write)]
@@ -450,6 +577,16 @@ impl Contract {
             i += 1;
         }
         let _ = storage.vec.remove(500);
+    }
+
+    #[storage(read, write)]
+    fn remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.remove(2500);
     }
 
     // === insert ===
@@ -484,6 +621,16 @@ impl Contract {
         storage.vec.insert(500, STRUCT32_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn insert_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.insert(2500, STRUCT32_DEFAULT);
+    }
+
     // === reverse ===
 
     #[storage(read, write)]
@@ -510,6 +657,16 @@ impl Contract {
     fn reverse_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.reverse();
+    }
+
+    #[storage(read, write)]
+    fn reverse_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -548,6 +705,16 @@ impl Contract {
         storage.vec.fill(STRUCT32_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn fill_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.fill(STRUCT32_DEFAULT);
+    }
+
     // === resize_grow ===
 
     #[storage(read, write)]
@@ -580,6 +747,16 @@ impl Contract {
         storage.vec.resize(2000, STRUCT32_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn resize_grow_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(10000, STRUCT32_DEFAULT);
+    }
+
     // === resize_shrink ===
 
     #[storage(read, write)]
@@ -610,6 +787,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.resize(500, STRUCT32_DEFAULT);
+    }
+
+    #[storage(read, write)]
+    fn resize_shrink_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(2500, STRUCT32_DEFAULT);
     }
 
     // === store_vec ===
@@ -647,6 +834,17 @@ impl Contract {
         storage.vec.store_vec(v);
     }
 
+    #[storage(write)]
+    fn store_vec_n5000() {
+        let mut v = Vec::<Struct32>::new();
+        let mut i = 0;
+        while i < 5000 {
+            v.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        storage.vec.store_vec(v);
+    }
+
     // === load_vec ===
 
     #[storage(read, write)]
@@ -673,6 +871,16 @@ impl Contract {
     fn load_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.load_vec();
+    }
+
+    #[storage(read, write)]
+    fn load_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -717,6 +925,18 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn iter_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        for elem in storage.vec.iter() {
+            let _ = elem.try_read();
+        }
+    }
+
     // === clear ===
 
     #[storage(read, write)]
@@ -743,6 +963,16 @@ impl Contract {
     fn clear_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT32_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.clear();
+    }
+
+    #[storage(read, write)]
+    fn clear_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT32_DEFAULT);
             i += 1;
         }
@@ -778,6 +1008,12 @@ fn bench_baseline_n1000() {
     caller.baseline_n1000();
 }
 
+#[test]
+fn bench_baseline_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.baseline_n5000();
+}
+
 // === Baseline tests (store_vec) ===
 
 #[test]
@@ -796,6 +1032,12 @@ fn bench_baseline_store_vec_n100() {
 fn bench_baseline_store_vec_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.baseline_store_vec_n1000();
+}
+
+#[test]
+fn bench_baseline_store_vec_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.baseline_store_vec_n5000();
 }
 
 // === push tests ===
@@ -818,6 +1060,12 @@ fn bench_push_n1000() {
     caller.push_n1000();
 }
 
+#[test]
+fn bench_push_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.push_n5000();
+}
+
 // === push_n_elems_into_empty_vec tests ===
 
 #[test]
@@ -836,6 +1084,12 @@ fn bench_push_n_elems_into_empty_vec_n100() {
 fn bench_push_n_elems_into_empty_vec_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.push_n_elems_into_empty_vec_n1000();
+}
+
+#[test]
+fn bench_push_n_elems_into_empty_vec_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.push_n_elems_into_empty_vec_n5000();
 }
 
 // === pop tests ===
@@ -858,6 +1112,12 @@ fn bench_pop_n1000() {
     caller.pop_n1000();
 }
 
+#[test]
+fn bench_pop_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.pop_n5000();
+}
+
 // === get tests ===
 
 #[test]
@@ -876,6 +1136,12 @@ fn bench_get_n100() {
 fn bench_get_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.get_n1000();
+}
+
+#[test]
+fn bench_get_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.get_n5000();
 }
 
 // === set tests ===
@@ -898,6 +1164,12 @@ fn bench_set_n1000() {
     caller.set_n1000();
 }
 
+#[test]
+fn bench_set_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.set_n5000();
+}
+
 // === first tests ===
 
 #[test]
@@ -916,6 +1188,12 @@ fn bench_first_n100() {
 fn bench_first_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.first_n1000();
+}
+
+#[test]
+fn bench_first_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.first_n5000();
 }
 
 // === last tests ===
@@ -938,6 +1216,12 @@ fn bench_last_n1000() {
     caller.last_n1000();
 }
 
+#[test]
+fn bench_last_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.last_n5000();
+}
+
 // === len tests ===
 
 #[test]
@@ -956,6 +1240,12 @@ fn bench_len_n100() {
 fn bench_len_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.len_n1000();
+}
+
+#[test]
+fn bench_len_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.len_n5000();
 }
 
 // === is_empty tests ===
@@ -978,6 +1268,12 @@ fn bench_is_empty_n1000() {
     caller.is_empty_n1000();
 }
 
+#[test]
+fn bench_is_empty_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.is_empty_n5000();
+}
+
 // === swap tests ===
 
 #[test]
@@ -996,6 +1292,12 @@ fn bench_swap_n100() {
 fn bench_swap_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.swap_n1000();
+}
+
+#[test]
+fn bench_swap_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.swap_n5000();
 }
 
 // === swap_remove tests ===
@@ -1018,6 +1320,12 @@ fn bench_swap_remove_n1000() {
     caller.swap_remove_n1000();
 }
 
+#[test]
+fn bench_swap_remove_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.swap_remove_n5000();
+}
+
 // === remove tests ===
 
 #[test]
@@ -1036,6 +1344,12 @@ fn bench_remove_n100() {
 fn bench_remove_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.remove_n1000();
+}
+
+#[test]
+fn bench_remove_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.remove_n5000();
 }
 
 // === insert tests ===
@@ -1058,6 +1372,12 @@ fn bench_insert_n1000() {
     caller.insert_n1000();
 }
 
+#[test]
+fn bench_insert_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.insert_n5000();
+}
+
 // === reverse tests ===
 
 #[test]
@@ -1076,6 +1396,12 @@ fn bench_reverse_n100() {
 fn bench_reverse_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.reverse_n1000();
+}
+
+#[test]
+fn bench_reverse_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.reverse_n5000();
 }
 
 // === fill tests ===
@@ -1098,6 +1424,12 @@ fn bench_fill_n1000() {
     caller.fill_n1000();
 }
 
+#[test]
+fn bench_fill_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.fill_n5000();
+}
+
 // === resize_grow tests ===
 
 #[test]
@@ -1116,6 +1448,12 @@ fn bench_resize_grow_n100() {
 fn bench_resize_grow_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.resize_grow_n1000();
+}
+
+#[test]
+fn bench_resize_grow_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.resize_grow_n5000();
 }
 
 // === resize_shrink tests ===
@@ -1138,6 +1476,12 @@ fn bench_resize_shrink_n1000() {
     caller.resize_shrink_n1000();
 }
 
+#[test]
+fn bench_resize_shrink_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.resize_shrink_n5000();
+}
+
 // === store_vec tests ===
 
 #[test]
@@ -1156,6 +1500,12 @@ fn bench_store_vec_n100() {
 fn bench_store_vec_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.store_vec_n1000();
+}
+
+#[test]
+fn bench_store_vec_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.store_vec_n5000();
 }
 
 // === load_vec tests ===
@@ -1178,6 +1528,12 @@ fn bench_load_vec_n1000() {
     caller.load_vec_n1000();
 }
 
+#[test]
+fn bench_load_vec_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.load_vec_n5000();
+}
+
 // === iter tests ===
 
 #[test]
@@ -1198,6 +1554,12 @@ fn bench_iter_n1000() {
     caller.iter_n1000();
 }
 
+#[test]
+fn bench_iter_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.iter_n5000();
+}
+
 // === clear tests ===
 
 #[test]
@@ -1216,5 +1578,11 @@ fn bench_clear_n100() {
 fn bench_clear_n1000() {
     let caller = abi(StorageVecS32Abi, CONTRACT_ID);
     caller.clear_n1000();
+}
+
+#[test]
+fn bench_clear_n5000() {
+    let caller = abi(StorageVecS32Abi, CONTRACT_ID);
+    caller.clear_n5000();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s32/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s32/src/main.sw
@@ -7,6 +7,90 @@ storage {
     vec: StorageVec<Struct32> = StorageVec {},
 }
 
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n10() {
+    let mut i = 0;
+    while i < 10 {
+        storage.vec.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n100() {
+    let mut i = 0;
+    while i < 100 {
+        storage.vec.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n1000() {
+    let mut i = 0;
+    while i < 1000 {
+        storage.vec.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n5000() {
+    let mut i = 0;
+    while i < 5000 {
+        storage.vec.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+fn build_vec_n10() -> Vec<Struct32> {
+    let mut v = Vec::<Struct32>::new();
+    let mut i = 0;
+    while i < 10 {
+        v.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n100() -> Vec<Struct32> {
+    let mut v = Vec::<Struct32>::new();
+    let mut i = 0;
+    while i < 100 {
+        v.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n1000() -> Vec<Struct32> {
+    let mut v = Vec::<Struct32>::new();
+    let mut i = 0;
+    while i < 1000 {
+        v.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n5000() -> Vec<Struct32> {
+    let mut v = Vec::<Struct32>::new();
+    let mut i = 0;
+    while i < 5000 {
+        v.push(STRUCT32_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
 impl Contract {
 
     // === Baseline (empty contract method call) ===
@@ -17,117 +101,65 @@ impl Contract {
 
     #[storage(read, write)]
     fn baseline_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn baseline_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn baseline_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn baseline_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
     }
 
     fn baseline_store_vec_n100() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
     }
 
     fn baseline_store_vec_n1000() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
     }
 
     fn baseline_store_vec_n5000() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
     }
 
     // === push ===
 
     #[storage(read, write)]
     fn push_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.push(STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.push(STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.push(STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.push(STRUCT32_DEFAULT);
     }
 
@@ -135,79 +167,47 @@ impl Contract {
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === pop ===
 
     #[storage(read, write)]
     fn pop_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.pop();
     }
 
@@ -215,41 +215,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn get_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.get(5).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.get(50).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.get(2500).unwrap().try_read();
     }
 
@@ -257,41 +241,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn set_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.set(5, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.set(50, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.set(500, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.set(2500, STRUCT32_DEFAULT);
     }
 
@@ -299,41 +267,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn first_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
@@ -341,41 +293,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn last_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
@@ -383,41 +319,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn len_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.len();
     }
 
@@ -425,41 +345,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn is_empty_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.is_empty();
     }
 
@@ -467,41 +371,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.swap(0, 9);
     }
 
     #[storage(read, write)]
     fn swap_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.swap(0, 99);
     }
 
     #[storage(read, write)]
     fn swap_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.swap(0, 999);
     }
 
     #[storage(read, write)]
     fn swap_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.swap(0, 4999);
     }
 
@@ -509,41 +397,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.swap_remove(5);
     }
 
     #[storage(read, write)]
     fn swap_remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.swap_remove(50);
     }
 
     #[storage(read, write)]
     fn swap_remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.swap_remove(500);
     }
 
     #[storage(read, write)]
     fn swap_remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.swap_remove(2500);
     }
 
@@ -551,41 +423,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.remove(5);
     }
 
     #[storage(read, write)]
     fn remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.remove(50);
     }
 
     #[storage(read, write)]
     fn remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.remove(500);
     }
 
     #[storage(read, write)]
     fn remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.remove(2500);
     }
 
@@ -593,41 +449,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn insert_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.insert(5, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.insert(50, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.insert(500, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.insert(2500, STRUCT32_DEFAULT);
     }
 
@@ -635,41 +475,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn reverse_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.reverse();
     }
 
@@ -677,41 +501,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn fill_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.fill(STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.fill(STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.fill(STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.fill(STRUCT32_DEFAULT);
     }
 
@@ -719,41 +527,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_grow_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(20, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(200, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(2000, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(10000, STRUCT32_DEFAULT);
     }
 
@@ -761,41 +553,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_shrink_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(5, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(50, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(500, STRUCT32_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(2500, STRUCT32_DEFAULT);
     }
 
@@ -803,45 +579,25 @@ impl Contract {
 
     #[storage(write)]
     fn store_vec_n10() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n100() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n1000() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n5000() {
-        let mut v = Vec::<Struct32>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
         storage.vec.store_vec(v);
     }
 
@@ -849,41 +605,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn load_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.load_vec();
     }
 
@@ -891,11 +631,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -903,11 +639,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -915,11 +647,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -927,11 +655,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -941,41 +665,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn clear_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT32_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.clear();
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s56/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s56/src/main.sw
@@ -7,6 +7,90 @@ storage {
     vec: StorageVec<Struct56> = StorageVec {},
 }
 
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n10() {
+    let mut i = 0;
+    while i < 10 {
+        storage.vec.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n100() {
+    let mut i = 0;
+    while i < 100 {
+        storage.vec.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n1000() {
+    let mut i = 0;
+    while i < 1000 {
+        storage.vec.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n5000() {
+    let mut i = 0;
+    while i < 5000 {
+        storage.vec.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+fn build_vec_n10() -> Vec<Struct56> {
+    let mut v = Vec::<Struct56>::new();
+    let mut i = 0;
+    while i < 10 {
+        v.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n100() -> Vec<Struct56> {
+    let mut v = Vec::<Struct56>::new();
+    let mut i = 0;
+    while i < 100 {
+        v.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n1000() -> Vec<Struct56> {
+    let mut v = Vec::<Struct56>::new();
+    let mut i = 0;
+    while i < 1000 {
+        v.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n5000() -> Vec<Struct56> {
+    let mut v = Vec::<Struct56>::new();
+    let mut i = 0;
+    while i < 5000 {
+        v.push(STRUCT56_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
 impl Contract {
 
     // === Baseline (empty contract method call) ===
@@ -17,117 +101,65 @@ impl Contract {
 
     #[storage(read, write)]
     fn baseline_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn baseline_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn baseline_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn baseline_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
     }
 
     fn baseline_store_vec_n100() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
     }
 
     fn baseline_store_vec_n1000() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
     }
 
     fn baseline_store_vec_n5000() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
     }
 
     // === push ===
 
     #[storage(read, write)]
     fn push_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.push(STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.push(STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.push(STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.push(STRUCT56_DEFAULT);
     }
 
@@ -135,79 +167,47 @@ impl Contract {
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === pop ===
 
     #[storage(read, write)]
     fn pop_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.pop();
     }
 
@@ -215,41 +215,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn get_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.get(5).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.get(50).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.get(2500).unwrap().try_read();
     }
 
@@ -257,41 +241,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn set_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.set(5, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.set(50, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.set(500, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.set(2500, STRUCT56_DEFAULT);
     }
 
@@ -299,41 +267,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn first_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
@@ -341,41 +293,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn last_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
@@ -383,41 +319,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn len_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.len();
     }
 
@@ -425,41 +345,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn is_empty_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.is_empty();
     }
 
@@ -467,41 +371,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.swap(0, 9);
     }
 
     #[storage(read, write)]
     fn swap_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.swap(0, 99);
     }
 
     #[storage(read, write)]
     fn swap_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.swap(0, 999);
     }
 
     #[storage(read, write)]
     fn swap_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.swap(0, 4999);
     }
 
@@ -509,41 +397,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.swap_remove(5);
     }
 
     #[storage(read, write)]
     fn swap_remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.swap_remove(50);
     }
 
     #[storage(read, write)]
     fn swap_remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.swap_remove(500);
     }
 
     #[storage(read, write)]
     fn swap_remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.swap_remove(2500);
     }
 
@@ -551,41 +423,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.remove(5);
     }
 
     #[storage(read, write)]
     fn remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.remove(50);
     }
 
     #[storage(read, write)]
     fn remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.remove(500);
     }
 
     #[storage(read, write)]
     fn remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.remove(2500);
     }
 
@@ -593,41 +449,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn insert_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.insert(5, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.insert(50, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.insert(500, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.insert(2500, STRUCT56_DEFAULT);
     }
 
@@ -635,41 +475,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn reverse_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.reverse();
     }
 
@@ -677,41 +501,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn fill_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.fill(STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.fill(STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.fill(STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.fill(STRUCT56_DEFAULT);
     }
 
@@ -719,41 +527,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_grow_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(20, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(200, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(2000, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(10000, STRUCT56_DEFAULT);
     }
 
@@ -761,41 +553,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_shrink_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(5, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(50, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(500, STRUCT56_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(2500, STRUCT56_DEFAULT);
     }
 
@@ -803,45 +579,25 @@ impl Contract {
 
     #[storage(write)]
     fn store_vec_n10() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n100() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n1000() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n5000() {
-        let mut v = Vec::<Struct56>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
         storage.vec.store_vec(v);
     }
 
@@ -849,41 +605,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn load_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.load_vec();
     }
 
@@ -891,11 +631,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -903,11 +639,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -915,11 +647,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -927,11 +655,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -941,41 +665,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn clear_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT56_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.clear();
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s56/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s56/src/main.sw
@@ -42,6 +42,15 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn baseline_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+    }
+
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
@@ -66,6 +75,15 @@ impl Contract {
         let mut v = Vec::<Struct56>::new();
         let mut i = 0;
         while i < 1000 {
+            v.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+    }
+
+    fn baseline_store_vec_n5000() {
+        let mut v = Vec::<Struct56>::new();
+        let mut i = 0;
+        while i < 5000 {
             v.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -103,6 +121,16 @@ impl Contract {
         storage.vec.push(STRUCT56_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn push_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.push(STRUCT56_DEFAULT);
+    }
+
     // === push_n_elems_into_empty_vec ===
 
     #[storage(read, write)]
@@ -127,6 +155,15 @@ impl Contract {
     fn push_n_elems_into_empty_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+    }
+
+    #[storage(read, write)]
+    fn push_n_elems_into_empty_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -158,6 +195,16 @@ impl Contract {
     fn pop_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.pop();
+    }
+
+    #[storage(read, write)]
+    fn pop_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -196,6 +243,16 @@ impl Contract {
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn get_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.get(2500).unwrap().try_read();
+    }
+
     // === set ===
 
     #[storage(read, write)]
@@ -228,6 +285,16 @@ impl Contract {
         storage.vec.set(500, STRUCT56_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn set_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.set(2500, STRUCT56_DEFAULT);
+    }
+
     // === first ===
 
     #[storage(read, write)]
@@ -254,6 +321,16 @@ impl Contract {
     fn first_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.first().unwrap().try_read();
+    }
+
+    #[storage(read, write)]
+    fn first_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -292,6 +369,16 @@ impl Contract {
         let _ = storage.vec.last().unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn last_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.last().unwrap().try_read();
+    }
+
     // === len ===
 
     #[storage(read, write)]
@@ -318,6 +405,16 @@ impl Contract {
     fn len_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.len();
+    }
+
+    #[storage(read, write)]
+    fn len_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -356,6 +453,16 @@ impl Contract {
         let _ = storage.vec.is_empty();
     }
 
+    #[storage(read, write)]
+    fn is_empty_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.is_empty();
+    }
+
     // === swap ===
 
     #[storage(read, write)]
@@ -386,6 +493,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.swap(0, 999);
+    }
+
+    #[storage(read, write)]
+    fn swap_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.swap(0, 4999);
     }
 
     // === swap_remove ===
@@ -420,6 +537,16 @@ impl Contract {
         let _ = storage.vec.swap_remove(500);
     }
 
+    #[storage(read, write)]
+    fn swap_remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.swap_remove(2500);
+    }
+
     // === remove ===
 
     #[storage(read, write)]
@@ -450,6 +577,16 @@ impl Contract {
             i += 1;
         }
         let _ = storage.vec.remove(500);
+    }
+
+    #[storage(read, write)]
+    fn remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.remove(2500);
     }
 
     // === insert ===
@@ -484,6 +621,16 @@ impl Contract {
         storage.vec.insert(500, STRUCT56_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn insert_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.insert(2500, STRUCT56_DEFAULT);
+    }
+
     // === reverse ===
 
     #[storage(read, write)]
@@ -510,6 +657,16 @@ impl Contract {
     fn reverse_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.reverse();
+    }
+
+    #[storage(read, write)]
+    fn reverse_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -548,6 +705,16 @@ impl Contract {
         storage.vec.fill(STRUCT56_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn fill_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.fill(STRUCT56_DEFAULT);
+    }
+
     // === resize_grow ===
 
     #[storage(read, write)]
@@ -580,6 +747,16 @@ impl Contract {
         storage.vec.resize(2000, STRUCT56_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn resize_grow_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(10000, STRUCT56_DEFAULT);
+    }
+
     // === resize_shrink ===
 
     #[storage(read, write)]
@@ -610,6 +787,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.resize(500, STRUCT56_DEFAULT);
+    }
+
+    #[storage(read, write)]
+    fn resize_shrink_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(2500, STRUCT56_DEFAULT);
     }
 
     // === store_vec ===
@@ -647,6 +834,17 @@ impl Contract {
         storage.vec.store_vec(v);
     }
 
+    #[storage(write)]
+    fn store_vec_n5000() {
+        let mut v = Vec::<Struct56>::new();
+        let mut i = 0;
+        while i < 5000 {
+            v.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        storage.vec.store_vec(v);
+    }
+
     // === load_vec ===
 
     #[storage(read, write)]
@@ -673,6 +871,16 @@ impl Contract {
     fn load_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.load_vec();
+    }
+
+    #[storage(read, write)]
+    fn load_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -717,6 +925,18 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn iter_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        for elem in storage.vec.iter() {
+            let _ = elem.try_read();
+        }
+    }
+
     // === clear ===
 
     #[storage(read, write)]
@@ -743,6 +963,16 @@ impl Contract {
     fn clear_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT56_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.clear();
+    }
+
+    #[storage(read, write)]
+    fn clear_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT56_DEFAULT);
             i += 1;
         }
@@ -778,6 +1008,12 @@ fn bench_baseline_n1000() {
     caller.baseline_n1000();
 }
 
+#[test]
+fn bench_baseline_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.baseline_n5000();
+}
+
 // === Baseline tests (store_vec) ===
 
 #[test]
@@ -796,6 +1032,12 @@ fn bench_baseline_store_vec_n100() {
 fn bench_baseline_store_vec_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.baseline_store_vec_n1000();
+}
+
+#[test]
+fn bench_baseline_store_vec_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.baseline_store_vec_n5000();
 }
 
 // === push tests ===
@@ -818,6 +1060,12 @@ fn bench_push_n1000() {
     caller.push_n1000();
 }
 
+#[test]
+fn bench_push_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.push_n5000();
+}
+
 // === push_n_elems_into_empty_vec tests ===
 
 #[test]
@@ -836,6 +1084,12 @@ fn bench_push_n_elems_into_empty_vec_n100() {
 fn bench_push_n_elems_into_empty_vec_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.push_n_elems_into_empty_vec_n1000();
+}
+
+#[test]
+fn bench_push_n_elems_into_empty_vec_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.push_n_elems_into_empty_vec_n5000();
 }
 
 // === pop tests ===
@@ -858,6 +1112,12 @@ fn bench_pop_n1000() {
     caller.pop_n1000();
 }
 
+#[test]
+fn bench_pop_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.pop_n5000();
+}
+
 // === get tests ===
 
 #[test]
@@ -876,6 +1136,12 @@ fn bench_get_n100() {
 fn bench_get_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.get_n1000();
+}
+
+#[test]
+fn bench_get_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.get_n5000();
 }
 
 // === set tests ===
@@ -898,6 +1164,12 @@ fn bench_set_n1000() {
     caller.set_n1000();
 }
 
+#[test]
+fn bench_set_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.set_n5000();
+}
+
 // === first tests ===
 
 #[test]
@@ -916,6 +1188,12 @@ fn bench_first_n100() {
 fn bench_first_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.first_n1000();
+}
+
+#[test]
+fn bench_first_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.first_n5000();
 }
 
 // === last tests ===
@@ -938,6 +1216,12 @@ fn bench_last_n1000() {
     caller.last_n1000();
 }
 
+#[test]
+fn bench_last_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.last_n5000();
+}
+
 // === len tests ===
 
 #[test]
@@ -956,6 +1240,12 @@ fn bench_len_n100() {
 fn bench_len_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.len_n1000();
+}
+
+#[test]
+fn bench_len_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.len_n5000();
 }
 
 // === is_empty tests ===
@@ -978,6 +1268,12 @@ fn bench_is_empty_n1000() {
     caller.is_empty_n1000();
 }
 
+#[test]
+fn bench_is_empty_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.is_empty_n5000();
+}
+
 // === swap tests ===
 
 #[test]
@@ -996,6 +1292,12 @@ fn bench_swap_n100() {
 fn bench_swap_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.swap_n1000();
+}
+
+#[test]
+fn bench_swap_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.swap_n5000();
 }
 
 // === swap_remove tests ===
@@ -1018,6 +1320,12 @@ fn bench_swap_remove_n1000() {
     caller.swap_remove_n1000();
 }
 
+#[test]
+fn bench_swap_remove_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.swap_remove_n5000();
+}
+
 // === remove tests ===
 
 #[test]
@@ -1036,6 +1344,12 @@ fn bench_remove_n100() {
 fn bench_remove_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.remove_n1000();
+}
+
+#[test]
+fn bench_remove_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.remove_n5000();
 }
 
 // === insert tests ===
@@ -1058,6 +1372,12 @@ fn bench_insert_n1000() {
     caller.insert_n1000();
 }
 
+#[test]
+fn bench_insert_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.insert_n5000();
+}
+
 // === reverse tests ===
 
 #[test]
@@ -1076,6 +1396,12 @@ fn bench_reverse_n100() {
 fn bench_reverse_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.reverse_n1000();
+}
+
+#[test]
+fn bench_reverse_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.reverse_n5000();
 }
 
 // === fill tests ===
@@ -1098,6 +1424,12 @@ fn bench_fill_n1000() {
     caller.fill_n1000();
 }
 
+#[test]
+fn bench_fill_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.fill_n5000();
+}
+
 // === resize_grow tests ===
 
 #[test]
@@ -1116,6 +1448,12 @@ fn bench_resize_grow_n100() {
 fn bench_resize_grow_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.resize_grow_n1000();
+}
+
+#[test]
+fn bench_resize_grow_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.resize_grow_n5000();
 }
 
 // === resize_shrink tests ===
@@ -1138,6 +1476,12 @@ fn bench_resize_shrink_n1000() {
     caller.resize_shrink_n1000();
 }
 
+#[test]
+fn bench_resize_shrink_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.resize_shrink_n5000();
+}
+
 // === store_vec tests ===
 
 #[test]
@@ -1156,6 +1500,12 @@ fn bench_store_vec_n100() {
 fn bench_store_vec_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.store_vec_n1000();
+}
+
+#[test]
+fn bench_store_vec_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.store_vec_n5000();
 }
 
 // === load_vec tests ===
@@ -1178,6 +1528,12 @@ fn bench_load_vec_n1000() {
     caller.load_vec_n1000();
 }
 
+#[test]
+fn bench_load_vec_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.load_vec_n5000();
+}
+
 // === iter tests ===
 
 #[test]
@@ -1198,6 +1554,12 @@ fn bench_iter_n1000() {
     caller.iter_n1000();
 }
 
+#[test]
+fn bench_iter_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.iter_n5000();
+}
+
 // === clear tests ===
 
 #[test]
@@ -1216,5 +1578,11 @@ fn bench_clear_n100() {
 fn bench_clear_n1000() {
     let caller = abi(StorageVecS56Abi, CONTRACT_ID);
     caller.clear_n1000();
+}
+
+#[test]
+fn bench_clear_n5000() {
+    let caller = abi(StorageVecS56Abi, CONTRACT_ID);
+    caller.clear_n5000();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s72/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s72/src/main.sw
@@ -42,6 +42,15 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn baseline_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+    }
+
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
@@ -66,6 +75,15 @@ impl Contract {
         let mut v = Vec::<Struct72>::new();
         let mut i = 0;
         while i < 1000 {
+            v.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+    }
+
+    fn baseline_store_vec_n5000() {
+        let mut v = Vec::<Struct72>::new();
+        let mut i = 0;
+        while i < 5000 {
             v.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -103,6 +121,16 @@ impl Contract {
         storage.vec.push(STRUCT72_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn push_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.push(STRUCT72_DEFAULT);
+    }
+
     // === push_n_elems_into_empty_vec ===
 
     #[storage(read, write)]
@@ -127,6 +155,15 @@ impl Contract {
     fn push_n_elems_into_empty_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+    }
+
+    #[storage(read, write)]
+    fn push_n_elems_into_empty_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -158,6 +195,16 @@ impl Contract {
     fn pop_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.pop();
+    }
+
+    #[storage(read, write)]
+    fn pop_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -196,6 +243,16 @@ impl Contract {
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn get_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.get(2500).unwrap().try_read();
+    }
+
     // === set ===
 
     #[storage(read, write)]
@@ -228,6 +285,16 @@ impl Contract {
         storage.vec.set(500, STRUCT72_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn set_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.set(2500, STRUCT72_DEFAULT);
+    }
+
     // === first ===
 
     #[storage(read, write)]
@@ -254,6 +321,16 @@ impl Contract {
     fn first_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.first().unwrap().try_read();
+    }
+
+    #[storage(read, write)]
+    fn first_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -292,6 +369,16 @@ impl Contract {
         let _ = storage.vec.last().unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn last_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.last().unwrap().try_read();
+    }
+
     // === len ===
 
     #[storage(read, write)]
@@ -318,6 +405,16 @@ impl Contract {
     fn len_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.len();
+    }
+
+    #[storage(read, write)]
+    fn len_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -356,6 +453,16 @@ impl Contract {
         let _ = storage.vec.is_empty();
     }
 
+    #[storage(read, write)]
+    fn is_empty_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.is_empty();
+    }
+
     // === swap ===
 
     #[storage(read, write)]
@@ -386,6 +493,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.swap(0, 999);
+    }
+
+    #[storage(read, write)]
+    fn swap_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.swap(0, 4999);
     }
 
     // === swap_remove ===
@@ -420,6 +537,16 @@ impl Contract {
         let _ = storage.vec.swap_remove(500);
     }
 
+    #[storage(read, write)]
+    fn swap_remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.swap_remove(2500);
+    }
+
     // === remove ===
 
     #[storage(read, write)]
@@ -450,6 +577,16 @@ impl Contract {
             i += 1;
         }
         let _ = storage.vec.remove(500);
+    }
+
+    #[storage(read, write)]
+    fn remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.remove(2500);
     }
 
     // === insert ===
@@ -484,6 +621,16 @@ impl Contract {
         storage.vec.insert(500, STRUCT72_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn insert_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.insert(2500, STRUCT72_DEFAULT);
+    }
+
     // === reverse ===
 
     #[storage(read, write)]
@@ -510,6 +657,16 @@ impl Contract {
     fn reverse_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.reverse();
+    }
+
+    #[storage(read, write)]
+    fn reverse_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -548,6 +705,16 @@ impl Contract {
         storage.vec.fill(STRUCT72_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn fill_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.fill(STRUCT72_DEFAULT);
+    }
+
     // === resize_grow ===
 
     #[storage(read, write)]
@@ -580,6 +747,16 @@ impl Contract {
         storage.vec.resize(2000, STRUCT72_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn resize_grow_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(10000, STRUCT72_DEFAULT);
+    }
+
     // === resize_shrink ===
 
     #[storage(read, write)]
@@ -610,6 +787,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.resize(500, STRUCT72_DEFAULT);
+    }
+
+    #[storage(read, write)]
+    fn resize_shrink_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(2500, STRUCT72_DEFAULT);
     }
 
     // === store_vec ===
@@ -647,6 +834,17 @@ impl Contract {
         storage.vec.store_vec(v);
     }
 
+    #[storage(write)]
+    fn store_vec_n5000() {
+        let mut v = Vec::<Struct72>::new();
+        let mut i = 0;
+        while i < 5000 {
+            v.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        storage.vec.store_vec(v);
+    }
+
     // === load_vec ===
 
     #[storage(read, write)]
@@ -673,6 +871,16 @@ impl Contract {
     fn load_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.load_vec();
+    }
+
+    #[storage(read, write)]
+    fn load_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -717,6 +925,18 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn iter_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        for elem in storage.vec.iter() {
+            let _ = elem.try_read();
+        }
+    }
+
     // === clear ===
 
     #[storage(read, write)]
@@ -743,6 +963,16 @@ impl Contract {
     fn clear_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT72_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.clear();
+    }
+
+    #[storage(read, write)]
+    fn clear_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT72_DEFAULT);
             i += 1;
         }
@@ -778,6 +1008,12 @@ fn bench_baseline_n1000() {
     caller.baseline_n1000();
 }
 
+#[test]
+fn bench_baseline_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.baseline_n5000();
+}
+
 // === Baseline tests (store_vec) ===
 
 #[test]
@@ -796,6 +1032,12 @@ fn bench_baseline_store_vec_n100() {
 fn bench_baseline_store_vec_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.baseline_store_vec_n1000();
+}
+
+#[test]
+fn bench_baseline_store_vec_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.baseline_store_vec_n5000();
 }
 
 // === push tests ===
@@ -818,6 +1060,12 @@ fn bench_push_n1000() {
     caller.push_n1000();
 }
 
+#[test]
+fn bench_push_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.push_n5000();
+}
+
 // === push_n_elems_into_empty_vec tests ===
 
 #[test]
@@ -836,6 +1084,12 @@ fn bench_push_n_elems_into_empty_vec_n100() {
 fn bench_push_n_elems_into_empty_vec_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.push_n_elems_into_empty_vec_n1000();
+}
+
+#[test]
+fn bench_push_n_elems_into_empty_vec_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.push_n_elems_into_empty_vec_n5000();
 }
 
 // === pop tests ===
@@ -858,6 +1112,12 @@ fn bench_pop_n1000() {
     caller.pop_n1000();
 }
 
+#[test]
+fn bench_pop_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.pop_n5000();
+}
+
 // === get tests ===
 
 #[test]
@@ -876,6 +1136,12 @@ fn bench_get_n100() {
 fn bench_get_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.get_n1000();
+}
+
+#[test]
+fn bench_get_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.get_n5000();
 }
 
 // === set tests ===
@@ -898,6 +1164,12 @@ fn bench_set_n1000() {
     caller.set_n1000();
 }
 
+#[test]
+fn bench_set_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.set_n5000();
+}
+
 // === first tests ===
 
 #[test]
@@ -916,6 +1188,12 @@ fn bench_first_n100() {
 fn bench_first_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.first_n1000();
+}
+
+#[test]
+fn bench_first_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.first_n5000();
 }
 
 // === last tests ===
@@ -938,6 +1216,12 @@ fn bench_last_n1000() {
     caller.last_n1000();
 }
 
+#[test]
+fn bench_last_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.last_n5000();
+}
+
 // === len tests ===
 
 #[test]
@@ -956,6 +1240,12 @@ fn bench_len_n100() {
 fn bench_len_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.len_n1000();
+}
+
+#[test]
+fn bench_len_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.len_n5000();
 }
 
 // === is_empty tests ===
@@ -978,6 +1268,12 @@ fn bench_is_empty_n1000() {
     caller.is_empty_n1000();
 }
 
+#[test]
+fn bench_is_empty_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.is_empty_n5000();
+}
+
 // === swap tests ===
 
 #[test]
@@ -996,6 +1292,12 @@ fn bench_swap_n100() {
 fn bench_swap_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.swap_n1000();
+}
+
+#[test]
+fn bench_swap_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.swap_n5000();
 }
 
 // === swap_remove tests ===
@@ -1018,6 +1320,12 @@ fn bench_swap_remove_n1000() {
     caller.swap_remove_n1000();
 }
 
+#[test]
+fn bench_swap_remove_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.swap_remove_n5000();
+}
+
 // === remove tests ===
 
 #[test]
@@ -1036,6 +1344,12 @@ fn bench_remove_n100() {
 fn bench_remove_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.remove_n1000();
+}
+
+#[test]
+fn bench_remove_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.remove_n5000();
 }
 
 // === insert tests ===
@@ -1058,6 +1372,12 @@ fn bench_insert_n1000() {
     caller.insert_n1000();
 }
 
+#[test]
+fn bench_insert_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.insert_n5000();
+}
+
 // === reverse tests ===
 
 #[test]
@@ -1076,6 +1396,12 @@ fn bench_reverse_n100() {
 fn bench_reverse_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.reverse_n1000();
+}
+
+#[test]
+fn bench_reverse_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.reverse_n5000();
 }
 
 // === fill tests ===
@@ -1098,6 +1424,12 @@ fn bench_fill_n1000() {
     caller.fill_n1000();
 }
 
+#[test]
+fn bench_fill_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.fill_n5000();
+}
+
 // === resize_grow tests ===
 
 #[test]
@@ -1116,6 +1448,12 @@ fn bench_resize_grow_n100() {
 fn bench_resize_grow_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.resize_grow_n1000();
+}
+
+#[test]
+fn bench_resize_grow_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.resize_grow_n5000();
 }
 
 // === resize_shrink tests ===
@@ -1138,6 +1476,12 @@ fn bench_resize_shrink_n1000() {
     caller.resize_shrink_n1000();
 }
 
+#[test]
+fn bench_resize_shrink_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.resize_shrink_n5000();
+}
+
 // === store_vec tests ===
 
 #[test]
@@ -1156,6 +1500,12 @@ fn bench_store_vec_n100() {
 fn bench_store_vec_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.store_vec_n1000();
+}
+
+#[test]
+fn bench_store_vec_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.store_vec_n5000();
 }
 
 // === load_vec tests ===
@@ -1178,6 +1528,12 @@ fn bench_load_vec_n1000() {
     caller.load_vec_n1000();
 }
 
+#[test]
+fn bench_load_vec_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.load_vec_n5000();
+}
+
 // === iter tests ===
 
 #[test]
@@ -1198,6 +1554,12 @@ fn bench_iter_n1000() {
     caller.iter_n1000();
 }
 
+#[test]
+fn bench_iter_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.iter_n5000();
+}
+
 // === clear tests ===
 
 #[test]
@@ -1216,5 +1578,11 @@ fn bench_clear_n100() {
 fn bench_clear_n1000() {
     let caller = abi(StorageVecS72Abi, CONTRACT_ID);
     caller.clear_n1000();
+}
+
+#[test]
+fn bench_clear_n5000() {
+    let caller = abi(StorageVecS72Abi, CONTRACT_ID);
+    caller.clear_n5000();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s72/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s72/src/main.sw
@@ -7,6 +7,90 @@ storage {
     vec: StorageVec<Struct72> = StorageVec {},
 }
 
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n10() {
+    let mut i = 0;
+    while i < 10 {
+        storage.vec.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n100() {
+    let mut i = 0;
+    while i < 100 {
+        storage.vec.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n1000() {
+    let mut i = 0;
+    while i < 1000 {
+        storage.vec.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n5000() {
+    let mut i = 0;
+    while i < 5000 {
+        storage.vec.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+fn build_vec_n10() -> Vec<Struct72> {
+    let mut v = Vec::<Struct72>::new();
+    let mut i = 0;
+    while i < 10 {
+        v.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n100() -> Vec<Struct72> {
+    let mut v = Vec::<Struct72>::new();
+    let mut i = 0;
+    while i < 100 {
+        v.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n1000() -> Vec<Struct72> {
+    let mut v = Vec::<Struct72>::new();
+    let mut i = 0;
+    while i < 1000 {
+        v.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n5000() -> Vec<Struct72> {
+    let mut v = Vec::<Struct72>::new();
+    let mut i = 0;
+    while i < 5000 {
+        v.push(STRUCT72_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
 impl Contract {
 
     // === Baseline (empty contract method call) ===
@@ -17,117 +101,65 @@ impl Contract {
 
     #[storage(read, write)]
     fn baseline_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn baseline_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn baseline_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn baseline_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
     }
 
     fn baseline_store_vec_n100() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
     }
 
     fn baseline_store_vec_n1000() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
     }
 
     fn baseline_store_vec_n5000() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
     }
 
     // === push ===
 
     #[storage(read, write)]
     fn push_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.push(STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.push(STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.push(STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.push(STRUCT72_DEFAULT);
     }
 
@@ -135,79 +167,47 @@ impl Contract {
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === pop ===
 
     #[storage(read, write)]
     fn pop_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.pop();
     }
 
@@ -215,41 +215,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn get_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.get(5).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.get(50).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.get(2500).unwrap().try_read();
     }
 
@@ -257,41 +241,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn set_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.set(5, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.set(50, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.set(500, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.set(2500, STRUCT72_DEFAULT);
     }
 
@@ -299,41 +267,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn first_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
@@ -341,41 +293,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn last_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
@@ -383,41 +319,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn len_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.len();
     }
 
@@ -425,41 +345,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn is_empty_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.is_empty();
     }
 
@@ -467,41 +371,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.swap(0, 9);
     }
 
     #[storage(read, write)]
     fn swap_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.swap(0, 99);
     }
 
     #[storage(read, write)]
     fn swap_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.swap(0, 999);
     }
 
     #[storage(read, write)]
     fn swap_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.swap(0, 4999);
     }
 
@@ -509,41 +397,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.swap_remove(5);
     }
 
     #[storage(read, write)]
     fn swap_remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.swap_remove(50);
     }
 
     #[storage(read, write)]
     fn swap_remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.swap_remove(500);
     }
 
     #[storage(read, write)]
     fn swap_remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.swap_remove(2500);
     }
 
@@ -551,41 +423,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.remove(5);
     }
 
     #[storage(read, write)]
     fn remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.remove(50);
     }
 
     #[storage(read, write)]
     fn remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.remove(500);
     }
 
     #[storage(read, write)]
     fn remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.remove(2500);
     }
 
@@ -593,41 +449,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn insert_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.insert(5, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.insert(50, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.insert(500, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.insert(2500, STRUCT72_DEFAULT);
     }
 
@@ -635,41 +475,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn reverse_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.reverse();
     }
 
@@ -677,41 +501,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn fill_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.fill(STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.fill(STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.fill(STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.fill(STRUCT72_DEFAULT);
     }
 
@@ -719,41 +527,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_grow_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(20, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(200, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(2000, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(10000, STRUCT72_DEFAULT);
     }
 
@@ -761,41 +553,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_shrink_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(5, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(50, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(500, STRUCT72_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(2500, STRUCT72_DEFAULT);
     }
 
@@ -803,45 +579,25 @@ impl Contract {
 
     #[storage(write)]
     fn store_vec_n10() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n100() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n1000() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n5000() {
-        let mut v = Vec::<Struct72>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
         storage.vec.store_vec(v);
     }
 
@@ -849,41 +605,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn load_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.load_vec();
     }
 
@@ -891,11 +631,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -903,11 +639,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -915,11 +647,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -927,11 +655,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -941,41 +665,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn clear_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT72_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.clear();
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s8/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s8/src/main.sw
@@ -41,6 +41,15 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn baseline_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+    }
+
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
@@ -65,6 +74,15 @@ impl Contract {
         let mut v = Vec::<u64>::new();
         let mut i = 0;
         while i < 1000 {
+            v.push(0);
+            i += 1;
+        }
+    }
+
+    fn baseline_store_vec_n5000() {
+        let mut v = Vec::<u64>::new();
+        let mut i = 0;
+        while i < 5000 {
             v.push(0);
             i += 1;
         }
@@ -102,6 +120,16 @@ impl Contract {
         storage.vec.push(0);
     }
 
+    #[storage(read, write)]
+    fn push_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.push(0);
+    }
+
     // === push_n_elems_into_empty_vec ===
 
     #[storage(read, write)]
@@ -126,6 +154,15 @@ impl Contract {
     fn push_n_elems_into_empty_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+    }
+
+    #[storage(read, write)]
+    fn push_n_elems_into_empty_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(0);
             i += 1;
         }
@@ -157,6 +194,16 @@ impl Contract {
     fn pop_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.pop();
+    }
+
+    #[storage(read, write)]
+    fn pop_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(0);
             i += 1;
         }
@@ -195,6 +242,16 @@ impl Contract {
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn get_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.get(2500).unwrap().try_read();
+    }
+
     // === set ===
 
     #[storage(read, write)]
@@ -227,6 +284,16 @@ impl Contract {
         storage.vec.set(500, 0);
     }
 
+    #[storage(read, write)]
+    fn set_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.set(2500, 0);
+    }
+
     // === first ===
 
     #[storage(read, write)]
@@ -253,6 +320,16 @@ impl Contract {
     fn first_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.first().unwrap().try_read();
+    }
+
+    #[storage(read, write)]
+    fn first_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(0);
             i += 1;
         }
@@ -291,6 +368,16 @@ impl Contract {
         let _ = storage.vec.last().unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn last_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.last().unwrap().try_read();
+    }
+
     // === len ===
 
     #[storage(read, write)]
@@ -317,6 +404,16 @@ impl Contract {
     fn len_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.len();
+    }
+
+    #[storage(read, write)]
+    fn len_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(0);
             i += 1;
         }
@@ -355,6 +452,16 @@ impl Contract {
         let _ = storage.vec.is_empty();
     }
 
+    #[storage(read, write)]
+    fn is_empty_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.is_empty();
+    }
+
     // === swap ===
 
     #[storage(read, write)]
@@ -385,6 +492,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.swap(0, 999);
+    }
+
+    #[storage(read, write)]
+    fn swap_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.swap(0, 4999);
     }
 
     // === swap_remove ===
@@ -419,6 +536,16 @@ impl Contract {
         let _ = storage.vec.swap_remove(500);
     }
 
+    #[storage(read, write)]
+    fn swap_remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.swap_remove(2500);
+    }
+
     // === remove ===
 
     #[storage(read, write)]
@@ -449,6 +576,16 @@ impl Contract {
             i += 1;
         }
         let _ = storage.vec.remove(500);
+    }
+
+    #[storage(read, write)]
+    fn remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.remove(2500);
     }
 
     // === insert ===
@@ -483,6 +620,16 @@ impl Contract {
         storage.vec.insert(500, 0);
     }
 
+    #[storage(read, write)]
+    fn insert_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.insert(2500, 0);
+    }
+
     // === reverse ===
 
     #[storage(read, write)]
@@ -509,6 +656,16 @@ impl Contract {
     fn reverse_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.reverse();
+    }
+
+    #[storage(read, write)]
+    fn reverse_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(0);
             i += 1;
         }
@@ -547,6 +704,16 @@ impl Contract {
         storage.vec.fill(0);
     }
 
+    #[storage(read, write)]
+    fn fill_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.fill(0);
+    }
+
     // === resize_grow ===
 
     #[storage(read, write)]
@@ -579,6 +746,16 @@ impl Contract {
         storage.vec.resize(2000, 0);
     }
 
+    #[storage(read, write)]
+    fn resize_grow_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.resize(10000, 0);
+    }
+
     // === resize_shrink ===
 
     #[storage(read, write)]
@@ -609,6 +786,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.resize(500, 0);
+    }
+
+    #[storage(read, write)]
+    fn resize_shrink_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        storage.vec.resize(2500, 0);
     }
 
     // === store_vec ===
@@ -646,6 +833,17 @@ impl Contract {
         storage.vec.store_vec(v);
     }
 
+    #[storage(write)]
+    fn store_vec_n5000() {
+        let mut v = Vec::<u64>::new();
+        let mut i = 0;
+        while i < 5000 {
+            v.push(0);
+            i += 1;
+        }
+        storage.vec.store_vec(v);
+    }
+
     // === load_vec ===
 
     #[storage(read, write)]
@@ -672,6 +870,16 @@ impl Contract {
     fn load_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.load_vec();
+    }
+
+    #[storage(read, write)]
+    fn load_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(0);
             i += 1;
         }
@@ -716,6 +924,18 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn iter_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        for elem in storage.vec.iter() {
+            let _ = elem.try_read();
+        }
+    }
+
     // === clear ===
 
     #[storage(read, write)]
@@ -742,6 +962,16 @@ impl Contract {
     fn clear_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(0);
+            i += 1;
+        }
+        let _ = storage.vec.clear();
+    }
+
+    #[storage(read, write)]
+    fn clear_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(0);
             i += 1;
         }
@@ -777,6 +1007,12 @@ fn bench_baseline_n1000() {
     caller.baseline_n1000();
 }
 
+#[test]
+fn bench_baseline_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.baseline_n5000();
+}
+
 // === Baseline tests (store_vec) ===
 
 #[test]
@@ -795,6 +1031,12 @@ fn bench_baseline_store_vec_n100() {
 fn bench_baseline_store_vec_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.baseline_store_vec_n1000();
+}
+
+#[test]
+fn bench_baseline_store_vec_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.baseline_store_vec_n5000();
 }
 
 // === push tests ===
@@ -817,6 +1059,12 @@ fn bench_push_n1000() {
     caller.push_n1000();
 }
 
+#[test]
+fn bench_push_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.push_n5000();
+}
+
 // === push_n_elems_into_empty_vec tests ===
 
 #[test]
@@ -835,6 +1083,12 @@ fn bench_push_n_elems_into_empty_vec_n100() {
 fn bench_push_n_elems_into_empty_vec_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.push_n_elems_into_empty_vec_n1000();
+}
+
+#[test]
+fn bench_push_n_elems_into_empty_vec_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.push_n_elems_into_empty_vec_n5000();
 }
 
 // === pop tests ===
@@ -857,6 +1111,12 @@ fn bench_pop_n1000() {
     caller.pop_n1000();
 }
 
+#[test]
+fn bench_pop_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.pop_n5000();
+}
+
 // === get tests ===
 
 #[test]
@@ -875,6 +1135,12 @@ fn bench_get_n100() {
 fn bench_get_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.get_n1000();
+}
+
+#[test]
+fn bench_get_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.get_n5000();
 }
 
 // === set tests ===
@@ -897,6 +1163,12 @@ fn bench_set_n1000() {
     caller.set_n1000();
 }
 
+#[test]
+fn bench_set_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.set_n5000();
+}
+
 // === first tests ===
 
 #[test]
@@ -915,6 +1187,12 @@ fn bench_first_n100() {
 fn bench_first_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.first_n1000();
+}
+
+#[test]
+fn bench_first_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.first_n5000();
 }
 
 // === last tests ===
@@ -937,6 +1215,12 @@ fn bench_last_n1000() {
     caller.last_n1000();
 }
 
+#[test]
+fn bench_last_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.last_n5000();
+}
+
 // === len tests ===
 
 #[test]
@@ -955,6 +1239,12 @@ fn bench_len_n100() {
 fn bench_len_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.len_n1000();
+}
+
+#[test]
+fn bench_len_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.len_n5000();
 }
 
 // === is_empty tests ===
@@ -977,6 +1267,12 @@ fn bench_is_empty_n1000() {
     caller.is_empty_n1000();
 }
 
+#[test]
+fn bench_is_empty_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.is_empty_n5000();
+}
+
 // === swap tests ===
 
 #[test]
@@ -995,6 +1291,12 @@ fn bench_swap_n100() {
 fn bench_swap_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.swap_n1000();
+}
+
+#[test]
+fn bench_swap_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.swap_n5000();
 }
 
 // === swap_remove tests ===
@@ -1017,6 +1319,12 @@ fn bench_swap_remove_n1000() {
     caller.swap_remove_n1000();
 }
 
+#[test]
+fn bench_swap_remove_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.swap_remove_n5000();
+}
+
 // === remove tests ===
 
 #[test]
@@ -1035,6 +1343,12 @@ fn bench_remove_n100() {
 fn bench_remove_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.remove_n1000();
+}
+
+#[test]
+fn bench_remove_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.remove_n5000();
 }
 
 // === insert tests ===
@@ -1057,6 +1371,12 @@ fn bench_insert_n1000() {
     caller.insert_n1000();
 }
 
+#[test]
+fn bench_insert_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.insert_n5000();
+}
+
 // === reverse tests ===
 
 #[test]
@@ -1075,6 +1395,12 @@ fn bench_reverse_n100() {
 fn bench_reverse_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.reverse_n1000();
+}
+
+#[test]
+fn bench_reverse_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.reverse_n5000();
 }
 
 // === fill tests ===
@@ -1097,6 +1423,12 @@ fn bench_fill_n1000() {
     caller.fill_n1000();
 }
 
+#[test]
+fn bench_fill_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.fill_n5000();
+}
+
 // === resize_grow tests ===
 
 #[test]
@@ -1115,6 +1447,12 @@ fn bench_resize_grow_n100() {
 fn bench_resize_grow_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.resize_grow_n1000();
+}
+
+#[test]
+fn bench_resize_grow_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.resize_grow_n5000();
 }
 
 // === resize_shrink tests ===
@@ -1137,6 +1475,12 @@ fn bench_resize_shrink_n1000() {
     caller.resize_shrink_n1000();
 }
 
+#[test]
+fn bench_resize_shrink_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.resize_shrink_n5000();
+}
+
 // === store_vec tests ===
 
 #[test]
@@ -1155,6 +1499,12 @@ fn bench_store_vec_n100() {
 fn bench_store_vec_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.store_vec_n1000();
+}
+
+#[test]
+fn bench_store_vec_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.store_vec_n5000();
 }
 
 // === load_vec tests ===
@@ -1177,6 +1527,12 @@ fn bench_load_vec_n1000() {
     caller.load_vec_n1000();
 }
 
+#[test]
+fn bench_load_vec_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.load_vec_n5000();
+}
+
 // === iter tests ===
 
 #[test]
@@ -1197,6 +1553,12 @@ fn bench_iter_n1000() {
     caller.iter_n1000();
 }
 
+#[test]
+fn bench_iter_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.iter_n5000();
+}
+
 // === clear tests ===
 
 #[test]
@@ -1215,5 +1577,11 @@ fn bench_clear_n100() {
 fn bench_clear_n1000() {
     let caller = abi(StorageVecS8Abi, CONTRACT_ID);
     caller.clear_n1000();
+}
+
+#[test]
+fn bench_clear_n5000() {
+    let caller = abi(StorageVecS8Abi, CONTRACT_ID);
+    caller.clear_n5000();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s8/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s8/src/main.sw
@@ -6,6 +6,90 @@ storage {
     vec: StorageVec<u64> = StorageVec {},
 }
 
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n10() {
+    let mut i = 0;
+    while i < 10 {
+        storage.vec.push(0);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n100() {
+    let mut i = 0;
+    while i < 100 {
+        storage.vec.push(0);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n1000() {
+    let mut i = 0;
+    while i < 1000 {
+        storage.vec.push(0);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n5000() {
+    let mut i = 0;
+    while i < 5000 {
+        storage.vec.push(0);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+fn build_vec_n10() -> Vec<u64> {
+    let mut v = Vec::<u64>::new();
+    let mut i = 0;
+    while i < 10 {
+        v.push(0);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n100() -> Vec<u64> {
+    let mut v = Vec::<u64>::new();
+    let mut i = 0;
+    while i < 100 {
+        v.push(0);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n1000() -> Vec<u64> {
+    let mut v = Vec::<u64>::new();
+    let mut i = 0;
+    while i < 1000 {
+        v.push(0);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n5000() -> Vec<u64> {
+    let mut v = Vec::<u64>::new();
+    let mut i = 0;
+    while i < 5000 {
+        v.push(0);
+        i += 1;
+    }
+    v
+}
+
 impl Contract {
 
     // === Baseline (empty contract method call) ===
@@ -16,117 +100,65 @@ impl Contract {
 
     #[storage(read, write)]
     fn baseline_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn baseline_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn baseline_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn baseline_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n10();
     }
 
     fn baseline_store_vec_n100() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n100();
     }
 
     fn baseline_store_vec_n1000() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n1000();
     }
 
     fn baseline_store_vec_n5000() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n5000();
     }
 
     // === push ===
 
     #[storage(read, write)]
     fn push_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.push(0);
     }
 
     #[storage(read, write)]
     fn push_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.push(0);
     }
 
     #[storage(read, write)]
     fn push_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.push(0);
     }
 
     #[storage(read, write)]
     fn push_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.push(0);
     }
 
@@ -134,79 +166,47 @@ impl Contract {
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === pop ===
 
     #[storage(read, write)]
     fn pop_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.pop();
     }
 
@@ -214,41 +214,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn get_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.get(5).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.get(50).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.get(2500).unwrap().try_read();
     }
 
@@ -256,41 +240,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn set_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.set(5, 0);
     }
 
     #[storage(read, write)]
     fn set_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.set(50, 0);
     }
 
     #[storage(read, write)]
     fn set_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.set(500, 0);
     }
 
     #[storage(read, write)]
     fn set_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.set(2500, 0);
     }
 
@@ -298,41 +266,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn first_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
@@ -340,41 +292,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn last_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
@@ -382,41 +318,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn len_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.len();
     }
 
@@ -424,41 +344,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn is_empty_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.is_empty();
     }
 
@@ -466,41 +370,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.swap(0, 9);
     }
 
     #[storage(read, write)]
     fn swap_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.swap(0, 99);
     }
 
     #[storage(read, write)]
     fn swap_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.swap(0, 999);
     }
 
     #[storage(read, write)]
     fn swap_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.swap(0, 4999);
     }
 
@@ -508,41 +396,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.swap_remove(5);
     }
 
     #[storage(read, write)]
     fn swap_remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.swap_remove(50);
     }
 
     #[storage(read, write)]
     fn swap_remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.swap_remove(500);
     }
 
     #[storage(read, write)]
     fn swap_remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.swap_remove(2500);
     }
 
@@ -550,41 +422,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.remove(5);
     }
 
     #[storage(read, write)]
     fn remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.remove(50);
     }
 
     #[storage(read, write)]
     fn remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.remove(500);
     }
 
     #[storage(read, write)]
     fn remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.remove(2500);
     }
 
@@ -592,41 +448,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn insert_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.insert(5, 0);
     }
 
     #[storage(read, write)]
     fn insert_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.insert(50, 0);
     }
 
     #[storage(read, write)]
     fn insert_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.insert(500, 0);
     }
 
     #[storage(read, write)]
     fn insert_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.insert(2500, 0);
     }
 
@@ -634,41 +474,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn reverse_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.reverse();
     }
 
@@ -676,41 +500,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn fill_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.fill(0);
     }
 
     #[storage(read, write)]
     fn fill_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.fill(0);
     }
 
     #[storage(read, write)]
     fn fill_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.fill(0);
     }
 
     #[storage(read, write)]
     fn fill_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.fill(0);
     }
 
@@ -718,41 +526,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_grow_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(20, 0);
     }
 
     #[storage(read, write)]
     fn resize_grow_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(200, 0);
     }
 
     #[storage(read, write)]
     fn resize_grow_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(2000, 0);
     }
 
     #[storage(read, write)]
     fn resize_grow_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(10000, 0);
     }
 
@@ -760,41 +552,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_shrink_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(5, 0);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(50, 0);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(500, 0);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(2500, 0);
     }
 
@@ -802,45 +578,25 @@ impl Contract {
 
     #[storage(write)]
     fn store_vec_n10() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n10();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n100() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n100();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n1000() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n1000();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n5000() {
-        let mut v = Vec::<u64>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(0);
-            i += 1;
-        }
+        let v = build_vec_n5000();
         storage.vec.store_vec(v);
     }
 
@@ -848,41 +604,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn load_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.load_vec();
     }
 
@@ -890,11 +630,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -902,11 +638,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -914,11 +646,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -926,11 +654,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -940,41 +664,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn clear_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(0);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.clear();
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s88/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s88/src/main.sw
@@ -7,6 +7,90 @@ storage {
     vec: StorageVec<Struct88> = StorageVec {},
 }
 
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n10() {
+    let mut i = 0;
+    while i < 10 {
+        storage.vec.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n100() {
+    let mut i = 0;
+    while i < 100 {
+        storage.vec.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n1000() {
+    let mut i = 0;
+    while i < 1000 {
+        storage.vec.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n5000() {
+    let mut i = 0;
+    while i < 5000 {
+        storage.vec.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+fn build_vec_n10() -> Vec<Struct88> {
+    let mut v = Vec::<Struct88>::new();
+    let mut i = 0;
+    while i < 10 {
+        v.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n100() -> Vec<Struct88> {
+    let mut v = Vec::<Struct88>::new();
+    let mut i = 0;
+    while i < 100 {
+        v.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n1000() -> Vec<Struct88> {
+    let mut v = Vec::<Struct88>::new();
+    let mut i = 0;
+    while i < 1000 {
+        v.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n5000() -> Vec<Struct88> {
+    let mut v = Vec::<Struct88>::new();
+    let mut i = 0;
+    while i < 5000 {
+        v.push(STRUCT88_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
 impl Contract {
 
     // === Baseline (empty contract method call) ===
@@ -17,117 +101,65 @@ impl Contract {
 
     #[storage(read, write)]
     fn baseline_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn baseline_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn baseline_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn baseline_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
     }
 
     fn baseline_store_vec_n100() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
     }
 
     fn baseline_store_vec_n1000() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
     }
 
     fn baseline_store_vec_n5000() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
     }
 
     // === push ===
 
     #[storage(read, write)]
     fn push_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.push(STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.push(STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.push(STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.push(STRUCT88_DEFAULT);
     }
 
@@ -135,79 +167,47 @@ impl Contract {
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === pop ===
 
     #[storage(read, write)]
     fn pop_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.pop();
     }
 
@@ -215,41 +215,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn get_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.get(5).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.get(50).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.get(2500).unwrap().try_read();
     }
 
@@ -257,41 +241,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn set_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.set(5, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.set(50, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.set(500, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.set(2500, STRUCT88_DEFAULT);
     }
 
@@ -299,41 +267,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn first_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
@@ -341,41 +293,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn last_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
@@ -383,41 +319,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn len_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.len();
     }
 
@@ -425,41 +345,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn is_empty_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.is_empty();
     }
 
@@ -467,41 +371,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.swap(0, 9);
     }
 
     #[storage(read, write)]
     fn swap_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.swap(0, 99);
     }
 
     #[storage(read, write)]
     fn swap_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.swap(0, 999);
     }
 
     #[storage(read, write)]
     fn swap_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.swap(0, 4999);
     }
 
@@ -509,41 +397,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.swap_remove(5);
     }
 
     #[storage(read, write)]
     fn swap_remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.swap_remove(50);
     }
 
     #[storage(read, write)]
     fn swap_remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.swap_remove(500);
     }
 
     #[storage(read, write)]
     fn swap_remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.swap_remove(2500);
     }
 
@@ -551,41 +423,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.remove(5);
     }
 
     #[storage(read, write)]
     fn remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.remove(50);
     }
 
     #[storage(read, write)]
     fn remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.remove(500);
     }
 
     #[storage(read, write)]
     fn remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.remove(2500);
     }
 
@@ -593,41 +449,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn insert_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.insert(5, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.insert(50, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.insert(500, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.insert(2500, STRUCT88_DEFAULT);
     }
 
@@ -635,41 +475,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn reverse_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.reverse();
     }
 
@@ -677,41 +501,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn fill_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.fill(STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.fill(STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.fill(STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.fill(STRUCT88_DEFAULT);
     }
 
@@ -719,41 +527,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_grow_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(20, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(200, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(2000, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(10000, STRUCT88_DEFAULT);
     }
 
@@ -761,41 +553,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_shrink_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(5, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(50, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(500, STRUCT88_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(2500, STRUCT88_DEFAULT);
     }
 
@@ -803,45 +579,25 @@ impl Contract {
 
     #[storage(write)]
     fn store_vec_n10() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n100() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n1000() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n5000() {
-        let mut v = Vec::<Struct88>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
         storage.vec.store_vec(v);
     }
 
@@ -849,41 +605,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn load_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.load_vec();
     }
 
@@ -891,11 +631,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -903,11 +639,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -915,11 +647,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -927,11 +655,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -941,41 +665,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn clear_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT88_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.clear();
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s88/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s88/src/main.sw
@@ -42,6 +42,15 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn baseline_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+    }
+
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
@@ -66,6 +75,15 @@ impl Contract {
         let mut v = Vec::<Struct88>::new();
         let mut i = 0;
         while i < 1000 {
+            v.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+    }
+
+    fn baseline_store_vec_n5000() {
+        let mut v = Vec::<Struct88>::new();
+        let mut i = 0;
+        while i < 5000 {
             v.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -103,6 +121,16 @@ impl Contract {
         storage.vec.push(STRUCT88_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn push_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.push(STRUCT88_DEFAULT);
+    }
+
     // === push_n_elems_into_empty_vec ===
 
     #[storage(read, write)]
@@ -127,6 +155,15 @@ impl Contract {
     fn push_n_elems_into_empty_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+    }
+
+    #[storage(read, write)]
+    fn push_n_elems_into_empty_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -158,6 +195,16 @@ impl Contract {
     fn pop_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.pop();
+    }
+
+    #[storage(read, write)]
+    fn pop_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -196,6 +243,16 @@ impl Contract {
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn get_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.get(2500).unwrap().try_read();
+    }
+
     // === set ===
 
     #[storage(read, write)]
@@ -228,6 +285,16 @@ impl Contract {
         storage.vec.set(500, STRUCT88_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn set_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.set(2500, STRUCT88_DEFAULT);
+    }
+
     // === first ===
 
     #[storage(read, write)]
@@ -254,6 +321,16 @@ impl Contract {
     fn first_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.first().unwrap().try_read();
+    }
+
+    #[storage(read, write)]
+    fn first_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -292,6 +369,16 @@ impl Contract {
         let _ = storage.vec.last().unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn last_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.last().unwrap().try_read();
+    }
+
     // === len ===
 
     #[storage(read, write)]
@@ -318,6 +405,16 @@ impl Contract {
     fn len_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.len();
+    }
+
+    #[storage(read, write)]
+    fn len_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -356,6 +453,16 @@ impl Contract {
         let _ = storage.vec.is_empty();
     }
 
+    #[storage(read, write)]
+    fn is_empty_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.is_empty();
+    }
+
     // === swap ===
 
     #[storage(read, write)]
@@ -386,6 +493,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.swap(0, 999);
+    }
+
+    #[storage(read, write)]
+    fn swap_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.swap(0, 4999);
     }
 
     // === swap_remove ===
@@ -420,6 +537,16 @@ impl Contract {
         let _ = storage.vec.swap_remove(500);
     }
 
+    #[storage(read, write)]
+    fn swap_remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.swap_remove(2500);
+    }
+
     // === remove ===
 
     #[storage(read, write)]
@@ -450,6 +577,16 @@ impl Contract {
             i += 1;
         }
         let _ = storage.vec.remove(500);
+    }
+
+    #[storage(read, write)]
+    fn remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.remove(2500);
     }
 
     // === insert ===
@@ -484,6 +621,16 @@ impl Contract {
         storage.vec.insert(500, STRUCT88_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn insert_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.insert(2500, STRUCT88_DEFAULT);
+    }
+
     // === reverse ===
 
     #[storage(read, write)]
@@ -510,6 +657,16 @@ impl Contract {
     fn reverse_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.reverse();
+    }
+
+    #[storage(read, write)]
+    fn reverse_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -548,6 +705,16 @@ impl Contract {
         storage.vec.fill(STRUCT88_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn fill_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.fill(STRUCT88_DEFAULT);
+    }
+
     // === resize_grow ===
 
     #[storage(read, write)]
@@ -580,6 +747,16 @@ impl Contract {
         storage.vec.resize(2000, STRUCT88_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn resize_grow_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(10000, STRUCT88_DEFAULT);
+    }
+
     // === resize_shrink ===
 
     #[storage(read, write)]
@@ -610,6 +787,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.resize(500, STRUCT88_DEFAULT);
+    }
+
+    #[storage(read, write)]
+    fn resize_shrink_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(2500, STRUCT88_DEFAULT);
     }
 
     // === store_vec ===
@@ -647,6 +834,17 @@ impl Contract {
         storage.vec.store_vec(v);
     }
 
+    #[storage(write)]
+    fn store_vec_n5000() {
+        let mut v = Vec::<Struct88>::new();
+        let mut i = 0;
+        while i < 5000 {
+            v.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        storage.vec.store_vec(v);
+    }
+
     // === load_vec ===
 
     #[storage(read, write)]
@@ -673,6 +871,16 @@ impl Contract {
     fn load_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.load_vec();
+    }
+
+    #[storage(read, write)]
+    fn load_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -717,6 +925,18 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn iter_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        for elem in storage.vec.iter() {
+            let _ = elem.try_read();
+        }
+    }
+
     // === clear ===
 
     #[storage(read, write)]
@@ -743,6 +963,16 @@ impl Contract {
     fn clear_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT88_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.clear();
+    }
+
+    #[storage(read, write)]
+    fn clear_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT88_DEFAULT);
             i += 1;
         }
@@ -778,6 +1008,12 @@ fn bench_baseline_n1000() {
     caller.baseline_n1000();
 }
 
+#[test]
+fn bench_baseline_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.baseline_n5000();
+}
+
 // === Baseline tests (store_vec) ===
 
 #[test]
@@ -796,6 +1032,12 @@ fn bench_baseline_store_vec_n100() {
 fn bench_baseline_store_vec_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.baseline_store_vec_n1000();
+}
+
+#[test]
+fn bench_baseline_store_vec_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.baseline_store_vec_n5000();
 }
 
 // === push tests ===
@@ -818,6 +1060,12 @@ fn bench_push_n1000() {
     caller.push_n1000();
 }
 
+#[test]
+fn bench_push_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.push_n5000();
+}
+
 // === push_n_elems_into_empty_vec tests ===
 
 #[test]
@@ -836,6 +1084,12 @@ fn bench_push_n_elems_into_empty_vec_n100() {
 fn bench_push_n_elems_into_empty_vec_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.push_n_elems_into_empty_vec_n1000();
+}
+
+#[test]
+fn bench_push_n_elems_into_empty_vec_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.push_n_elems_into_empty_vec_n5000();
 }
 
 // === pop tests ===
@@ -858,6 +1112,12 @@ fn bench_pop_n1000() {
     caller.pop_n1000();
 }
 
+#[test]
+fn bench_pop_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.pop_n5000();
+}
+
 // === get tests ===
 
 #[test]
@@ -876,6 +1136,12 @@ fn bench_get_n100() {
 fn bench_get_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.get_n1000();
+}
+
+#[test]
+fn bench_get_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.get_n5000();
 }
 
 // === set tests ===
@@ -898,6 +1164,12 @@ fn bench_set_n1000() {
     caller.set_n1000();
 }
 
+#[test]
+fn bench_set_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.set_n5000();
+}
+
 // === first tests ===
 
 #[test]
@@ -916,6 +1188,12 @@ fn bench_first_n100() {
 fn bench_first_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.first_n1000();
+}
+
+#[test]
+fn bench_first_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.first_n5000();
 }
 
 // === last tests ===
@@ -938,6 +1216,12 @@ fn bench_last_n1000() {
     caller.last_n1000();
 }
 
+#[test]
+fn bench_last_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.last_n5000();
+}
+
 // === len tests ===
 
 #[test]
@@ -956,6 +1240,12 @@ fn bench_len_n100() {
 fn bench_len_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.len_n1000();
+}
+
+#[test]
+fn bench_len_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.len_n5000();
 }
 
 // === is_empty tests ===
@@ -978,6 +1268,12 @@ fn bench_is_empty_n1000() {
     caller.is_empty_n1000();
 }
 
+#[test]
+fn bench_is_empty_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.is_empty_n5000();
+}
+
 // === swap tests ===
 
 #[test]
@@ -996,6 +1292,12 @@ fn bench_swap_n100() {
 fn bench_swap_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.swap_n1000();
+}
+
+#[test]
+fn bench_swap_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.swap_n5000();
 }
 
 // === swap_remove tests ===
@@ -1018,6 +1320,12 @@ fn bench_swap_remove_n1000() {
     caller.swap_remove_n1000();
 }
 
+#[test]
+fn bench_swap_remove_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.swap_remove_n5000();
+}
+
 // === remove tests ===
 
 #[test]
@@ -1036,6 +1344,12 @@ fn bench_remove_n100() {
 fn bench_remove_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.remove_n1000();
+}
+
+#[test]
+fn bench_remove_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.remove_n5000();
 }
 
 // === insert tests ===
@@ -1058,6 +1372,12 @@ fn bench_insert_n1000() {
     caller.insert_n1000();
 }
 
+#[test]
+fn bench_insert_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.insert_n5000();
+}
+
 // === reverse tests ===
 
 #[test]
@@ -1076,6 +1396,12 @@ fn bench_reverse_n100() {
 fn bench_reverse_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.reverse_n1000();
+}
+
+#[test]
+fn bench_reverse_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.reverse_n5000();
 }
 
 // === fill tests ===
@@ -1098,6 +1424,12 @@ fn bench_fill_n1000() {
     caller.fill_n1000();
 }
 
+#[test]
+fn bench_fill_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.fill_n5000();
+}
+
 // === resize_grow tests ===
 
 #[test]
@@ -1116,6 +1448,12 @@ fn bench_resize_grow_n100() {
 fn bench_resize_grow_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.resize_grow_n1000();
+}
+
+#[test]
+fn bench_resize_grow_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.resize_grow_n5000();
 }
 
 // === resize_shrink tests ===
@@ -1138,6 +1476,12 @@ fn bench_resize_shrink_n1000() {
     caller.resize_shrink_n1000();
 }
 
+#[test]
+fn bench_resize_shrink_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.resize_shrink_n5000();
+}
+
 // === store_vec tests ===
 
 #[test]
@@ -1156,6 +1500,12 @@ fn bench_store_vec_n100() {
 fn bench_store_vec_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.store_vec_n1000();
+}
+
+#[test]
+fn bench_store_vec_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.store_vec_n5000();
 }
 
 // === load_vec tests ===
@@ -1178,6 +1528,12 @@ fn bench_load_vec_n1000() {
     caller.load_vec_n1000();
 }
 
+#[test]
+fn bench_load_vec_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.load_vec_n5000();
+}
+
 // === iter tests ===
 
 #[test]
@@ -1198,6 +1554,12 @@ fn bench_iter_n1000() {
     caller.iter_n1000();
 }
 
+#[test]
+fn bench_iter_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.iter_n5000();
+}
+
 // === clear tests ===
 
 #[test]
@@ -1216,5 +1578,11 @@ fn bench_clear_n100() {
 fn bench_clear_n1000() {
     let caller = abi(StorageVecS88Abi, CONTRACT_ID);
     caller.clear_n1000();
+}
+
+#[test]
+fn bench_clear_n5000() {
+    let caller = abi(StorageVecS88Abi, CONTRACT_ID);
+    caller.clear_n5000();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/src/main.sw
@@ -42,6 +42,15 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn baseline_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+    }
+
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
@@ -66,6 +75,15 @@ impl Contract {
         let mut v = Vec::<Struct96>::new();
         let mut i = 0;
         while i < 1000 {
+            v.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+    }
+
+    fn baseline_store_vec_n5000() {
+        let mut v = Vec::<Struct96>::new();
+        let mut i = 0;
+        while i < 5000 {
             v.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -103,6 +121,16 @@ impl Contract {
         storage.vec.push(STRUCT96_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn push_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.push(STRUCT96_DEFAULT);
+    }
+
     // === push_n_elems_into_empty_vec ===
 
     #[storage(read, write)]
@@ -127,6 +155,15 @@ impl Contract {
     fn push_n_elems_into_empty_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+    }
+
+    #[storage(read, write)]
+    fn push_n_elems_into_empty_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -158,6 +195,16 @@ impl Contract {
     fn pop_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.pop();
+    }
+
+    #[storage(read, write)]
+    fn pop_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -196,6 +243,16 @@ impl Contract {
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn get_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.get(2500).unwrap().try_read();
+    }
+
     // === set ===
 
     #[storage(read, write)]
@@ -228,6 +285,16 @@ impl Contract {
         storage.vec.set(500, STRUCT96_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn set_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.set(2500, STRUCT96_DEFAULT);
+    }
+
     // === first ===
 
     #[storage(read, write)]
@@ -254,6 +321,16 @@ impl Contract {
     fn first_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.first().unwrap().try_read();
+    }
+
+    #[storage(read, write)]
+    fn first_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -292,6 +369,16 @@ impl Contract {
         let _ = storage.vec.last().unwrap().try_read();
     }
 
+    #[storage(read, write)]
+    fn last_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.last().unwrap().try_read();
+    }
+
     // === len ===
 
     #[storage(read, write)]
@@ -318,6 +405,16 @@ impl Contract {
     fn len_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.len();
+    }
+
+    #[storage(read, write)]
+    fn len_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -356,6 +453,16 @@ impl Contract {
         let _ = storage.vec.is_empty();
     }
 
+    #[storage(read, write)]
+    fn is_empty_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.is_empty();
+    }
+
     // === swap ===
 
     #[storage(read, write)]
@@ -386,6 +493,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.swap(0, 999);
+    }
+
+    #[storage(read, write)]
+    fn swap_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.swap(0, 4999);
     }
 
     // === swap_remove ===
@@ -420,6 +537,16 @@ impl Contract {
         let _ = storage.vec.swap_remove(500);
     }
 
+    #[storage(read, write)]
+    fn swap_remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.swap_remove(2500);
+    }
+
     // === remove ===
 
     #[storage(read, write)]
@@ -450,6 +577,16 @@ impl Contract {
             i += 1;
         }
         let _ = storage.vec.remove(500);
+    }
+
+    #[storage(read, write)]
+    fn remove_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.remove(2500);
     }
 
     // === insert ===
@@ -484,6 +621,16 @@ impl Contract {
         storage.vec.insert(500, STRUCT96_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn insert_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.insert(2500, STRUCT96_DEFAULT);
+    }
+
     // === reverse ===
 
     #[storage(read, write)]
@@ -510,6 +657,16 @@ impl Contract {
     fn reverse_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.reverse();
+    }
+
+    #[storage(read, write)]
+    fn reverse_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -548,6 +705,16 @@ impl Contract {
         storage.vec.fill(STRUCT96_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn fill_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.fill(STRUCT96_DEFAULT);
+    }
+
     // === resize_grow ===
 
     #[storage(read, write)]
@@ -580,6 +747,16 @@ impl Contract {
         storage.vec.resize(2000, STRUCT96_DEFAULT);
     }
 
+    #[storage(read, write)]
+    fn resize_grow_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(10000, STRUCT96_DEFAULT);
+    }
+
     // === resize_shrink ===
 
     #[storage(read, write)]
@@ -610,6 +787,16 @@ impl Contract {
             i += 1;
         }
         storage.vec.resize(500, STRUCT96_DEFAULT);
+    }
+
+    #[storage(read, write)]
+    fn resize_shrink_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.resize(2500, STRUCT96_DEFAULT);
     }
 
     // === store_vec ===
@@ -647,6 +834,17 @@ impl Contract {
         storage.vec.store_vec(v);
     }
 
+    #[storage(write)]
+    fn store_vec_n5000() {
+        let mut v = Vec::<Struct96>::new();
+        let mut i = 0;
+        while i < 5000 {
+            v.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        storage.vec.store_vec(v);
+    }
+
     // === load_vec ===
 
     #[storage(read, write)]
@@ -673,6 +871,16 @@ impl Contract {
     fn load_vec_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.load_vec();
+    }
+
+    #[storage(read, write)]
+    fn load_vec_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -717,6 +925,18 @@ impl Contract {
         }
     }
 
+    #[storage(read, write)]
+    fn iter_n5000() {
+        let mut i = 0;
+        while i < 5000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        for elem in storage.vec.iter() {
+            let _ = elem.try_read();
+        }
+    }
+
     // === clear ===
 
     #[storage(read, write)]
@@ -743,6 +963,16 @@ impl Contract {
     fn clear_n1000() {
         let mut i = 0;
         while i < 1000 {
+            storage.vec.push(STRUCT96_DEFAULT);
+            i += 1;
+        }
+        let _ = storage.vec.clear();
+    }
+
+    #[storage(read, write)]
+    fn clear_n5000() {
+        let mut i = 0;
+        while i < 5000 {
             storage.vec.push(STRUCT96_DEFAULT);
             i += 1;
         }
@@ -778,6 +1008,12 @@ fn bench_baseline_n1000() {
     caller.baseline_n1000();
 }
 
+#[test]
+fn bench_baseline_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.baseline_n5000();
+}
+
 // === Baseline tests (store_vec) ===
 
 #[test]
@@ -796,6 +1032,12 @@ fn bench_baseline_store_vec_n100() {
 fn bench_baseline_store_vec_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.baseline_store_vec_n1000();
+}
+
+#[test]
+fn bench_baseline_store_vec_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.baseline_store_vec_n5000();
 }
 
 // === push tests ===
@@ -818,6 +1060,12 @@ fn bench_push_n1000() {
     caller.push_n1000();
 }
 
+#[test]
+fn bench_push_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.push_n5000();
+}
+
 // === push_n_elems_into_empty_vec tests ===
 
 #[test]
@@ -836,6 +1084,12 @@ fn bench_push_n_elems_into_empty_vec_n100() {
 fn bench_push_n_elems_into_empty_vec_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.push_n_elems_into_empty_vec_n1000();
+}
+
+#[test]
+fn bench_push_n_elems_into_empty_vec_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.push_n_elems_into_empty_vec_n5000();
 }
 
 // === pop tests ===
@@ -858,6 +1112,12 @@ fn bench_pop_n1000() {
     caller.pop_n1000();
 }
 
+#[test]
+fn bench_pop_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.pop_n5000();
+}
+
 // === get tests ===
 
 #[test]
@@ -876,6 +1136,12 @@ fn bench_get_n100() {
 fn bench_get_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.get_n1000();
+}
+
+#[test]
+fn bench_get_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.get_n5000();
 }
 
 // === set tests ===
@@ -898,6 +1164,12 @@ fn bench_set_n1000() {
     caller.set_n1000();
 }
 
+#[test]
+fn bench_set_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.set_n5000();
+}
+
 // === first tests ===
 
 #[test]
@@ -916,6 +1188,12 @@ fn bench_first_n100() {
 fn bench_first_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.first_n1000();
+}
+
+#[test]
+fn bench_first_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.first_n5000();
 }
 
 // === last tests ===
@@ -938,6 +1216,12 @@ fn bench_last_n1000() {
     caller.last_n1000();
 }
 
+#[test]
+fn bench_last_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.last_n5000();
+}
+
 // === len tests ===
 
 #[test]
@@ -956,6 +1240,12 @@ fn bench_len_n100() {
 fn bench_len_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.len_n1000();
+}
+
+#[test]
+fn bench_len_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.len_n5000();
 }
 
 // === is_empty tests ===
@@ -978,6 +1268,12 @@ fn bench_is_empty_n1000() {
     caller.is_empty_n1000();
 }
 
+#[test]
+fn bench_is_empty_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.is_empty_n5000();
+}
+
 // === swap tests ===
 
 #[test]
@@ -996,6 +1292,12 @@ fn bench_swap_n100() {
 fn bench_swap_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.swap_n1000();
+}
+
+#[test]
+fn bench_swap_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.swap_n5000();
 }
 
 // === swap_remove tests ===
@@ -1018,6 +1320,12 @@ fn bench_swap_remove_n1000() {
     caller.swap_remove_n1000();
 }
 
+#[test]
+fn bench_swap_remove_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.swap_remove_n5000();
+}
+
 // === remove tests ===
 
 #[test]
@@ -1036,6 +1344,12 @@ fn bench_remove_n100() {
 fn bench_remove_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.remove_n1000();
+}
+
+#[test]
+fn bench_remove_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.remove_n5000();
 }
 
 // === insert tests ===
@@ -1058,6 +1372,12 @@ fn bench_insert_n1000() {
     caller.insert_n1000();
 }
 
+#[test]
+fn bench_insert_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.insert_n5000();
+}
+
 // === reverse tests ===
 
 #[test]
@@ -1076,6 +1396,12 @@ fn bench_reverse_n100() {
 fn bench_reverse_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.reverse_n1000();
+}
+
+#[test]
+fn bench_reverse_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.reverse_n5000();
 }
 
 // === fill tests ===
@@ -1098,6 +1424,12 @@ fn bench_fill_n1000() {
     caller.fill_n1000();
 }
 
+#[test]
+fn bench_fill_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.fill_n5000();
+}
+
 // === resize_grow tests ===
 
 #[test]
@@ -1116,6 +1448,12 @@ fn bench_resize_grow_n100() {
 fn bench_resize_grow_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.resize_grow_n1000();
+}
+
+#[test]
+fn bench_resize_grow_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.resize_grow_n5000();
 }
 
 // === resize_shrink tests ===
@@ -1138,6 +1476,12 @@ fn bench_resize_shrink_n1000() {
     caller.resize_shrink_n1000();
 }
 
+#[test]
+fn bench_resize_shrink_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.resize_shrink_n5000();
+}
+
 // === store_vec tests ===
 
 #[test]
@@ -1156,6 +1500,12 @@ fn bench_store_vec_n100() {
 fn bench_store_vec_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.store_vec_n1000();
+}
+
+#[test]
+fn bench_store_vec_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.store_vec_n5000();
 }
 
 // === load_vec tests ===
@@ -1178,6 +1528,12 @@ fn bench_load_vec_n1000() {
     caller.load_vec_n1000();
 }
 
+#[test]
+fn bench_load_vec_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.load_vec_n5000();
+}
+
 // === iter tests ===
 
 #[test]
@@ -1198,6 +1554,12 @@ fn bench_iter_n1000() {
     caller.iter_n1000();
 }
 
+#[test]
+fn bench_iter_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.iter_n5000();
+}
+
 // === clear tests ===
 
 #[test]
@@ -1216,5 +1578,11 @@ fn bench_clear_n100() {
 fn bench_clear_n1000() {
     let caller = abi(StorageVecS96Abi, CONTRACT_ID);
     caller.clear_n1000();
+}
+
+#[test]
+fn bench_clear_n5000() {
+    let caller = abi(StorageVecS96Abi, CONTRACT_ID);
+    caller.clear_n5000();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/src/main.sw
@@ -7,6 +7,90 @@ storage {
     vec: StorageVec<Struct96> = StorageVec {},
 }
 
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n10() {
+    let mut i = 0;
+    while i < 10 {
+        storage.vec.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n100() {
+    let mut i = 0;
+    while i < 100 {
+        storage.vec.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n1000() {
+    let mut i = 0;
+    while i < 1000 {
+        storage.vec.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+#[storage(read, write)]
+fn populate_n5000() {
+    let mut i = 0;
+    while i < 5000 {
+        storage.vec.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+}
+
+#[inline(never)]
+fn build_vec_n10() -> Vec<Struct96> {
+    let mut v = Vec::<Struct96>::new();
+    let mut i = 0;
+    while i < 10 {
+        v.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n100() -> Vec<Struct96> {
+    let mut v = Vec::<Struct96>::new();
+    let mut i = 0;
+    while i < 100 {
+        v.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n1000() -> Vec<Struct96> {
+    let mut v = Vec::<Struct96>::new();
+    let mut i = 0;
+    while i < 1000 {
+        v.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
+#[inline(never)]
+fn build_vec_n5000() -> Vec<Struct96> {
+    let mut v = Vec::<Struct96>::new();
+    let mut i = 0;
+    while i < 5000 {
+        v.push(STRUCT96_DEFAULT);
+        i += 1;
+    }
+    v
+}
+
 impl Contract {
 
     // === Baseline (empty contract method call) ===
@@ -17,117 +101,65 @@ impl Contract {
 
     #[storage(read, write)]
     fn baseline_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn baseline_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn baseline_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn baseline_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === Baselines (build heap Vec of N elements) ===
 
     fn baseline_store_vec_n10() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
     }
 
     fn baseline_store_vec_n100() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
     }
 
     fn baseline_store_vec_n1000() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
     }
 
     fn baseline_store_vec_n5000() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
     }
 
     // === push ===
 
     #[storage(read, write)]
     fn push_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.push(STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.push(STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.push(STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn push_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.push(STRUCT96_DEFAULT);
     }
 
@@ -135,79 +167,47 @@ impl Contract {
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
     }
 
     #[storage(read, write)]
     fn push_n_elems_into_empty_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
     }
 
     // === pop ===
 
     #[storage(read, write)]
     fn pop_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.pop();
     }
 
     #[storage(read, write)]
     fn pop_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.pop();
     }
 
@@ -215,41 +215,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn get_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.get(5).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.get(50).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.get(500).unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn get_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.get(2500).unwrap().try_read();
     }
 
@@ -257,41 +241,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn set_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.set(5, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.set(50, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.set(500, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn set_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.set(2500, STRUCT96_DEFAULT);
     }
 
@@ -299,41 +267,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn first_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn first_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.first().unwrap().try_read();
     }
 
@@ -341,41 +293,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn last_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
     #[storage(read, write)]
     fn last_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.last().unwrap().try_read();
     }
 
@@ -383,41 +319,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn len_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.len();
     }
 
     #[storage(read, write)]
     fn len_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.len();
     }
 
@@ -425,41 +345,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn is_empty_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.is_empty();
     }
 
     #[storage(read, write)]
     fn is_empty_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.is_empty();
     }
 
@@ -467,41 +371,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.swap(0, 9);
     }
 
     #[storage(read, write)]
     fn swap_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.swap(0, 99);
     }
 
     #[storage(read, write)]
     fn swap_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.swap(0, 999);
     }
 
     #[storage(read, write)]
     fn swap_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.swap(0, 4999);
     }
 
@@ -509,41 +397,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn swap_remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.swap_remove(5);
     }
 
     #[storage(read, write)]
     fn swap_remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.swap_remove(50);
     }
 
     #[storage(read, write)]
     fn swap_remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.swap_remove(500);
     }
 
     #[storage(read, write)]
     fn swap_remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.swap_remove(2500);
     }
 
@@ -551,41 +423,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn remove_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.remove(5);
     }
 
     #[storage(read, write)]
     fn remove_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.remove(50);
     }
 
     #[storage(read, write)]
     fn remove_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.remove(500);
     }
 
     #[storage(read, write)]
     fn remove_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.remove(2500);
     }
 
@@ -593,41 +449,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn insert_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.insert(5, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.insert(50, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.insert(500, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn insert_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.insert(2500, STRUCT96_DEFAULT);
     }
 
@@ -635,41 +475,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn reverse_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.reverse();
     }
 
     #[storage(read, write)]
     fn reverse_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.reverse();
     }
 
@@ -677,41 +501,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn fill_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.fill(STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.fill(STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.fill(STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn fill_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.fill(STRUCT96_DEFAULT);
     }
 
@@ -719,41 +527,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_grow_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(20, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(200, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(2000, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_grow_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(10000, STRUCT96_DEFAULT);
     }
 
@@ -761,41 +553,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn resize_shrink_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         storage.vec.resize(5, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         storage.vec.resize(50, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         storage.vec.resize(500, STRUCT96_DEFAULT);
     }
 
     #[storage(read, write)]
     fn resize_shrink_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         storage.vec.resize(2500, STRUCT96_DEFAULT);
     }
 
@@ -803,45 +579,25 @@ impl Contract {
 
     #[storage(write)]
     fn store_vec_n10() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 10 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n10();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n100() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 100 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n100();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n1000() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 1000 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n1000();
         storage.vec.store_vec(v);
     }
 
     #[storage(write)]
     fn store_vec_n5000() {
-        let mut v = Vec::<Struct96>::new();
-        let mut i = 0;
-        while i < 5000 {
-            v.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        let v = build_vec_n5000();
         storage.vec.store_vec(v);
     }
 
@@ -849,41 +605,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn load_vec_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.load_vec();
     }
 
     #[storage(read, write)]
     fn load_vec_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.load_vec();
     }
 
@@ -891,11 +631,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -903,11 +639,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -915,11 +647,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -927,11 +655,7 @@ impl Contract {
 
     #[storage(read, write)]
     fn iter_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         for elem in storage.vec.iter() {
             let _ = elem.try_read();
         }
@@ -941,41 +665,25 @@ impl Contract {
 
     #[storage(read, write)]
     fn clear_n10() {
-        let mut i = 0;
-        while i < 10 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n10();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n100() {
-        let mut i = 0;
-        while i < 100 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n100();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n1000() {
-        let mut i = 0;
-        while i < 1000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n1000();
         let _ = storage.vec.clear();
     }
 
     #[storage(read, write)]
     fn clear_n5000() {
-        let mut i = 0;
-        while i < 5000 {
-            storage.vec.push(STRUCT96_DEFAULT);
-            i += 1;
-        }
+        populate_n5000();
         let _ = storage.vec.clear();
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/test.toml
@@ -1,1 +1,2 @@
 category = "unit_tests_pass"
+unsupported_profiles = ["debug"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/storage_benchmarks/storage_vec_s96/test.toml
@@ -1,2 +1,1 @@
 category = "unit_tests_pass"
-unsupported_profiles = ["debug"]

--- a/test/src/in_language_tests/test_programs/test_types/src/main.sw
+++ b/test/src/in_language_tests/test_programs/test_types/src/main.sw
@@ -821,6 +821,7 @@ impl TestInstance for EnumLargerThanQuadSlot {
     }
 }
 
+// Size: 5 * 8 + 32 = 72 bytes
 pub struct StructA {
     f_bool: bool,
     f_u8: u8,
@@ -901,6 +902,7 @@ impl TestInstance for StructA {
     }
 }
 
+// Size: 72 + (4 * 8 + 32) + 8 + 8 = 152 bytes
 pub struct StructB {
     f_struct_a: StructA,
     f_tuple: (u8, u16, u32, u64, u256),
@@ -912,6 +914,7 @@ pub struct StructB {
     f_array_nested_array_u8_len_2_len_3: [[u8; 2]; 3],
 }
 
+// Size: 152 * 2 = 304 bytes
 pub type ArrayStructBLen2 = [StructB; 2];
 
 impl PartialEq for StructB {


### PR DESCRIPTION
## Description

This PR implements a chunk-based dynamic storage `StorageVec<V>`:
- vec content is stored in consecutive dynamic storage slots each holding at most `CHUNK_MAX_SIZE` bytes of element data.
- all slots hold the same maximum number of elements: `CHUNK_MAX_SIZE / size_of::<V>()`.
- individual elements are always stored in a single slot; i.e. they never cross slot boundaries.
- the first slot contains a `u64` length header followed by up to `CHUNK_MAX_SIZE` bytes of element data.

As shown in Performance Comparison, this implementation outperform the current one (where all the elements are stored in a single slot, without the length header) in almost all the operations except:
- for small vectors
- for bulk operations like `reverse` and growing `resize`

## Future Improvements

Additional measurements have shown that:
- having all the content in a single slot, but with the length header, performs better than the current implementation (single slot, no length header) on all benchmarks for small vectors.
- different chunk sizes in the chunk-based `StorageVec` sizes have different trade-offs for different methods. Being able to choose the `CHUNK_MAX_SIZE` based on an application particular storage usage is benefitial.
- bulk operations like `remove`, `fill`, `revert`, etc. might benefit from two different implementations, one that is allocation-heavy and does the operation in memory, vs. one that is more allocation-friendly but requires more storage access.

Based on those insights, we plan the following future improvements:
- including a `SmallStorageVec<V>` in the `std` which will implement a single slot plus length header storage vec optimized for content up to ~2kb.
- implementing a `ChunkedStorageVec<V, const CHUNK_MAX_SIZE>` which will allow devs to specify the size. Standard `StorageVec` will than be just a type alias: `type StorageVec<V> = ChunkedStorageVec<V, 1024>`. To be able to implement this, we first need to the language support for generic type aliases.
- additionally, we might consider additionally parameterizing the `ChunkedStorageVec` with different strategies for bulk operations.

## Performance Comparison

This is the performance comparison between the current `StorageVec` implementation and the chunk-based one, for the `storage_vec_s8` and `storage_vec_s96` projects.

For smaller vectors, having the whole vector in a single slot gives better performance (and justifies having a `SmallStorageVec`). The chunked based `StorageVec` performs better on vectors whose element size is greater than ~2kb.

| Bench                                   |   Before |    After | Difference | Percentage |
|:----------------------------------------|---------:|---------:|-----------:|-----------:|
| bench_push_n10                          |      734 |      998 |       -264 |    -35.97% |
| bench_push_n100                         |      784 |     1096 |       -312 |    -39.80% |
| bench_push_n1000                        |     1049 |     1104 |        -55 |     -5.24% |
| bench_push_n5000                        |     2273 |     1074 |       1199 |     52.75% |
| bench_push_n_elems_into_empty_vec_n10   |     7810 |    11074 |      -3264 |    -41.79% |
| bench_push_n_elems_into_empty_vec_n100  |    72513 |   103074 |     -30561 |    -42.15% |
| bench_push_n_elems_into_empty_vec_n1000 |   855685 |  1067659 |    -211974 |    -24.77% |
| bench_push_n_elems_into_empty_vec_n5000 |  7334420 |  5356522 |    1977898 |     26.97% |
| bench_pop_n10                           |      301 |      379 |        -78 |    -25.91% |
| bench_pop_n100                          |      374 |      471 |        -97 |    -25.94% |
| bench_pop_n1000                         |      899 |      504 |        395 |     43.94% |
| bench_pop_n5000                         |     3166 |      480 |       2686 |     84.84% |
| bench_get_n10                           |      245 |      275 |        -30 |    -12.24% |
| bench_get_n100                          |      302 |      330 |        -28 |     -9.27% |
| bench_get_n1000                         |      743 |      350 |        393 |     52.89% |
| bench_get_n5000                         |     2683 |      350 |       2333 |     86.95% |
| bench_set_n10                           |      253 |      309 |        -56 |    -22.13% |
| bench_set_n100                          |      330 |      384 |        -54 |    -16.36% |
| bench_set_n1000                         |      843 |      421 |        422 |     50.06% |
| bench_set_n5000                         |     3037 |      421 |       2616 |     86.14% |
| bench_first_n10                         |      252 |      266 |        -14 |     -5.56% |
| bench_first_n100                        |      304 |      316 |        -12 |     -3.95% |
| bench_first_n1000                       |      735 |      324 |        411 |     55.92% |
| bench_first_n5000                       |     2675 |      325 |       2350 |     87.85% |
| bench_last_n10                          |      269 |      298 |        -29 |    -10.78% |
| bench_last_n100                         |      326 |      353 |        -27 |     -8.28% |
| bench_last_n1000                        |      766 |      366 |        400 |     52.22% |
| bench_last_n5000                        |     2706 |      342 |       2364 |     87.36% |
| bench_len_n10                           |       44 |       43 |          1 |      2.27% |
| bench_len_n100                          |       88 |       85 |          3 |      3.41% |
| bench_len_n1000                         |      316 |      102 |        214 |     67.72% |
| bench_len_n5000                         |     1286 |      102 |       1184 |     92.07% |
| bench_is_empty_n10                      |       82 |       81 |          1 |      1.22% |
| bench_is_empty_n100                     |       96 |       93 |          3 |      3.12% |
| bench_is_empty_n1000                    |      319 |      105 |        214 |     67.08% |
| bench_is_empty_n5000                    |     1289 |      105 |       1184 |     91.85% |
| bench_swap_n10                          |      576 |      655 |        -79 |    -13.72% |
| bench_swap_n100                         |      725 |      802 |        -77 |    -10.62% |
| bench_swap_n1000                        |     1919 |      818 |       1101 |     57.37% |
| bench_swap_n5000                        |     7277 |      764 |       6513 |     89.50% |
| bench_swap_remove_n10                   |      323 |      685 |       -362 |   -112.07% |
| bench_swap_remove_n100                  |      366 |      797 |       -431 |   -117.76% |
| bench_swap_remove_n1000                 |      886 |      842 |         44 |      4.97% |
| bench_swap_remove_n5000                 |     3153 |      818 |       2335 |     74.06% |
| bench_remove_n10                        |      351 |      670 |       -319 |    -90.88% |
| bench_remove_n100                       |      374 |      762 |       -388 |   -103.74% |
| bench_remove_n1000                      |      903 |     2817 |      -1914 |   -211.96% |
| bench_remove_n5000                      |     3250 |    10875 |      -7625 |   -234.62% |
| bench_insert_n10                        |     1015 |     1247 |       -232 |    -22.86% |
| bench_insert_n100                       |     1118 |     1375 |       -257 |    -22.99% |
| bench_insert_n1000                      |     2106 |     3384 |      -1278 |    -60.68% |
| bench_insert_n5000                      |     6567 |    11301 |      -4734 |    -72.09% |
| bench_reverse_n10                       |      424 |      460 |        -36 |     -8.49% |
| bench_reverse_n100                      |     1517 |     1483 |         34 |      2.24% |
| bench_reverse_n1000                     |    12357 |   334571 |    -322214 |  -2607.54% |
| bench_reverse_n5000                     |    60624 |  1679483 |   -1618859 |  -2670.33% |
| bench_fill_n10                          |      326 |     1698 |      -1372 |   -420.86% |
| bench_fill_n100                         |     1257 |     1748 |       -491 |    -39.06% |
| bench_fill_n1000                        |    10549 |     2898 |       7651 |     72.53% |
| bench_fill_n5000                        |    51846 |     8076 |      43770 |     84.42% |
| bench_resize_grow_n10                   |     5440 |     7586 |      -2146 |    -39.45% |
| bench_resize_grow_n100                  |    51760 |    75387 |     -23627 |    -45.65% |
| bench_resize_grow_n1000                 |   514943 |   751303 |    -236360 |    -45.90% |
| bench_resize_grow_n5000                 |  2573538 |  3755298 |   -1181760 |    -45.92% |
| bench_resize_shrink_n10                 |      310 |      304 |          6 |      1.94% |
| bench_resize_shrink_n100                |      349 |      344 |          5 |      1.43% |
| bench_resize_shrink_n1000               |      822 |      360 |        462 |     56.20% |
| bench_resize_shrink_n5000               |     2925 |      360 |       2565 |     87.69% |
| bench_store_vec_n10                     |     5232 |     6659 |      -1427 |    -27.27% |
| bench_store_vec_n100                    |    50603 |    52030 |      -1427 |     -2.82% |
| bench_store_vec_n1000                   |   504235 |   506811 |      -2576 |     -0.51% |
| bench_store_vec_n5000                   |  2520489 |  2528277 |      -7788 |     -0.31% |
| bench_load_vec_n10                      |      294 |      311 |        -17 |     -5.78% |
| bench_load_vec_n100                     |      333 |      348 |        -15 |     -4.50% |
| bench_load_vec_n1000                    |      822 |     1006 |       -184 |    -22.38% |
| bench_load_vec_n5000                    |     2952 |     3860 |       -908 |    -30.76% |
| bench_iter_n10                          |     2681 |     2940 |       -259 |     -9.66% |
| bench_iter_n100                         |    27785 |    30382 |      -2597 |     -9.35% |
| bench_iter_n1000                        |   494403 |   309437 |     184966 |     37.41% |
| bench_iter_n5000                        |  7316373 |  1544821 |    5771552 |     78.89% |
| bench_clear_n10                         |       96 |       96 |          0 |      0.00% |
| bench_clear_n100                        |       98 |       96 |          2 |      2.04% |
| bench_clear_n1000                       |       98 |       96 |          2 |      2.04% |
| bench_clear_n5000                       |       98 |       96 |          2 |      2.04% |

| Bench                                   |   Before |    After | Difference | Percentage |
|:----------------------------------------|---------:|---------:|-----------:|-----------:|
| bench_push_n10                          |     6321 |     7319 |       -998 |    -15.79% |
| bench_push_n100                         |     6670 |     7339 |       -669 |    -10.03% |
| bench_push_n1000                        |     9965 |     7329 |       2636 |     26.45% |
| bench_push_n5000                        |    24649 |     7329 |      17320 |     70.27% |
| bench_push_n_elems_into_empty_vec_n10   |    63637 |    67051 |      -3414 |     -5.36% |
| bench_push_n_elems_into_empty_vec_n100  |   645943 |   668697 |     -22754 |     -3.52% |
| bench_push_n_elems_into_empty_vec_n1000 |  8104285 |  6685021 |    1419264 |     17.51% |
| bench_push_n_elems_into_empty_vec_n5000 | 77228220 | 33424226 |   43803994 |     56.72% |
| bench_pop_n10                           |      371 |      478 |       -107 |    -28.84% |
| bench_pop_n100                          |     1002 |      499 |        503 |     50.20% |
| bench_pop_n1000                         |     7139 |      514 |       6625 |     92.80% |
| bench_pop_n5000                         |    34341 |      512 |      33829 |     98.51% |
| bench_get_n10                           |      309 |      339 |        -30 |     -9.71% |
| bench_get_n100                          |      842 |      351 |        491 |     58.31% |
| bench_get_n1000                         |     6086 |      357 |       5729 |     94.13% |
| bench_get_n5000                         |    29358 |      357 |      29001 |     98.78% |
| bench_set_n10                           |      326 |      382 |        -56 |    -17.18% |
| bench_set_n100                          |      942 |      408 |        534 |     56.69% |
| bench_set_n1000                         |     6885 |      428 |       6457 |     93.78% |
| bench_set_n5000                         |    33205 |      428 |      32777 |     98.71% |
| bench_first_n10                         |      317 |      331 |        -14 |     -4.42% |
| bench_first_n100                        |      844 |      336 |        508 |     60.19% |
| bench_first_n1000                       |     6077 |      331 |       5746 |     94.55% |
| bench_first_n5000                       |    29349 |      331 |      29018 |     98.87% |
| bench_last_n10                          |      334 |      363 |        -29 |     -8.68% |
| bench_last_n100                         |      866 |      374 |        492 |     56.81% |
| bench_last_n1000                        |     6109 |      378 |       5731 |     93.81% |
| bench_last_n5000                        |    29381 |      379 |      29002 |     98.71% |
| bench_len_n10                           |       71 |       70 |          1 |      1.41% |
| bench_len_n100                          |      352 |       90 |        262 |     74.43% |
| bench_len_n1000                         |     2981 |      100 |       2881 |     96.65% |
| bench_len_n5000                         |    14617 |      100 |      14517 |     99.32% |
| bench_is_empty_n10                      |      109 |      108 |          1 |      0.92% |
| bench_is_empty_n100                     |      360 |       98 |        262 |     72.78% |
| bench_is_empty_n1000                    |     2984 |      103 |       2881 |     96.55% |
| bench_is_empty_n5000                    |    14620 |      103 |      14517 |     99.30% |
| bench_swap_n10                          |      729 |      808 |        -79 |    -10.84% |
| bench_swap_n100                         |     2197 |      834 |       1363 |     62.04% |
| bench_swap_n1000                        |    16652 |      824 |      15828 |     95.05% |
| bench_swap_n5000                        |    80928 |      824 |      80104 |     98.98% |
| bench_swap_remove_n10                   |      407 |      858 |       -451 |   -110.81% |
| bench_swap_remove_n100                  |     1008 |      850 |        158 |     15.67% |
| bench_swap_remove_n1000                 |     7140 |      860 |       6280 |     87.96% |
| bench_swap_remove_n5000                 |    34342 |      860 |      33482 |     97.50% |
| bench_remove_n10                        |      435 |      842 |       -407 |    -93.56% |
| bench_remove_n100                       |     1038 |     2814 |      -1776 |   -171.10% |
| bench_remove_n1000                      |     7376 |    25314 |     -17938 |   -243.19% |
| bench_remove_n5000                      |    35539 |   125314 |     -89775 |   -252.61% |
| bench_insert_n10                        |     6697 |     7115 |       -418 |     -6.24% |
| bench_insert_n100                       |     7898 |     9087 |      -1189 |    -15.05% |
| bench_insert_n1000                      |    19928 |    31257 |     -11329 |    -56.85% |
| bench_insert_n5000                      |    73451 |   129857 |     -56406 |    -76.79% |
| bench_reverse_n10                       |      487 |      552 |        -65 |    -13.35% |
| bench_reverse_n100                      |     2138 |    33463 |     -31325 |  -1465.15% |
| bench_reverse_n1000                     |    18589 |   333143 |    -314554 |  -1692.15% |
| bench_reverse_n5000                     |    91792 |  1665143 |   -1573351 |  -1714.04% |
| bench_fill_n10                          |      373 |      472 |        -99 |    -26.54% |
| bench_fill_n100                         |     1623 |     1923 |       -300 |    -18.48% |
| bench_fill_n1000                        |    14125 |    16413 |      -2288 |    -16.20% |
| bench_fill_n5000                        |    69692 |    80813 |     -11121 |    -15.96% |
| bench_resize_grow_n10                   |    60963 |    63948 |      -2985 |     -4.90% |
| bench_resize_grow_n100                  |   606882 |   636240 |     -29358 |     -4.84% |
| bench_resize_grow_n1000                 |  6066088 |  6359160 |    -293072 |     -4.83% |
| bench_resize_grow_n5000                 | 30329221 | 31794360 |   -1465139 |     -4.83% |
| bench_resize_shrink_n10                 |      379 |      376 |          3 |      0.79% |
| bench_resize_shrink_n100                |      936 |      366 |        570 |     60.90% |
| bench_resize_shrink_n1000               |     6615 |      366 |       6249 |     94.47% |
| bench_resize_shrink_n5000               |    31852 |      366 |      31486 |     98.85% |
| bench_store_vec_n10                     |    60679 |    62108 |      -1429 |     -2.36% |
| bench_store_vec_n100                    |   605073 |   607970 |      -2897 |     -0.48% |
| bench_store_vec_n1000                   |  6048933 |  6066445 |     -17512 |     -0.29% |
| bench_store_vec_n5000                   | 30243981 | 30326445 |     -82464 |     -0.27% |
| bench_load_vec_n10                      |      353 |      372 |        -19 |     -5.38% |
| bench_load_vec_n100                     |      916 |     1158 |       -242 |    -26.42% |
| bench_load_vec_n1000                    |     6677 |     9061 |      -2384 |    -35.70% |
| bench_load_vec_n5000                    |    32234 |    44146 |     -11912 |    -36.95% |
| bench_iter_n10                          |     3080 |     3339 |       -259 |     -8.41% |
| bench_iter_n100                         |    55651 |    31979 |      23672 |     42.54% |
| bench_iter_n1000                        |  3174070 |   318179 |    2855891 |     89.98% |
| bench_iter_n5000                        | 74044706 |  1585179 |   72459527 |     97.86% |
| bench_clear_n10                         |       96 |       96 |          0 |      0.00% |
| bench_clear_n100                        |       96 |       96 |          0 |      0.00% |
| bench_clear_n1000                       |       96 |       96 |          0 |      0.00% |
| bench_clear_n5000                       |       96 |       96 |          0 |      0.00% |

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.