### PR TITLE
Fix swayfmt comment placement after multibyte comments

### DIFF
--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -1351,7 +1351,9 @@ impl<V> StorageKey<StorageVec<V>> {
             // requires the offset to be within the currently used size. Writing the length
             // first establishes those 8 bytes so subsequent updates to the same slot at
             // offset ≥ 8 are valid.
-            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8); // Compute which slot and offset to write the new element.
+            __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
+
+            // Compute which slot and offset to write the new element.
             let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len);
             __state_update_slot(elem_slot, __addr_of(value), elem_offset, SIZE_OF_V);
         }
@@ -2717,20 +2719,27 @@ impl<V> StorageKey<StorageVec<V>> {
                 return;
             }
 
-            let (elements_ptr, elements_bytes) = vec.as_raw_slice().into_parts(); // Every slot holds the same number of elements. The element area of each
-// slot is CHUNK_MAX_SIZE bytes, so `slot_elem_bytes` is the maximum byte
-// count for that area. Note: `slot_elem_bytes <= CHUNK_MAX_SIZE` always,
-// since we floor-divide then multiply back.
+            let (elements_ptr, elements_bytes) = vec.as_raw_slice().into_parts();
 
-// TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
-//       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
+            // Every slot holds the same number of elements. The element area of each
+            // slot is CHUNK_MAX_SIZE bytes, so `slot_elem_bytes` is the maximum byte
+            // count for that area. Note: `slot_elem_bytes <= CHUNK_MAX_SIZE` always,
+            // since we floor-divide then multiply back.
+
+            // TODO: Move `SIZE_OF_V` to the top of `else`, like in all other methods,
+            //       once https://github.com/FuelLabs/sway/issues/7650 is fixed.
             const SIZE_OF_V: u64 = __size_of::<V>();
             const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
-            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V; // All elements fit in the first slot (after the 8-byte header).
+            const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
+
+            // All elements fit in the first slot (after the 8-byte header).
             if elements_bytes <= SLOT_ELEM_BYTES {
                 __state_update_slot(field_id, elements_ptr, 8, elements_bytes);
-            } else { // Write the first slot's full element area into slot 0 (at byte offset 8).
-                __state_update_slot(field_id, elements_ptr, 8, SLOT_ELEM_BYTES); // Write the remaining elements into subsequent chunk slots.
+            } else {
+                // Write the first slot's full element area into slot 0 (at byte offset 8).
+                __state_update_slot(field_id, elements_ptr, 8, SLOT_ELEM_BYTES);
+
+                // Write the remaining elements into subsequent chunk slots.
                 let mut bytes_written = SLOT_ELEM_BYTES;
                 let mut chunk_number: u64 = 1;
                 while bytes_written < elements_bytes {

--- a/swayfmt/src/comments.rs
+++ b/swayfmt/src/comments.rs
@@ -303,11 +303,7 @@ fn insert_after_span(
     if !is_empty_block(formatted_code, insertion_index) {
         // There can be cases where comments are at the end.
         // If so, we try to 'pin' our comment's indentation to the previous line instead.
-        if formatted_code[insertion_index + indent.len()..]
-            .chars()
-            .next()
-            == Some('}')
-        {
+        if formatted_code[insertion_index + indent.len()..].starts_with('}') {
             // It could be possible that the first comment found here is a Trailing,
             // then a Newlined.
             // We want all subsequent newlined comments to follow the indentation of the

--- a/swayfmt/src/comments.rs
+++ b/swayfmt/src/comments.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     Format, Formatter, FormatterError,
 };
-use ropey::Rope;
 use std::{fmt::Write, ops::Range};
 use sway_ast::token::{Comment, CommentKind};
 use sway_types::{Span, Spanned};
@@ -263,7 +262,7 @@ fn collect_extra_newlines(unformatted_span: Span, comments_found: &Vec<Comment>)
 
 /// Check if a block is empty. When formatted without comments, empty code blocks are formatted into "{}", which is what this check is for.
 fn is_empty_block(formatted_code: &FormattedCode, end: usize) -> bool {
-    formatted_code.chars().nth(end - 1) == Some('{') && formatted_code.chars().nth(end) == Some('}')
+    end > 0 && formatted_code[..end].ends_with('{') && formatted_code[end..].starts_with('}')
 }
 
 /// Main driver of writing comments. This function is a no-op if the block of code is empty.
@@ -285,10 +284,15 @@ fn insert_after_span(
     extra_newlines: Vec<usize>,
 ) -> Result<usize, FormatterError> {
     let mut comment_str = String::new();
+    let insertion_index = from.end + offset;
+
+    if !formatted_code.is_char_boundary(insertion_index) {
+        return Err(FormatterError::CommentError);
+    }
 
     // We want to anchor the comment to the next line, and here,
     // we make the assumption here that comments will never be right before the final leaf span.
-    let mut indent = formatted_code[from.end + offset..]
+    let mut indent = formatted_code[insertion_index..]
         .chars()
         .take_while(|c| c.is_whitespace())
         .collect::<String>();
@@ -296,10 +300,14 @@ fn insert_after_span(
     // In the case of empty blocks, we do not know the indentation of comments at that time.
     // Writing comments in empty blocks has to be deferred to `write_comments` instead, which will
     // contain the Formatter's indentation context.
-    if !is_empty_block(formatted_code, from.end) {
+    if !is_empty_block(formatted_code, insertion_index) {
         // There can be cases where comments are at the end.
         // If so, we try to 'pin' our comment's indentation to the previous line instead.
-        if formatted_code.chars().nth(from.end + offset + indent.len()) == Some('}') {
+        if formatted_code[insertion_index + indent.len()..]
+            .chars()
+            .next()
+            == Some('}')
+        {
             // It could be possible that the first comment found here is a Trailing,
             // then a Newlined.
             // We want all subsequent newlined comments to follow the indentation of the
@@ -309,7 +317,7 @@ fn insert_after_span(
                 .any(|c| c.comment_kind == CommentKind::Newlined)
             {
                 // Find and assign the indentation of the previous line to `indent`.
-                let prev_line = formatted_code[..from.end + offset]
+                let prev_line = formatted_code[..insertion_index]
                     .trim_end()
                     .chars()
                     .rev()
@@ -350,11 +358,11 @@ fn insert_after_span(
                     }
                 }
                 CommentKind::Inlined => {
-                    if !formatted_code[..from.end].ends_with(' ') {
+                    if !formatted_code[..insertion_index].ends_with(' ') {
                         write!(comment_str, " ")?;
                     }
                     write!(comment_str, "{}", comment.span().as_str())?;
-                    if !formatted_code[from.end + offset..].starts_with([' ', '\n']) {
+                    if !formatted_code[insertion_index..].starts_with([' ', '\n']) {
                         write!(comment_str, " ")?;
                     }
                 }
@@ -364,28 +372,19 @@ fn insert_after_span(
             };
         }
 
-        let mut src_rope = Rope::from_str(formatted_code);
-
         // We do a sanity check here to ensure that we don't insert an extra newline
         // if the place at which we're going to insert comments already ends with '\n'.
-        if let Some(char) = src_rope.get_char(from.end + offset) {
+        if let Some(char) = formatted_code[insertion_index..].chars().next() {
             if char == '\n' && comment_str.ends_with('\n') {
                 comment_str.pop();
             }
         };
 
         // Insert the actual comment(s).
-        src_rope
-            .try_insert(from.end + offset, &comment_str)
-            .map_err(|_| FormatterError::CommentError)?;
-
-        formatted_code.clear();
-        formatted_code.push_str(&src_rope.to_string());
+        formatted_code.insert_str(insertion_index, &comment_str);
     }
 
-    // In order to handle special characters, we return the number of characters rather than
-    // the size of the string.
-    Ok(comment_str.chars().count())
+    Ok(comment_str.len())
 }
 
 #[cfg(test)]

--- a/swayfmt/tests/mod.rs
+++ b/swayfmt/tests/mod.rs
@@ -63,6 +63,108 @@ fn const_spacing() {
 }
 
 #[test]
+fn statement_comments_in_impl_function_body_keep_statement_indentation() {
+    check(
+        indoc! {r#"
+        contract;
+
+        impl StorageKey<StorageVec<V>> {
+            fn push(self, value: V) {
+                let len = self.len();
+                // first establishes those 8 bytes so subsequent updates to the same slot at
+                // offset ≥ 8 are valid.
+                __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
+
+                // Compute which slot and offset to write the new element.
+                let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len);
+                __state_update_slot(elem_slot, __addr_of(value), elem_offset, SIZE_OF_V);
+            }
+        }
+        "#},
+        indoc! {r#"
+        contract;
+
+        impl StorageKey<StorageVec<V>> {
+            fn push(self, value: V) {
+                let len = self.len();
+                // first establishes those 8 bytes so subsequent updates to the same slot at
+                // offset ≥ 8 are valid.
+                __state_update_slot(self.field_id(), __addr_of(new_len), 0, 8);
+
+                // Compute which slot and offset to write the new element.
+                let (elem_slot, elem_offset) = self.get_slot_and_offset_of_elem(len);
+                __state_update_slot(elem_slot, __addr_of(value), elem_offset, SIZE_OF_V);
+            }
+        }
+        "#},
+    )
+}
+
+#[test]
+fn comments_after_block_items_keep_statement_indentation() {
+    check(
+        indoc! {r#"
+        contract;
+
+        impl StorageKey<StorageVec<V>> {
+            fn store_vec(self, vec: Vec<V>) {
+                // targeting slot 0 at offset ≥ 8 have a valid base.
+                __state_update_slot(self.field_id(), __addr_of(len), 0, 8);
+
+                let (elements_ptr, elements_bytes) = vec.as_raw_slice().into_parts();
+
+                // Every slot holds the same number of elements.
+                // The element area of each slot is CHUNK_MAX_SIZE bytes.
+                const SIZE_OF_V: u64 = __size_of::<V>();
+                const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
+                const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
+
+                // All elements fit in the first slot.
+                if elements_bytes <= SLOT_ELEM_BYTES {
+                    __state_update_slot(self.field_id(), elements_ptr, 8, elements_bytes);
+                } else {
+                    // Write the first slot's full element area into slot 0.
+                    __state_update_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES);
+
+                    // Write the remaining elements into subsequent chunk slots.
+                    let mut bytes_written = SLOT_ELEM_BYTES;
+                }
+            }
+        }
+        "#},
+        indoc! {r#"
+        contract;
+
+        impl StorageKey<StorageVec<V>> {
+            fn store_vec(self, vec: Vec<V>) {
+                // targeting slot 0 at offset ≥ 8 have a valid base.
+                __state_update_slot(self.field_id(), __addr_of(len), 0, 8);
+
+                let (elements_ptr, elements_bytes) = vec.as_raw_slice().into_parts();
+
+                // Every slot holds the same number of elements.
+                // The element area of each slot is CHUNK_MAX_SIZE bytes.
+                const SIZE_OF_V: u64 = __size_of::<V>();
+                const ELEMS_PER_SLOT: u64 = CHUNK_MAX_SIZE / SIZE_OF_V;
+                const SLOT_ELEM_BYTES: u64 = ELEMS_PER_SLOT * SIZE_OF_V;
+
+                // All elements fit in the first slot.
+                if elements_bytes <= SLOT_ELEM_BYTES {
+                    __state_update_slot(self.field_id(), elements_ptr, 8, elements_bytes);
+                } else {
+                    // Write the first slot's full element area into slot 0.
+                    __state_update_slot(self.field_id(), elements_ptr, 8, SLOT_ELEM_BYTES);
+
+                    // Write the remaining elements into subsequent chunk slots.
+                    let mut bytes_written = SLOT_ELEM_BYTES;
+                }
+            }
+        }
+        "#},
+    )
+}
+
+#[test]
 fn struct_alignment() {
     let mut formatter = Formatter::default();
     formatter.config.structures.field_alignment = FieldAlignment::AlignFields(40);


### PR DESCRIPTION
Fixes #7651.

## Description

This fixes `forc fmt` displacing line comments after earlier inserted comments contain multibyte characters such as `≥`.

The formatter compares parser leaf spans and reinserts comments into formatted code. Those spans are byte offsets, but the comment insertion path returned the inserted comment length as a character count. After a multibyte character appeared in an inserted comment, later insertion offsets drifted, causing comments to lose indentation or attach to the previous statement.

The comment insertion path now stays byte-indexed throughout, validates insertion points against UTF-8 char boundaries, and uses direct string insertion at the computed byte offset.

After #7649 merged, this branch was rebased onto `master` and the fixed formatter was run over `sway-lib-std/src/storage/storage_vec.sw`. The formatter now repairs the column-zero displaced comments; the remaining comments that had already been merged as true trailing comments were restored to their intended standalone lines and formatter-verified.

## Validation

- `cargo clippy -p swayfmt --lib --no-deps -- -D warnings`
- `cargo test -p swayfmt --quiet`
- `cargo fmt -p swayfmt -- --check`
- `git diff --check`
- `cargo run -q -p forc-fmt -- --file sway-lib-std/src/storage/storage_vec.sw`
- Earlier smoke-formatted the pre-workaround `storage_vec.sw` from PR #7649 commit `2a879cd4338a4ec118c4412685f1347f63a11a5d` and confirmed the reported comment blocks remain correctly indented.