### PR TITLE
Refactor `InstOp::GetConfig` for consistency

### DIFF
--- a/sway-core/src/asm_generation/evm/evm_asm_builder.rs
+++ b/sway-core/src/asm_generation/evm/evm_asm_builder.rs
@@ -341,7 +341,7 @@ impl<'ir, 'eng> EvmAsmBuilder<'ir, 'eng> {
                 } => self.compile_get_elem_ptr(instr_val, base, elem_ptr_ty, indices),
                 InstOp::GetLocal(local_var) => self.compile_get_local(instr_val, local_var),
                 InstOp::GetGlobal(global_var) => self.compile_get_global(instr_val, global_var),
-                InstOp::GetConfig(_, name) => self.compile_get_config(instr_val, name),
+                InstOp::GetConfig(config) => self.compile_get_config(instr_val, config),
                 InstOp::GetStorageKey(storage_key) => {
                     self.compile_get_storage_key(instr_val, storage_key)
                 }
@@ -478,7 +478,7 @@ impl<'ir, 'eng> EvmAsmBuilder<'ir, 'eng> {
         todo!();
     }
 
-    fn compile_get_config(&mut self, instr_val: &Value, name: &str) {
+    fn compile_get_config(&mut self, instr_val: &Value, config: &Config) {
         todo!();
     }
 

--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -82,7 +82,7 @@ fn compile(
     }
 
     for config in module.iter_configs(context) {
-        builder.compile_configurable(config);
+        builder.compile_configurable(config.get_content(context));
     }
 
     for function in module.function_iter(context) {

--- a/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
+++ b/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
@@ -521,7 +521,7 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
                 InstOp::GetGlobal(global_var) => {
                     self.compile_get_global(instr_val, global_var, module)
                 }
-                InstOp::GetConfig(_, name) => self.compile_get_config(instr_val, name),
+                InstOp::GetConfig(config) => self.compile_get_config(instr_val, config),
                 InstOp::GetStorageKey(storage_key) => {
                     self.compile_get_storage_key(instr_val, storage_key, module)
                 }
@@ -1436,7 +1436,12 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
         }
     }
 
-    fn compile_get_config(&mut self, addr_val: &Value, name: &String) -> Result<(), CompileError> {
+    fn compile_get_config(
+        &mut self,
+        addr_val: &Value,
+        config: &Config,
+    ) -> Result<(), CompileError> {
+        let name = config.get_name(self.context);
         let addr_reg = self.reg_seqr.next();
 
         // if configurable is at the global_section, it is v1

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -4475,10 +4475,14 @@ impl<'a> FnCompiler<'a> {
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<TerminatorValue, CompileError> {
         let name = decl.call_path.suffix.as_str();
+        let config = self
+            .module
+            .get_config(context, name)
+            .expect("the configurable declaration must have a corresponding config in the module");
         let val = self
             .current_block
             .append(context)
-            .get_config(self.module, name.to_string())
+            .get_config(config)
             .add_metadatum(context, span_md_idx);
         Ok(TerminatorValue::new(CompiledValue::InMemory(val), context))
     }
@@ -4518,17 +4522,12 @@ impl<'a> FnCompiler<'a> {
                 .get_global(global_val)
                 .add_metadatum(context, span_md_idx);
             Ok(TerminatorValue::new(CompiledValue::InMemory(val), context))
-        } else if self
+        } else if let Some(config) = self
             .module
             .get_config(context, &call_path.suffix.to_string())
-            .is_some()
         {
-            let name = call_path.suffix.to_string();
-            let config_val = Value::new_instruction(
-                context,
-                self.current_block,
-                InstOp::GetConfig(self.module, name),
-            );
+            let config_val =
+                Value::new_instruction(context, self.current_block, InstOp::GetConfig(config));
             Ok(TerminatorValue::new(
                 CompiledValue::InMemory(config_val),
                 context,

--- a/sway-ir/src/analysis/memory_utils.rs
+++ b/sway-ir/src/analysis/memory_utils.rs
@@ -280,7 +280,7 @@ fn get_symbols(context: &Context, val: Value, gep_only: bool) -> ReferredSymbols
             // We've reached a configurable at the top of the chain.
             // There cannot be a symbol behind it, and so the returned set is complete.
             ValueDatum::Instruction(Instruction {
-                op: InstOp::GetConfig(_, _),
+                op: InstOp::GetConfig(_),
                 ..
             }) if !gep_only => (),
             // We've reached a global at the top of the chain.
@@ -439,7 +439,7 @@ fn compute_escaped_symbols(context: &Context, function: &Function) -> EscapedSym
             InstOp::FuelVm(_) => (),
             InstOp::GetLocal(_) => (),
             InstOp::GetGlobal(_) => (),
-            InstOp::GetConfig(_, _) => (),
+            InstOp::GetConfig(_) => (),
             InstOp::GetStorageKey(_) => (),
             InstOp::GetElemPtr { .. } => (),
             InstOp::IntToPtr(_, _) => (),
@@ -486,7 +486,7 @@ pub fn get_loaded_ptr_values(context: &Context, inst: Value) -> Vec<Value> {
         | InstOp::CastPtr(_, _)
         | InstOp::GetLocal(_)
         | InstOp::GetGlobal(_)
-        | InstOp::GetConfig(_, _)
+        | InstOp::GetConfig(_)
         | InstOp::GetStorageKey(_)
         | InstOp::GetElemPtr { .. }
         | InstOp::IntToPtr(_, _) => vec![],
@@ -601,7 +601,7 @@ pub fn get_stored_ptr_values(context: &Context, inst: Value) -> Vec<Value> {
         | InstOp::CastPtr(_, _)
         | InstOp::GetLocal(_)
         | InstOp::GetGlobal(_)
-        | InstOp::GetConfig(_, _)
+        | InstOp::GetConfig(_)
         | InstOp::GetStorageKey(_)
         | InstOp::GetElemPtr { .. }
         | InstOp::IntToPtr(_, _) => vec![],

--- a/sway-ir/src/config.rs
+++ b/sway-ir/src/config.rs
@@ -1,0 +1,57 @@
+//! A value representing a configurable. Every `configurable` field in the program
+//! corresponds to a [Config].
+
+use std::cell::Cell;
+
+use crate::{context::Context, pretty::DebugWithContext, Constant, Function, MetadataIndex, Type};
+
+/// A wrapper around an [ECS](https://github.com/orlp/slotmap) handle into the
+/// [`Context`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, DebugWithContext)]
+pub struct Config(#[in_context(configs)] pub slotmap::DefaultKey);
+
+#[doc(hidden)]
+#[derive(Clone, Debug, DebugWithContext)]
+pub enum ConfigContent {
+    V0 {
+        name: String,
+        ty: Type,
+        ptr_ty: Type,
+        constant: Constant,
+        opt_metadata: Option<MetadataIndex>,
+    },
+    V1 {
+        name: String,
+        ty: Type,
+        ptr_ty: Type,
+        encoded_bytes: Vec<u8>,
+        decode_fn: Cell<Function>,
+        opt_metadata: Option<MetadataIndex>,
+    },
+}
+
+impl Config {
+    /// Insert a new configurable with the given `content` into the `context` and return its handle.
+    pub fn new(context: &mut Context, content: ConfigContent) -> Self {
+        Config(context.configs.insert(content))
+    }
+
+    /// Return the [ConfigContent] that this [Config] refers to.
+    pub fn get_content<'a>(&self, context: &'a Context) -> &'a ConfigContent {
+        &context.configs[self.0]
+    }
+
+    /// Return the configurable pointer type.
+    pub fn get_type(&self, context: &Context) -> Type {
+        match &context.configs[self.0] {
+            ConfigContent::V0 { ptr_ty, .. } | ConfigContent::V1 { ptr_ty, .. } => *ptr_ty,
+        }
+    }
+
+    /// Return the configurable name.
+    pub fn get_name<'a>(&self, context: &'a Context) -> &'a str {
+        match &context.configs[self.0] {
+            ConfigContent::V0 { name, .. } | ConfigContent::V1 { name, .. } => name,
+        }
+    }
+}

--- a/sway-ir/src/context.rs
+++ b/sway-ir/src/context.rs
@@ -18,7 +18,8 @@ use crate::{
     module::{Kind, ModuleContent, ModuleIterator},
     value::ValueContent,
     variable::LocalVarContent,
-    Constant, ConstantContent, GlobalVarContent, StorageKeyContent, Type, TypeContent,
+    ConfigContent, Constant, ConstantContent, GlobalVarContent, StorageKeyContent, Type,
+    TypeContent,
 };
 
 // Copy of `sway_core::build_config::Backtrace`, which cannot
@@ -45,6 +46,7 @@ pub struct Context<'eng> {
     pub(crate) values: SlotMap<DefaultKey, ValueContent>,
     pub(crate) local_vars: SlotMap<DefaultKey, LocalVarContent>,
     pub(crate) global_vars: SlotMap<DefaultKey, GlobalVarContent>,
+    pub(crate) configs: SlotMap<DefaultKey, ConfigContent>,
     pub(crate) storage_keys: SlotMap<DefaultKey, StorageKeyContent>,
     pub(crate) types: SlotMap<DefaultKey, TypeContent>,
     pub(crate) type_map: FxHashMap<TypeContent, Type>,
@@ -78,6 +80,7 @@ impl<'eng> Context<'eng> {
             values: Default::default(),
             local_vars: Default::default(),
             global_vars: Default::default(),
+            configs: Default::default(),
             storage_keys: Default::default(),
             types: Default::default(),
             type_map: Default::default(),

--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -19,7 +19,7 @@ use crate::{
     pretty::DebugWithContext,
     value::{Value, ValueDatum},
     variable::LocalVar,
-    AsmInstruction, ConstantContent, GlobalVar, Module, StorageKey,
+    AsmInstruction, Config, ConstantContent, GlobalVar, StorageKey,
 };
 
 #[derive(Debug, Clone, DebugWithContext)]
@@ -99,7 +99,7 @@ pub enum InstOp {
     /// Return a pointer to a global variable.
     GetGlobal(GlobalVar),
     /// Return a pointer to a configurable.
-    GetConfig(Module, String),
+    GetConfig(Config),
     /// Return a pointer to a storage key.
     GetStorageKey(StorageKey),
     /// Translate a pointer from a base to a nested element in an aggregate type.
@@ -554,10 +554,7 @@ impl InstOp {
             InstOp::GetElemPtr { elem_ptr_ty, .. } => Some(*elem_ptr_ty),
             InstOp::GetLocal(local_var) => Some(local_var.get_type(context)),
             InstOp::GetGlobal(global_var) => Some(global_var.get_type(context)),
-            InstOp::GetConfig(module, name) => Some(match module.get_config(context, name)? {
-                crate::ConfigContent::V0 { ptr_ty, .. } => *ptr_ty,
-                crate::ConfigContent::V1 { ptr_ty, .. } => *ptr_ty,
-            }),
+            InstOp::GetConfig(config) => Some(config.get_type(context)),
             InstOp::GetStorageKey(storage_key) => Some(storage_key.get_type(context)),
             InstOp::Alloc { ty: _, count: _ } => Some(Type::get_ptr(context)),
 
@@ -674,7 +671,7 @@ impl InstOp {
                 // `GetGlobal` returns an SSA `Value` but does not take any as an operand.
                 vec![]
             }
-            InstOp::GetConfig(_, _) => {
+            InstOp::GetConfig(_) => {
                 // `GetConfig` returns an SSA `Value` but does not take any as an operand.
                 vec![]
             }
@@ -919,7 +916,7 @@ impl InstOp {
                 // `GetGlobal` returns an SSA `Value` but does not take any as an operand.
                 panic!("Invalid index for GetGlobal");
             }
-            InstOp::GetConfig(_, _) => {
+            InstOp::GetConfig(_) => {
                 // `GetConfig` returns an SSA `Value` but does not take any as an operand.
                 panic!("Invalid index for GetConfig");
             }
@@ -1317,7 +1314,7 @@ impl InstOp {
             }
             InstOp::GetLocal(_) => (),
             InstOp::GetGlobal(_) => (),
-            InstOp::GetConfig(_, _) => (),
+            InstOp::GetConfig(_) => (),
             InstOp::GetStorageKey(_) => (),
             InstOp::GetElemPtr {
                 base,
@@ -1556,7 +1553,7 @@ impl InstOp {
             | InstOp::GetElemPtr { .. }
             | InstOp::GetLocal(_)
             | InstOp::GetGlobal(_)
-            | InstOp::GetConfig(_, _)
+            | InstOp::GetConfig(_)
             | InstOp::GetStorageKey(_)
             | InstOp::IntToPtr(..)
             | InstOp::Load(_)
@@ -1925,8 +1922,8 @@ impl<'a, 'eng> InstructionInserter<'a, 'eng> {
         insert_instruction!(self, InstOp::GetGlobal(global_var))
     }
 
-    pub fn get_config(self, module: Module, name: String) -> Value {
-        insert_instruction!(self, InstOp::GetConfig(module, name))
+    pub fn get_config(self, config: Config) -> Value {
+        insert_instruction!(self, InstOp::GetConfig(config))
     }
 
     pub fn alloc(self, ty: Type, count: Value) -> Value {

--- a/sway-ir/src/lib.rs
+++ b/sway-ir/src/lib.rs
@@ -43,6 +43,8 @@ pub mod asm;
 pub use asm::*;
 pub mod block;
 pub use block::*;
+pub mod config;
+pub use config::*;
 pub mod constant;
 pub use constant::*;
 pub mod context;

--- a/sway-ir/src/module.rs
+++ b/sway-ir/src/module.rs
@@ -2,12 +2,12 @@
 //!
 //! A module also has a 'kind' corresponding to the different Sway module types.
 
-use std::{cell::Cell, collections::BTreeMap};
+use std::collections::BTreeMap;
 
 use crate::{
     context::Context,
     function::{Function, FunctionIterator},
-    Constant, GlobalVar, MetadataIndex, StorageKey, Type,
+    Config, ConfigContent, Constant, GlobalVar, StorageKey, Type,
 };
 
 /// A wrapper around an [ECS](https://github.com/orlp/slotmap) handle into the
@@ -20,27 +20,8 @@ pub struct ModuleContent {
     pub kind: Kind,
     pub functions: Vec<Function>,
     pub global_variables: BTreeMap<Vec<String>, GlobalVar>,
-    pub configs: BTreeMap<String, ConfigContent>,
+    pub configs: BTreeMap<String, Config>,
     pub storage_keys: BTreeMap<String, StorageKey>,
-}
-
-#[derive(Clone, Debug)]
-pub enum ConfigContent {
-    V0 {
-        name: String,
-        ty: Type,
-        ptr_ty: Type,
-        constant: Constant,
-        opt_metadata: Option<MetadataIndex>,
-    },
-    V1 {
-        name: String,
-        ty: Type,
-        ptr_ty: Type,
-        encoded_bytes: Vec<u8>,
-        decode_fn: Cell<Function>,
-        opt_metadata: Option<MetadataIndex>,
-    },
 }
 
 /// The different 'kinds' of Sway module: `Contract`, `Library`, `Predicate` or `Script`.
@@ -149,13 +130,20 @@ impl Module {
     }
 
     /// Add a config value to this module.
-    pub fn add_config(&self, context: &mut Context, name: String, content: ConfigContent) {
-        context.modules[self.0].configs.insert(name, content);
+    pub fn add_config(
+        &self,
+        context: &mut Context,
+        name: String,
+        content: ConfigContent,
+    ) -> Config {
+        let config = Config::new(context, content);
+        context.modules[self.0].configs.insert(name, config);
+        config
     }
 
-    /// Get a named config content from this module, if found.
-    pub fn get_config<'a>(&self, context: &'a Context, name: &str) -> Option<&'a ConfigContent> {
-        context.modules[self.0].configs.get(name)
+    /// Get a named config from this module, if found.
+    pub fn get_config(&self, context: &Context, name: &str) -> Option<Config> {
+        context.modules[self.0].configs.get(name).copied()
     }
 
     /// Add a storage key value to this module.
@@ -195,11 +183,8 @@ impl Module {
             .retain(|mod_fn| mod_fn != function);
     }
 
-    pub fn iter_configs<'a>(
-        &'a self,
-        context: &'a Context,
-    ) -> impl Iterator<Item = &'a ConfigContent> + 'a {
-        context.modules[self.0].configs.values()
+    pub fn iter_configs<'a>(&'a self, context: &'a Context) -> impl Iterator<Item = Config> + 'a {
+        context.modules[self.0].configs.values().copied()
     }
 }
 

--- a/sway-ir/src/optimize/arg_mutability_tagger.rs
+++ b/sway-ir/src/optimize/arg_mutability_tagger.rs
@@ -195,7 +195,7 @@ fn analyse_fn(
                     | InstOp::BitCast(_, _)
                     | InstOp::GetLocal(_)
                     | InstOp::GetGlobal(_)
-                    | InstOp::GetConfig(_, _)
+                    | InstOp::GetConfig(_)
                     | InstOp::GetStorageKey(_)
                     | InstOp::IntToPtr(_, _)
                     | InstOp::Alloc { .. }

--- a/sway-ir/src/optimize/cse.rs
+++ b/sway-ir/src/optimize/cse.rs
@@ -12,8 +12,8 @@ use std::{
 };
 
 use crate::{
-    AnalysisResults, BinaryOpKind, Context, DebugWithContext, DomTree, Function, GlobalVar, InstOp,
-    IrError, LocalVar, Module, Pass, PassMutability, PostOrder, Predicate, ScopedPass, StorageKey,
+    AnalysisResults, BinaryOpKind, Config, Context, DebugWithContext, DomTree, Function, GlobalVar,
+    InstOp, IrError, LocalVar, Pass, PassMutability, PostOrder, Predicate, ScopedPass, StorageKey,
     Type, UnaryOpKind, Value, DOMINATORS_NAME, POSTORDER_NAME,
 };
 
@@ -66,7 +66,7 @@ enum Expr {
     // and the same is with `get_global`, `get_config` and `get_storage_key`.
     GetLocal(LocalVar),
     GetGlobal(GlobalVar),
-    GetConfig(Module, String),
+    GetConfig(Config),
     GetStorageKey(StorageKey),
     GetElemPtr {
         base: ValueNumber,
@@ -111,7 +111,7 @@ fn instr_to_expr(context: &Context, vntable: &VNTable, instr: Value) -> Option<E
         InstOp::FuelVm(_) => None,
         InstOp::GetLocal(local) => Some(Expr::GetLocal(*local)),
         InstOp::GetGlobal(global) => Some(Expr::GetGlobal(*global)),
-        InstOp::GetConfig(module, config) => Some(Expr::GetConfig(*module, config.clone())),
+        InstOp::GetConfig(config) => Some(Expr::GetConfig(*config)),
         InstOp::GetStorageKey(storage_key) => Some(Expr::GetStorageKey(*storage_key)),
         InstOp::GetElemPtr {
             base,

--- a/sway-ir/src/optimize/dce.rs
+++ b/sway-ir/src/optimize/dce.rs
@@ -365,7 +365,7 @@ pub fn globals_dce(
 
     // config decode fns
     for config in context.modules[module.0].configs.iter() {
-        if let crate::ConfigContent::V1 { decode_fn, .. } = config.1 {
+        if let crate::ConfigContent::V1 { decode_fn, .. } = config.1.get_content(context) {
             grow_called_function_used_globals_set(
                 context,
                 decode_fn.get(),

--- a/sway-ir/src/optimize/fn_dedup.rs
+++ b/sway-ir/src/optimize/fn_dedup.rs
@@ -281,7 +281,7 @@ fn hash_fn(
                     .lookup_global_variable_name(context, global)
                     .unwrap()
                     .hash(state),
-                crate::InstOp::GetConfig(_, name) => name.hash(state),
+                crate::InstOp::GetConfig(config) => config.get_name(context).hash(state),
                 crate::InstOp::GetStorageKey(storage_key) => function
                     .get_module(context)
                     .lookup_storage_key_path(context, storage_key)
@@ -377,7 +377,7 @@ pub fn dedup_fns(
 
     // Replace config decode fns
     for config in module.iter_configs(context) {
-        if let crate::ConfigContent::V1 { decode_fn, .. } = config {
+        if let crate::ConfigContent::V1 { decode_fn, .. } = config.get_content(context) {
             let f = decode_fn.get();
 
             let Some(callee_hash) = eq_class.function_hash_map.get(&f) else {

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -655,7 +655,7 @@ fn inline_instruction(
             InstOp::GetStorageKey(storage_key) => {
                 new_block.append(context).get_storage_key(storage_key)
             }
-            InstOp::GetConfig(module, name) => new_block.append(context).get_config(module, name),
+            InstOp::GetConfig(config) => new_block.append(context).get_config(config),
             InstOp::Alloc { ty, count } => new_block.append(context).alloc(ty, map_value(count)),
             InstOp::IntToPtr(value, ty) => {
                 new_block.append(context).int_to_ptr(map_value(value), ty)

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -1536,10 +1536,13 @@ mod ir_builder {
                         .append(context)
                         .get_global(*self.globals_map.get(&global_name).unwrap())
                         .add_metadatum(context, opt_metadata),
-                    IrAstOperation::GetConfig(name) => block
-                        .append(context)
-                        .get_config(self.module, name)
-                        .add_metadatum(context, opt_metadata),
+                    IrAstOperation::GetConfig(name) => {
+                        let config = self.module.get_config(context, &name).unwrap();
+                        block
+                            .append(context)
+                            .get_config(config)
+                            .add_metadatum(context, opt_metadata)
+                    }
                     IrAstOperation::GetStorageKey(path) => block
                         .append(context)
                         .get_storage_key(*self.storage_keys_map.get(&path).unwrap())
@@ -1743,14 +1746,10 @@ mod ir_builder {
                     .find(|x| x.get_name(context) == fn_name)
                     .unwrap();
 
-                if let Some(ConfigContent::V1 { decode_fn, .. }) = context
-                    .modules
-                    .get_mut(self.module.0)
-                    .unwrap()
-                    .configs
-                    .get_mut(&configurable_name)
-                {
-                    decode_fn.replace(f);
+                if let Some(config) = self.module.get_config(context, &configurable_name) {
+                    if let ConfigContent::V1 { decode_fn, .. } = config.get_content(context) {
+                        decode_fn.replace(f);
+                    }
                 }
             }
 

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -236,7 +236,7 @@ fn module_to_doc<'a>(
             module
                 .configs
                 .values()
-                .map(|value| config_to_doc(context, value, md_namer))
+                .map(|value| config_to_doc(context, value.get_content(context), md_namer))
                 .collect(),
         ),
     ))
@@ -1176,16 +1176,13 @@ fn instruction_to_doc<'a>(
                     .append(md_namer.md_idx_to_doc(context, metadata)),
                 )
             }
-            InstOp::GetConfig(_, name) => Doc::line(
-                match block.get_module(context).get_config(context, name).unwrap() {
-                    ConfigContent::V0 { name, ptr_ty, .. }
-                    | ConfigContent::V1 { name, ptr_ty, .. } => Doc::text(format!(
-                        "{} = get_config {}, {}",
-                        namer.name(context, ins_value),
-                        ptr_ty.as_string(context),
-                        name,
-                    )),
-                }
+            InstOp::GetConfig(config) => Doc::line(
+                Doc::text(format!(
+                    "{} = get_config {}, {}",
+                    namer.name(context, ins_value),
+                    config.get_type(context).as_string(context),
+                    config.get_name(context),
+                ))
                 .append(md_namer.md_idx_to_doc(context, metadata)),
             ),
             InstOp::GetStorageKey(storage_key) => {

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -16,7 +16,7 @@ use crate::{
     value::{Value, ValueDatum},
     variable::LocalVar,
     AnalysisResult, AnalysisResultT, AnalysisResults, BinaryOpKind, Block, BlockArgument,
-    BranchToWithArgs, Doc, GlobalVar, InitAggr, LogEventData, Module, Pass, PassMutability,
+    BranchToWithArgs, Config, Doc, GlobalVar, InitAggr, LogEventData, Module, Pass, PassMutability,
     ScopedPass, StorageKey, TypeContent, TypeOption, UnaryOpKind,
 };
 
@@ -376,7 +376,7 @@ impl InstructionVerifier<'_, '_> {
                 } => self.verify_get_elem_ptr(&ins, base, elem_ptr_ty, indices)?,
                 InstOp::GetLocal(local_var) => self.verify_get_local(local_var)?,
                 InstOp::GetGlobal(global_var) => self.verify_get_global(global_var)?,
-                InstOp::GetConfig(_, name) => self.verify_get_config(self.cur_module, name)?,
+                InstOp::GetConfig(config) => self.verify_get_config(config)?,
                 InstOp::GetStorageKey(storage_key) => self.verify_get_storage_key(storage_key)?,
                 InstOp::IntToPtr(value, ty) => self.verify_int_to_ptr(value, ty)?,
                 InstOp::Load(ptr) => self.verify_load(ptr)?,
@@ -895,8 +895,12 @@ impl InstructionVerifier<'_, '_> {
         }
     }
 
-    fn verify_get_config(&self, module: Module, name: &str) -> Result<(), IrError> {
-        if !self.context.modules[module.0].configs.contains_key(name) {
+    fn verify_get_config(&self, config: &Config) -> Result<(), IrError> {
+        if !self.context.modules[self.cur_module.0]
+            .configs
+            .values()
+            .any(|c| c == config)
+        {
             Err(IrError::VerifyGetNonExistentConfigPointer)
         } else {
             Ok(())


### PR DESCRIPTION
## Description

This PR refactors the implementation of the `InstOp::GetConfig` instruction to make it consistent with the implementations of `GetLocal`, `GetGlobal`, and `GetStorageKey` instructions. Having implementations consistent reduces unnecessary effort in understanding why `GetConfig` is different and how it works, especially when reading the code for the first time.

The `InstOp::GetConfig` instruction was the only instruction that kept a reference to the compiled programs `Module` as well as a parameter of type `String`. The `Module` parameter is used in only one place to retreive the type of the configurable and is otherwise ignored (`_`). All other instructions exclusively keep their arena values. This inconsistency required additional effort when reading and understanding code. Moreover, what the instruction conceptually does, is the same as the `GetLocal`, `GetGlobal`, and `GetStorageKey` instructions.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.