### PR TITLE
Parallelize runs of in-lang tests and shorten storage tests compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,21 +541,21 @@ jobs:
       # - name: Run In Language Unit Tests - ['dynamic_storage' enabled] (Release)
       #   run: forc test --error-on-warnings --release --path test/src/in_language_tests --experimental dynamic_storage
       - name: Run In Language Unit Tests (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel
       - name: Run In Language Unit Tests (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --release
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release
       - name: Run In Language Unit Tests - ['new_hashing' disabled] (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --no-experimental new_hashing --filter 'hash|sha256|keccak256'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --no-experimental new_hashing --filter 'hash|sha256|keccak256'
       - name: Run In Language Unit Tests - ['new_hashing' disabled] (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --release --no-experimental new_hashing --filter 'hash|sha256|keccak256'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release --no-experimental new_hashing --filter 'hash|sha256|keccak256'
       - name: Run In Language Unit Tests - ['str_array_no_padding' enabled] (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --experimental str_array_no_padding --filter 'str\['
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --experimental str_array_no_padding --filter 'str\['
       - name: Run In Language Unit Tests - ['str_array_no_padding' enabled] (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --release --experimental str_array_no_padding --filter 'str\['
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release --experimental str_array_no_padding --filter 'str\['
       - name: Run In Language Unit Tests - ['dynamic_storage' enabled] (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --experimental dynamic_storage --filter 'storage'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --experimental dynamic_storage --filter 'storage'
       - name: Run In Language Unit Tests - ['dynamic_storage' enabled] (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --release --experimental dynamic_storage --filter 'storage'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release --experimental dynamic_storage --filter 'storage'
 
   forc-pkg-fuels-deps-check:
     runs-on: ubuntu-latest

--- a/test/src/in_language_tests/run_in_language_tests.sh
+++ b/test/src/in_language_tests/run_in_language_tests.sh
@@ -2,12 +2,23 @@
 
 # Run `forc test` individually for each project under test_programs/.
 #
-# Usage: ./run_in_language_tests.sh [--filter REGEX] [extra `forc test` args, e.g. --release --experimental ...]
+# Usage: ./run_in_language_tests.sh [--parallel] [--filter REGEX] [extra `forc test` args, e.g. --release --experimental ...]
 #
 # Note: --error-on-warnings arg is always passed to `forc test`.
 #       When --filter is provided, projects are selected if either:
 #       - project directory name matches REGEX, or
 #       - any *.sw file in the project matches REGEX.
+#
+# Run modes:
+#   Default (sequential): projects are run one after another and the full
+#       `forc test` output (compilation and tests output) is printed. This mode
+#       must remain the default because tooling extracts gas costs from this output.
+#   --parallel: projects are run concurrently and only a concise per-project
+#       result is printed (green check mark on success, red cross mark on failure).
+#       The full output of failing projects is printed at the end. Intended for
+#       CI and local "do all tests pass?" checks where speed matters.
+#       Concurrency defaults to half of the available CPU cores (at least 1) and
+#       can be overridden via the PARALLEL_JOBS environment variable.
 #
 # The script continues even when individual test projects fail, and exits with
 # a non-zero code at the end if any project failed.
@@ -21,10 +32,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_PROGRAMS_DIR="$SCRIPT_DIR/test_programs"
 
 FILTER_REGEX=""
+PARALLEL=false
 FORC_TEST_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --parallel)
+            PARALLEL=true
+            shift
+            ;;
         --filter)
             if [[ $# -lt 2 ]]; then
                 echo "Error: --filter requires a regex argument" >&2
@@ -72,6 +88,8 @@ EXCLUDED_PROJECTS=(
 failed=()
 passed=()
 
+start_time=$SECONDS
+
 should_run_project() {
     local project_name="$1"
     local project_dir="$2"
@@ -93,6 +111,10 @@ should_run_project() {
     return 1
 }
 
+# Collect the projects to run (in a stable, sorted order) before running them,
+# so that both the sequential and parallel modes operate on the same list.
+project_names=()
+project_dirs=()
 while IFS= read -r -d '' forc_toml; do
     project_dir="$(dirname "$forc_toml")"
     project_name="$(basename "$project_dir")"
@@ -105,20 +127,121 @@ while IFS= read -r -d '' forc_toml; do
         continue
     fi
 
-    echo ""
-    echo "==> Testing: $project_name"
-
-    if "$FORC" test --error-on-warnings "${FORC_TEST_ARGS[@]}" --path "$project_dir"; then
-        passed+=("$project_name")
-    else
-        echo "FAILED: $project_name" >&2
-        failed+=("$project_name")
-    fi
+    project_names+=("$project_name")
+    project_dirs+=("$project_dir")
 done < <(find "$TEST_PROGRAMS_DIR" -mindepth 2 -maxdepth 2 -name "Forc.toml" -print0 | sort -z)
+
+if [[ "$PARALLEL" == true ]]; then
+    # Parallel mode: run all projects concurrently, capturing each project's
+    # output to its own log file. Only a concise per-project result is printed
+    # live (green check on success, red cross on failure). Full output of any
+    # failing project is printed at the end.
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    NC='\033[0m'
+
+    # Default concurrency to half of the available cores (at least 1) to leave
+    # headroom on the machine. Can be overridden via the PARALLEL_JOBS env var.
+    # `nproc` is Linux; `sysctl -n hw.ncpu` is the macOS equivalent.
+    cores="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+    PARALLEL_JOBS="${PARALLEL_JOBS:-$(( cores / 2 ))}"
+    (( PARALLEL_JOBS < 1 )) && PARALLEL_JOBS=1
+
+    # `wait -n` (wait for any single job to finish) requires Bash >= 4.3.
+    # macOS ships Bash 3.2, so fall back to polling there.
+    if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3) )); then
+        HAVE_WAIT_N=true
+    else
+        HAVE_WAIT_N=false
+    fi
+
+    wait_for_slot() {
+        if [[ "$HAVE_WAIT_N" == true ]]; then
+            wait -n 2>/dev/null || true
+        else
+            sleep 0.2
+        fi
+    }
+
+    logs_dir="$(mktemp -d)"
+    trap 'rm -rf "$logs_dir"' EXIT
+
+    run_one() {
+        local project_name="$1"
+        local project_dir="$2"
+        local log_file="$logs_dir/$project_name.log"
+
+        if "$FORC" test --error-on-warnings "${FORC_TEST_ARGS[@]}" --path "$project_dir" > "$log_file" 2>&1; then
+            printf '%b %s\n' "${GREEN}✓${NC}" "$project_name"
+            echo "pass" > "$logs_dir/$project_name.status"
+        else
+            printf '%b %s\n' "${RED}✗${NC}" "$project_name"
+            echo "fail" > "$logs_dir/$project_name.status"
+        fi
+    }
+
+    echo "Running ${#project_names[@]} test projects in parallel (up to $PARALLEL_JOBS at a time)..."
+    echo ""
+
+    for i in "${!project_names[@]}"; do
+        # Throttle: wait for a free slot before launching the next job.
+        while (( $(jobs -rp | wc -l) >= PARALLEL_JOBS )); do
+            wait_for_slot
+        done
+        run_one "${project_names[$i]}" "${project_dirs[$i]}" &
+    done
+
+    # Wait for all remaining jobs to finish.
+    wait
+
+    # Build pass/fail lists in the stable project order.
+    for project_name in "${project_names[@]}"; do
+        if [[ "$(cat "$logs_dir/$project_name.status" 2>/dev/null)" == "pass" ]]; then
+            passed+=("$project_name")
+        else
+            failed+=("$project_name")
+        fi
+    done
+
+    # Print the full output of any failing project to aid debugging on CI.
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo ""
+        echo "================================================"
+        echo "Output of failing test projects:"
+        echo "================================================"
+        for project_name in "${failed[@]}"; do
+            echo ""
+            echo "==> $project_name"
+            cat "$logs_dir/$project_name.log" 2>/dev/null
+        done
+    fi
+else
+    # Sequential mode (default): run projects one by one and print the full
+    # `forc test` output. This mode must stay the default because tooling
+    # extracts gas costs from this output.
+    for i in "${!project_names[@]}"; do
+        project_name="${project_names[$i]}"
+        project_dir="${project_dirs[$i]}"
+
+        echo ""
+        echo "==> Testing: $project_name"
+
+        if "$FORC" test --error-on-warnings "${FORC_TEST_ARGS[@]}" --path "$project_dir"; then
+            passed+=("$project_name")
+        else
+            echo "FAILED: $project_name" >&2
+            failed+=("$project_name")
+        fi
+    done
+fi
+
+elapsed=$(( SECONDS - start_time ))
+elapsed_str="$(printf '%dh %02dm %02ds' $(( elapsed / 3600 )) $(( (elapsed % 3600) / 60 )) $(( elapsed % 60 )))"
 
 echo ""
 echo "================================================"
 echo "Results: ${#passed[@]} passed, ${#failed[@]} failed"
+echo "Total run time: ${elapsed_str}"
 echo "================================================"
 
 if [[ ${#failed[@]} -gt 0 ]]; then

--- a/test/src/in_language_tests/test_programs/storage_key_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_key_contract_tests/src/main.sw
@@ -9,6 +9,7 @@ use std::hash::{Hash, sha256};
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[cfg(experimental_dynamic_storage = false)]
 #[storage(read, write)]
+#[inline(never)]
 fn assert_clear_clear_existed_impl<T>(key: StorageKey<T>)
 where
     T: Eq + TestInstance + AbiEncode,
@@ -23,6 +24,7 @@ where
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[cfg(experimental_dynamic_storage = true)]
 #[storage(read, write)]
+#[inline(never)]
 fn assert_clear_clear_existed_impl<T>(key: StorageKey<T>)
 where
     T: Eq + TestInstance + AbiEncode,
@@ -41,6 +43,7 @@ where
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_write_read_try_read_clear_clear_existed_impl<T>(slot_id_preimage: u64)
 where
     T: Eq + TestInstance + AbiEncode,

--- a/test/src/in_language_tests/test_programs/storage_map_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_map_contract_tests/src/main.sw
@@ -10,6 +10,7 @@ use std::storage::storage_map::*;
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[cfg(experimental_dynamic_storage = false)]
 #[storage(read, write)]
+#[inline(never)]
 fn assert_remove_remove_existed_impl<K, V>(map: StorageKey<StorageMap<K, V>>, key: K)
 where
     K: Hash,
@@ -25,6 +26,7 @@ where
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[cfg(experimental_dynamic_storage = true)]
 #[storage(read, write)]
+#[inline(never)]
 fn assert_remove_remove_existed_impl<K, V>(map: StorageKey<StorageMap<K, V>>, key: K)
 where
     K: Hash,
@@ -43,6 +45,7 @@ where
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_insert_try_insert_get_remove_impl<K, V>(slot_id_preimage: u64, key1: K, key2: K, key3: K)
 where
     K: Hash,

--- a/test/src/in_language_tests/test_programs/storage_vec_fill_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_fill_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_fill_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_insert_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_insert_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_insert_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_iter_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_iter_contract_tests/src/main.sw
@@ -21,6 +21,7 @@ storage {
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read)]
+#[inline(never)]
 fn assert_empty_vec_next_returns_none_impl<T>(slot_id_preimage: u64) {
     let vec: StorageKey<StorageVec<T>> = StorageKey::new(sha256(slot_id_preimage), 0, sha256(slot_id_preimage + 100));
     assert(vec.iter().next().is_none());
@@ -28,6 +29,7 @@ fn assert_empty_vec_next_returns_none_impl<T>(slot_id_preimage: u64) {
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_vec_with_elements_next_returns_element_impl<T>(
     slot_id_preimage: u64,
 )
@@ -64,6 +66,7 @@ where
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_vec_with_elements_for_loop_iteration_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_load_vec_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_load_vec_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_load_vec_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_of_storage_vec_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_of_storage_vec_contract_tests/src/main.sw
@@ -25,6 +25,7 @@ storage {
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_push_and_get_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_push_pop_get_len_first_last_is_empty_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_push_pop_get_len_first_last_is_empty_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_push_pop_get_len_first_last_is_empty_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_remove_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_remove_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_remove_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_resize_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_resize_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_resize_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_reverse_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_reverse_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_reverse_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_set_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_set_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_set_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_store_vec_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_store_vec_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(write)]
+#[inline(never)]
 fn assert_store_vec_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_swap_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_swap_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_swap_impl<T>(
     slot_id_preimage: u64,
 )

--- a/test/src/in_language_tests/test_programs/storage_vec_swap_remove_contract_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/storage_vec_swap_remove_contract_tests/src/main.sw
@@ -20,6 +20,7 @@ const NUM_OF_ELEMENTS: u64 = 11;
 
 #[allow(dead_code)] // TODO-DCA: Remove this `allow` once https://github.com/FuelLabs/sway/issues/7462 is fixed.
 #[storage(read, write)]
+#[inline(never)]
 fn assert_swap_remove_impl<T>(
     slot_id_preimage: u64,
 )


### PR DESCRIPTION
## Description

This PR:
- shortens the compilation time of storage in-language tests by marking the generic `<...>_impl` functions as `#[inline(never)]`,
- parallelizes execution of in-language tests.

Combined, this reduces the execution time of the whole in-language test suite from ~6 minutes to ~1 minute.

All storage tests have the same structure, testing a particular storage type for different stored types by calling a generic, usually large, `<...>_impl` function for each stored type. Since every monomorphized `<...>_impl` call happens only once, inlining pass will inline them all in a single large function. This creates a lot of preassure on our current inlining algorithm.

We will improve the inlining in dedicated optimization PRs. Until then, this PR gives us better test compilation times for storage tests. Compiling all storage tests sequentially before took ~4 minutes and after forbidding inlining takes ~3 minutes.

Running tests sequentially is still kept as default, to make sure the current performance script that extracts gas works as-is. Eventually adapting that script and having only the parallel running will be done in a follow up PR.  

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.