### PR TITLE
Use `HasChanges` to propagate information about in-place mutations

### DIFF
--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -6,6 +6,7 @@ use crate::{
         TyStructDecl, TyTraitDecl, TyTraitFn, TyTraitType, TyTypeAliasDecl,
     },
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -29,6 +29,7 @@ use crate::{
     },
     semantic_analysis::TypeCheckContext,
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
@@ -279,7 +280,7 @@ impl ReplaceDecls for DeclRefFunction {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         let engines = ctx.engines();
         let decl_engine = engines.de();
 
@@ -295,9 +296,9 @@ impl ReplaceDecls for DeclRefFunction {
             return Ok(
                 if let AssociatedItemDeclId::Function(new_decl_ref) = new_decl_ref {
                     self.id = new_decl_ref;
-                    true
+                    HasChanges::Yes
                 } else {
-                    false
+                    HasChanges::No
                 },
             );
         }
@@ -313,14 +314,14 @@ impl ReplaceDecls for DeclRefFunction {
                 return Ok(
                     if let AssociatedItemDeclId::Function(new_decl_ref) = new_decl_ref {
                         self.id = new_decl_ref;
-                        true
+                        HasChanges::Yes
                     } else {
-                        false
+                        HasChanges::No
                     },
                 );
             }
         }
-        Ok(false)
+        Ok(HasChanges::No)
     }
 }
 

--- a/sway-core/src/decl_engine/replace_decls.rs
+++ b/sway-core/src/decl_engine/replace_decls.rs
@@ -15,18 +15,18 @@ pub trait ReplaceDecls {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted>;
+    ) -> Result<HasChanges, ErrorEmitted>;
 
     fn replace_decls(
         &mut self,
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if !decl_mapping.is_empty() {
             self.replace_decls_inner(decl_mapping, handler, ctx)
         } else {
-            Ok(false)
+            Ok(HasChanges::No)
         }
     }
 }
@@ -37,7 +37,7 @@ impl<T: ReplaceDecls + Clone> ReplaceDecls for std::sync::Arc<T> {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if let Some(item) = std::sync::Arc::get_mut(self) {
             item.replace_decls_inner(decl_mapping, handler, ctx)
         } else {
@@ -87,7 +87,7 @@ pub(crate) trait MaterializeConstGenerics {
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted>;
+    ) -> Result<HasChanges, ErrorEmitted>;
 }
 
 impl<T: MaterializeConstGenerics + Clone> MaterializeConstGenerics for std::sync::Arc<T> {
@@ -97,7 +97,7 @@ impl<T: MaterializeConstGenerics + Clone> MaterializeConstGenerics for std::sync
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if let Some(item) = std::sync::Arc::get_mut(self) {
             item.materialize_const_generics(engines, handler, name, value)
         } else {
@@ -116,10 +116,11 @@ impl<T: MaterializeConstGenerics> MaterializeConstGenerics for Vec<T> {
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         for item in self.iter_mut() {
-            item.materialize_const_generics(engines, handler, name, value)?;
+            has_changes |= item.materialize_const_generics(engines, handler, name, value)?;
         }
-        Ok(())
+        Ok(has_changes)
     }
 }

--- a/sway-core/src/has_changes.rs
+++ b/sway-core/src/has_changes.rs
@@ -1,0 +1,58 @@
+/// Reports whether an operation that mutates declarations ([`crate::language::ty::TyDecl`]),
+/// type ids ([`crate::TypeId`]), or other entities in place actually changed anything.
+///
+/// It is used to propagate "did anything change" information across various
+/// in-place transformations, e.g., [`crate::SubstTypes`], declaration replacement,
+/// monomorphization, etc.
+#[derive(Default)]
+pub enum HasChanges {
+    Yes,
+    #[default]
+    No,
+}
+
+impl HasChanges {
+    pub fn has_changes(&self) -> bool {
+        matches!(self, HasChanges::Yes)
+    }
+}
+
+impl std::ops::BitOr for HasChanges {
+    type Output = HasChanges;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (HasChanges::No, HasChanges::No) => HasChanges::No,
+            _ => HasChanges::Yes,
+        }
+    }
+}
+
+impl std::ops::BitOrAssign for HasChanges {
+    fn bitor_assign(&mut self, rhs: Self) {
+        if rhs.has_changes() {
+            *self = HasChanges::Yes;
+        }
+    }
+}
+
+impl From<bool> for HasChanges {
+    fn from(value: bool) -> Self {
+        if value {
+            HasChanges::Yes
+        } else {
+            HasChanges::No
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! has_changes {
+    ($($stmt:expr);* ;) => {{
+        let mut has_changes = $crate::HasChanges::No;
+        $(
+            has_changes |= $stmt;
+        )*
+        has_changes
+    }};
+}

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -1,14 +1,8 @@
 use crate::{
-    decl_engine::*,
-    engine_threading::*,
-    language::ty::*,
-    semantic_analysis::{
+    HasChanges, decl_engine::*, engine_threading::*, has_changes, language::ty::*, semantic_analysis::{
         TypeCheckAnalysis, TypeCheckAnalysisContext, TypeCheckContext, TypeCheckFinalization,
         TypeCheckFinalizationContext,
-    },
-    transform::{AllowDeprecatedState, AttributeKind},
-    type_system::*,
-    types::*,
+    }, transform::{AllowDeprecatedState, AttributeKind}, type_system::*, types::*
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -75,7 +69,7 @@ impl ReplaceDecls for TyAstNode {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         match self.content {
             TyAstNodeContent::Declaration(TyDecl::VariableDecl(ref mut decl)) => {
                 decl.body.replace_decls(decl_mapping, handler, ctx)
@@ -83,12 +77,12 @@ impl ReplaceDecls for TyAstNode {
             TyAstNodeContent::Declaration(TyDecl::ConstantDecl(ref mut decl)) => {
                 decl.replace_decls(decl_mapping, handler, ctx)
             }
-            TyAstNodeContent::Declaration(_) => Ok(false),
+            TyAstNodeContent::Declaration(_) => Ok(HasChanges::No),
             TyAstNodeContent::Expression(ref mut expr) => {
                 expr.replace_decls(decl_mapping, handler, ctx)
             }
-            TyAstNodeContent::SideEffect(_) => Ok(false),
-            TyAstNodeContent::Error(_, _) => Ok(false),
+            TyAstNodeContent::SideEffect(_) => Ok(HasChanges::No),
+            TyAstNodeContent::Error(_, _) => Ok(HasChanges::No),
         }
     }
 }
@@ -153,33 +147,38 @@ impl MaterializeConstGenerics for TyAstNode {
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         match &mut self.content {
             TyAstNodeContent::Declaration(TyDecl::ConstantDecl(constant_decl)) => {
                 let decl = engines.de().get(&constant_decl.decl_id);
 
                 let mut decl = TyConstantDecl::clone(&*decl);
-                decl.materialize_const_generics(engines, handler, name, value)?;
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let r = engines.de().insert(decl, None);
                 *constant_decl = ConstantDecl { decl_id: *r.id() };
 
-                Ok(())
+                Ok(has_changes)
             }
             TyAstNodeContent::Declaration(TyDecl::VariableDecl(decl)) => {
-                decl.body
-                    .materialize_const_generics(engines, handler, name, value)?;
-                decl.return_type
-                    .materialize_const_generics(engines, handler, name, value)?;
-                decl.type_ascription
-                    .type_id
-                    .materialize_const_generics(engines, handler, name, value)?;
-                Ok(())
+                let has_changes = has_changes! {
+                    decl
+                        .body
+                        .materialize_const_generics(engines, handler, name, value)?;
+                    decl
+                        .return_type
+                        .materialize_const_generics(engines, handler, name, value)?;
+                    decl
+                        .type_ascription
+                        .type_id
+                        .materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyAstNodeContent::Expression(expr) => {
                 expr.materialize_const_generics(engines, handler, name, value)
             }
-            _ => Ok(()),
+            _ => Ok(HasChanges::No),
         }
     }
 }

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -161,10 +161,15 @@ impl MaterializeConstGenerics for TyAstNode {
                 let decl = engines.de().get(&constant_decl.decl_id);
 
                 let mut decl = TyConstantDecl::clone(&*decl);
-                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
+                let mut has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let r = engines.de().insert(decl, None);
+                let r = engines.de().insert(decl, None); // TODO: Add `parsed_decl_id`.
                 *constant_decl = ConstantDecl { decl_id: *r.id() };
+
+                // TODO: Deliberately using `mut has_changes` above and changing it here.
+                //       This will be changed when we inspect returned `HasChanges` and
+                //       remove additional not needed `DeclEngine::insert` calls.
+                has_changes |= HasChanges::Yes;
 
                 Ok(has_changes)
             }
@@ -243,7 +248,6 @@ impl TyAstNode {
     }
 
     pub(crate) fn type_info(&self, type_engine: &TypeEngine) -> TypeInfo {
-        // return statement should be ()
         match &self.content {
             TyAstNodeContent::Declaration(_) => TypeInfo::Tuple(Vec::new()),
             TyAstNodeContent::Expression(TyExpression { return_type, .. }) => {

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -161,7 +161,8 @@ impl MaterializeConstGenerics for TyAstNode {
                 let decl = engines.de().get(&constant_decl.decl_id);
 
                 let mut decl = TyConstantDecl::clone(&*decl);
-                let mut has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
+                let mut has_changes =
+                    decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let r = engines.de().insert(decl, None); // TODO: Add `parsed_decl_id`.
                 *constant_decl = ConstantDecl { decl_id: *r.id() };

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -1,8 +1,16 @@
 use crate::{
-    HasChanges, decl_engine::*, engine_threading::*, has_changes, language::ty::*, semantic_analysis::{
+    decl_engine::*,
+    engine_threading::*,
+    has_changes,
+    language::ty::*,
+    semantic_analysis::{
         TypeCheckAnalysis, TypeCheckAnalysisContext, TypeCheckContext, TypeCheckFinalization,
         TypeCheckFinalizationContext,
-    }, transform::{AllowDeprecatedState, AttributeKind}, type_system::*, types::*
+    },
+    transform::{AllowDeprecatedState, AttributeKind},
+    type_system::*,
+    types::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -1,6 +1,6 @@
 use crate::{
     decl_engine::*, engine_threading::*, language::ty::*, semantic_analysis::TypeCheckContext,
-    transform::AllowDeprecatedState, type_system::*,
+    transform::AllowDeprecatedState, type_system::*, HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::hash::Hasher;
@@ -61,9 +61,9 @@ impl ReplaceDecls for TyCodeBlock {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            let mut has_changes = false;
+            let mut has_changes = HasChanges::No;
             for node in self.contents.iter_mut() {
                 if let Ok(r) = node.replace_decls(decl_mapping, handler, ctx) {
                     has_changes |= r;
@@ -80,10 +80,9 @@ impl UpdateConstantExpression for TyCodeBlock {
         engines: &Engines,
         implementing_type: &TyDecl,
     ) -> HasChanges {
-        self.contents
-            .iter_mut()
-            .map(|ast_node| ast_node.update_constant_expression(engines, implementing_type))
-            .fold(HasChanges::No, |acc, x| acc | x)
+        self.contents.iter_mut().fold(HasChanges::No, |acc, x| {
+            acc | x.update_constant_expression(engines, implementing_type)
+        })
     }
 }
 
@@ -94,9 +93,11 @@ impl MaterializeConstGenerics for TyCodeBlock {
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
-        self.contents
-            .iter_mut()
-            .try_for_each(|x| x.materialize_const_generics(engines, handler, name, value))
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
+        for x in self.contents.iter_mut() {
+            has_changes |= x.materialize_const_generics(engines, handler, name, value)?;
+        }
+        Ok(has_changes)
     }
 }

--- a/sway-core/src/language/ty/declaration/configurable.rs
+++ b/sway-core/src/language/ty/declaration/configurable.rs
@@ -6,6 +6,7 @@ use crate::{
     semantic_analysis::TypeCheckContext,
     transform,
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -103,11 +104,11 @@ impl ReplaceDecls for TyConfigurableDecl {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if let Some(expr) = &mut self.value {
             expr.replace_decls(decl_mapping, handler, ctx)
         } else {
-            Ok(false)
+            Ok(HasChanges::No)
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/const_generic.rs
+++ b/sway-core/src/language/ty/declaration/const_generic.rs
@@ -60,6 +60,8 @@ impl MaterializeConstGenerics for TyConstGenericDecl {
         let mut has_changes = HasChanges::No;
         if self.call_path.suffix.as_str() == name {
             match self.value.as_ref() {
+                // If the const generic already has value,
+                // it must be the same as the `value`.
                 Some(v) => {
                     assert!(
                         v.extract_literal_value()

--- a/sway-core/src/language/ty/declaration/const_generic.rs
+++ b/sway-core/src/language/ty/declaration/const_generic.rs
@@ -56,7 +56,8 @@ impl MaterializeConstGenerics for TyConstGenericDecl {
         _handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         if self.call_path.suffix.as_str() == name {
             match self.value.as_ref() {
                 Some(v) => {
@@ -75,10 +76,11 @@ impl MaterializeConstGenerics for TyConstGenericDecl {
                 }
                 None => {
                     self.value = Some(value.clone());
+                    has_changes = HasChanges::Yes;
                 }
             }
         }
-        Ok(())
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -6,6 +6,7 @@ use crate::{
     semantic_analysis::TypeCheckContext,
     transform,
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -107,11 +108,11 @@ impl ReplaceDecls for TyConstantDecl {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if let Some(expr) = &mut self.value {
             expr.replace_decls(decl_mapping, handler, ctx)
         } else {
-            Ok(false)
+            Ok(HasChanges::No)
         }
     }
 }
@@ -123,15 +124,18 @@ impl MaterializeConstGenerics for TyConstantDecl {
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         if let Some(v) = self.value.as_mut() {
-            v.materialize_const_generics(engines, handler, name, value)?;
+            has_changes |= v.materialize_const_generics(engines, handler, name, value)?;
         }
-        self.return_type
+        has_changes |= self
+            .return_type
             .materialize_const_generics(engines, handler, name, value)?;
-        self.type_ascription
+        has_changes |= self
+            .type_ascription
             .type_id
             .materialize_const_generics(engines, handler, name, value)?;
-        Ok(())
+        Ok(has_changes)
     }
 }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -5,6 +5,7 @@ use crate::{
     semantic_analysis::TypeCheckContext,
     type_system::*,
     types::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -64,10 +65,10 @@ impl ReplaceDecls for ConstantDecl {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         let mut decl = TyConstantDecl::clone(&*ctx.engines.de().get(&self.decl_id));
         let has_changes = decl.replace_decls(decl_mapping, handler, ctx)?;
-        if has_changes {
+        if has_changes.has_changes() {
             let parsed_decl_id = ctx.engines.de().get_parsed_decl_id(&self.decl_id);
             let new_ref = ctx.engines.de().insert(decl, parsed_decl_id.as_ref());
             self.decl_id.replace_id(*new_ref.id());

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -5,7 +5,7 @@ use crate::{
     has_changes,
     language::{
         parsed::EnumDeclaration,
-        ty::{self, TyDeclParsedType, TyExpression},
+        ty::{TyDeclParsedType, TyExpression},
         CallPath, Visibility,
     },
     transform,

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -6,6 +6,7 @@ use crate::{
     language::{parsed::EnumDeclaration, ty::TyDeclParsedType, CallPath, Visibility},
     transform,
     type_system::*,
+    HasChanges,
 };
 use ast_elements::type_parameter::ConstGenericExpr;
 use monomorphization::MonomorphizeHelper;
@@ -113,14 +114,17 @@ impl MaterializeConstGenerics for TyEnumDecl {
         handler: &Handler,
         name: &str,
         value: &crate::language::ty::TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         for p in self.generic_parameters.iter_mut() {
             match p {
                 TypeParameter::Const(p) if p.name.as_str() == name => {
                     p.expr = Some(ConstGenericExpr::from_ty_expression(handler, value)?);
+                    has_changes = HasChanges::Yes;
                 }
                 TypeParameter::Type(p) => {
-                    p.type_id
+                    has_changes |= p
+                        .type_id
                         .materialize_const_generics(engines, handler, name, value)?;
                 }
                 _ => {}
@@ -128,13 +132,13 @@ impl MaterializeConstGenerics for TyEnumDecl {
         }
 
         for variant in self.variants.iter_mut() {
-            variant
+            has_changes |= variant
                 .type_argument
                 .type_id
                 .materialize_const_generics(engines, handler, name, value)?;
         }
 
-        Ok(())
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -3,7 +3,11 @@ use crate::{
     decl_engine::MaterializeConstGenerics,
     engine_threading::*,
     has_changes,
-    language::{parsed::EnumDeclaration, ty::TyDeclParsedType, CallPath, Visibility},
+    language::{
+        parsed::EnumDeclaration,
+        ty::{self, TyDeclParsedType, TyExpression},
+        CallPath, Visibility,
+    },
     transform,
     type_system::*,
     HasChanges,
@@ -113,7 +117,7 @@ impl MaterializeConstGenerics for TyEnumDecl {
         engines: &Engines,
         handler: &Handler,
         name: &str,
-        value: &crate::language::ty::TyExpression,
+        value: &TyExpression,
     ) -> Result<HasChanges, ErrorEmitted> {
         let mut has_changes = HasChanges::No;
         for p in self.generic_parameters.iter_mut() {

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -12,6 +12,7 @@ use crate::{
     transform::{self, AttributeKind},
     type_system::*,
     types::*,
+    HasChanges,
 };
 use ast_elements::type_parameter::ConstGenericExpr;
 use either::Either;
@@ -184,12 +185,15 @@ impl MaterializeConstGenerics for TyFunctionDecl {
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         for tp in self.type_parameters.iter_mut() {
             match tp {
-                TypeParameter::Type(p) => p
-                    .type_id
-                    .materialize_const_generics(engines, handler, name, value)?,
+                TypeParameter::Type(p) => {
+                    has_changes |= p
+                        .type_id
+                        .materialize_const_generics(engines, handler, name, value)?;
+                }
                 TypeParameter::Const(p) if p.name.as_str() == name => match p.expr.as_ref() {
                     Some(v) => {
                         assert!(
@@ -203,6 +207,7 @@ impl MaterializeConstGenerics for TyFunctionDecl {
                     }
                     None => {
                         p.expr = Some(ConstGenericExpr::from_ty_expression(handler, value)?);
+                        has_changes = HasChanges::Yes;
                     }
                 },
                 _ => {}
@@ -210,16 +215,19 @@ impl MaterializeConstGenerics for TyFunctionDecl {
         }
 
         for param in self.parameters.iter_mut() {
-            param
+            has_changes |= param
                 .type_argument
                 .type_id
                 .materialize_const_generics(engines, handler, name, value)?;
         }
-        self.return_type
+        has_changes |= self
+            .return_type
             .type_id
             .materialize_const_generics(engines, handler, name, value)?;
-        self.body
-            .materialize_const_generics(engines, handler, name, value)
+        has_changes |= self
+            .body
+            .materialize_const_generics(engines, handler, name, value)?;
+        Ok(has_changes)
     }
 }
 
@@ -299,13 +307,12 @@ fn rename_const_generics_on_function_inner(
                         .clone(),
                     b.name.clone(),
                 );
-                has_changes = has_changes
-                    | function.subst_inner(&SubstTypesContext {
-                        handler,
-                        engines,
-                        type_subst_map: Some(&type_subst_map),
-                        subst_function_body: true,
-                    });
+                has_changes |= function.subst_inner(&SubstTypesContext {
+                    handler,
+                    engines,
+                    type_subst_map: Some(&type_subst_map),
+                    subst_function_body: true,
+                });
             }
             (GenericArgument::Const(a), TypeParameter::Const(b)) => {
                 engines
@@ -349,13 +356,12 @@ impl DeclRefFunction {
             let mut has_changes = HasChanges::No;
             if let Some(TyDecl::ImplSelfOrTrait(t)) = &method.implementing_type {
                 let impl_self_or_trait = &*engines.de().get(&t.decl_id);
-                has_changes = has_changes
-                    | rename_const_generics_on_function(
-                        handler,
-                        engines,
-                        impl_self_or_trait,
-                        &mut method,
-                    );
+                has_changes |= rename_const_generics_on_function(
+                    handler,
+                    engines,
+                    impl_self_or_trait,
+                    &mut method,
+                );
 
                 let mut type_id_type_parameters = vec![];
                 let mut const_generic_parameters = BTreeMap::default();
@@ -425,13 +431,12 @@ impl DeclRefFunction {
             method_type_subst_map.extend(&type_id_type_subst_map);
             method_type_subst_map.insert(method_implementing_for, type_id);
 
-            has_changes = has_changes
-                | method.subst(&SubstTypesContext::new(
-                    handler,
-                    engines,
-                    &method_type_subst_map,
-                    true,
-                ));
+            has_changes |= method.subst(&SubstTypesContext::new(
+                handler,
+                engines,
+                &method_type_subst_map,
+                true,
+            ));
 
             let decl_ref = if has_changes.has_changes() {
                 engines
@@ -554,7 +559,7 @@ impl HashWithEngines for TyFunctionDecl {
 
 impl SubstTypes for TyFunctionDecl {
     fn subst_inner(&mut self, ctx: &SubstTypesContext) -> HasChanges {
-        let changes = if ctx.subst_function_body {
+        let mut has_changes = if ctx.subst_function_body {
             has_changes! {
                 self.type_parameters.subst(ctx);
                 self.parameters.subst(ctx);
@@ -573,17 +578,16 @@ impl SubstTypes for TyFunctionDecl {
 
         if let Some(map) = ctx.type_subst_map.as_ref() {
             let handler = Handler::default();
-            // TODO: This is a workaround until we implement `materialize_const_generics`
-            //       that returns `HasChanges`.
-            let mut const_generic_materialization_has_changes = HasChanges::No;
             for (name, value) in &map.const_generics_materialization {
-                let _ = self.materialize_const_generics(ctx.engines, &handler, name, value);
-                const_generic_materialization_has_changes = HasChanges::Yes;
+                if let Ok(materialization_has_changes) =
+                    self.materialize_const_generics(ctx.engines, &handler, name, value)
+                {
+                    has_changes |= materialization_has_changes;
+                }
             }
-            changes | const_generic_materialization_has_changes
-        } else {
-            changes
         }
+
+        has_changes
     }
 }
 
@@ -593,7 +597,7 @@ impl ReplaceDecls for TyFunctionDecl {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         let mut func_ctx = ctx.by_ref().with_self_type(self.implementing_for);
         self.body
             .replace_decls(decl_mapping, handler, &mut func_ctx)

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -5,6 +5,7 @@ use crate::{
     has_changes,
     language::{parsed::ImplSelfOrTrait, CallPath},
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     transform,
     type_system::*,
-    Namespace,
+    HasChanges, Namespace,
 };
 use ast_elements::type_parameter::ConstGenericExpr;
 use monomorphization::MonomorphizeHelper;
@@ -106,24 +106,26 @@ impl MaterializeConstGenerics for TyStructDecl {
         handler: &Handler,
         name: &str,
         value: &crate::language::ty::TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         for p in self.generic_parameters.iter_mut() {
             match p {
                 TypeParameter::Const(p) if p.name.as_str() == name => {
                     p.expr = Some(ConstGenericExpr::from_ty_expression(handler, value)?);
+                    has_changes = HasChanges::Yes;
                 }
                 _ => {}
             }
         }
 
         for field in self.fields.iter_mut() {
-            field
+            has_changes |= field
                 .type_argument
                 .type_id
                 .materialize_const_generics(engines, handler, name, value)?;
         }
 
-        Ok(())
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     transform,
     type_system::*,
+    HasChanges,
 };
 use monomorphization::MonomorphizeHelper;
 use serde::{Deserialize, Serialize};
@@ -173,8 +174,8 @@ impl MaterializeConstGenerics for TyTraitDecl {
         _handler: &Handler,
         _name: &str,
         _value: &crate::language::ty::TyExpression,
-    ) -> Result<(), ErrorEmitted> {
-        Ok(())
+    ) -> Result<HasChanges, ErrorEmitted> {
+        Ok(HasChanges::No)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -14,6 +14,7 @@ use crate::{
     language::{parsed::TraitFn, ty::*, Purity},
     transform,
     type_system::*,
+    HasChanges,
 };
 
 #[derive(Clone, Debug)]

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -1,6 +1,6 @@
 use crate::{
     engine_threading::*, has_changes, language::parsed::TraitTypeDeclaration,
-    language::ty::TyDeclParsedType, transform, type_system::*,
+    language::ty::TyDeclParsedType, transform, type_system::*, HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -4,6 +4,7 @@ use crate::{
     language::{parsed::TypeAliasDeclaration, ty::TyDeclParsedType, CallPath, Visibility},
     transform,
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -3,6 +3,7 @@ use crate::{
     engine_threading::*,
     language::{parsed::VariableDeclaration, ty::*},
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -1,4 +1,4 @@
-use crate::{engine_threading::*, language::ty::*, type_system::*};
+use crate::{engine_threading::*, language::ty::*, type_system::*, HasChanges};
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use sway_types::Ident;

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -432,7 +432,8 @@ impl MaterializeConstGenerics for TyExpression {
             TyExpressionVariant::CodeBlock(block) => {
                 let mut has_changes = HasChanges::No;
                 for node in block.contents.iter_mut() {
-                    has_changes |= node.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |=
+                        node.materialize_const_generics(engines, handler, name, value)?;
                 }
                 Ok(has_changes)
             }
@@ -459,12 +460,15 @@ impl MaterializeConstGenerics for TyExpression {
                         .insert(name.to_string(), value.clone());
 
                     let mut new_decl = TyFunctionDecl::clone(&*fn_decl);
-                    if new_decl.subst_inner(&SubstTypesContext {
-                        handler,
-                        engines,
-                        type_subst_map: Some(&type_subst_map),
-                        subst_function_body: true,
-                    }).has_changes() {
+                    if new_decl
+                        .subst_inner(&SubstTypesContext {
+                            handler,
+                            engines,
+                            type_subst_map: Some(&type_subst_map),
+                            subst_function_body: true,
+                        })
+                        .has_changes()
+                    {
                         *fn_ref = engines.de().insert(new_decl, None);
                         has_changes = HasChanges::Yes;
                     }
@@ -478,7 +482,8 @@ impl MaterializeConstGenerics for TyExpression {
                 }
 
                 for (_, expr) in arguments {
-                    has_changes |= expr.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |=
+                        expr.materialize_const_generics(engines, handler, name, value)?;
                 }
                 Ok(has_changes)
             }
@@ -537,7 +542,8 @@ impl MaterializeConstGenerics for TyExpression {
                 let mut has_changes =
                     elem_type.materialize_const_generics(engines, handler, name, value)?;
                 for item in contents.iter_mut() {
-                    has_changes |= item.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |=
+                        item.materialize_const_generics(engines, handler, name, value)?;
                 }
                 Ok(has_changes)
             }
@@ -614,8 +620,9 @@ impl MaterializeConstGenerics for TyExpression {
             TyExpressionVariant::StructExpression { fields, .. } => {
                 let mut has_changes = HasChanges::No;
                 for f in fields {
-                    has_changes |=
-                        f.value.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |= f
+                        .value
+                        .materialize_const_generics(engines, handler, name, value)?;
                 }
                 Ok(has_changes)
             }

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -10,6 +10,7 @@ use crate::{
     transform::{AllowDeprecatedState, Attributes},
     type_system::*,
     types::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt, hash::Hasher};
@@ -69,7 +70,7 @@ impl ReplaceDecls for TyExpression {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         self.expression.replace_decls(decl_mapping, handler, ctx)
     }
 }
@@ -423,15 +424,17 @@ impl MaterializeConstGenerics for TyExpression {
         handler: &Handler,
         name: &str,
         value: &TyExpression,
-    ) -> Result<(), ErrorEmitted> {
-        self.return_type
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = self
+            .return_type
             .materialize_const_generics(engines, handler, name, value)?;
-        match &mut self.expression {
+        has_changes |= match &mut self.expression {
             TyExpressionVariant::CodeBlock(block) => {
+                let mut has_changes = HasChanges::No;
                 for node in block.contents.iter_mut() {
-                    node.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |= node.materialize_const_generics(engines, handler, name, value)?;
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::ConstGenericExpression { decl, .. } => {
                 decl.materialize_const_generics(engines, handler, name, value)
@@ -445,46 +448,50 @@ impl MaterializeConstGenerics for TyExpression {
                 fn_ref,
                 ..
             } => {
+                let mut has_changes = HasChanges::No;
+
                 // Materialize non dummy fns
-                let new_decl = engines.de().get(fn_ref.id());
-                if !new_decl.is_trait_method_dummy {
+                let fn_decl = engines.de().get(fn_ref.id());
+                if !fn_decl.is_trait_method_dummy {
                     let mut type_subst_map = TypeSubstMap::new();
                     type_subst_map
                         .const_generics_materialization
                         .insert(name.to_string(), value.clone());
 
-                    let mut new_decl = TyFunctionDecl::clone(&*new_decl);
-                    let r = new_decl.subst_inner(&SubstTypesContext {
+                    let mut new_decl = TyFunctionDecl::clone(&*fn_decl);
+                    if new_decl.subst_inner(&SubstTypesContext {
                         handler,
                         engines,
                         type_subst_map: Some(&type_subst_map),
                         subst_function_body: true,
-                    });
-
-                    if matches!(r, HasChanges::Yes) {
+                    }).has_changes() {
                         *fn_ref = engines.de().insert(new_decl, None);
+                        has_changes = HasChanges::Yes;
                     }
                 }
 
                 if let Some(type_binding) = type_binding.as_mut() {
-                    type_binding
+                    has_changes |= type_binding
                         .type_arguments
                         .to_vec_mut()
                         .materialize_const_generics(engines, handler, name, value)?;
                 }
 
                 for (_, expr) in arguments {
-                    expr.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |= expr.materialize_const_generics(engines, handler, name, value)?;
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::IntrinsicFunction(TyIntrinsicFunctionKind {
                 arguments,
                 type_arguments,
                 ..
             }) => {
-                type_arguments.materialize_const_generics(engines, handler, name, value)?;
-                arguments.materialize_const_generics(engines, handler, name, value)
+                let has_changes = has_changes! {
+                    type_arguments.materialize_const_generics(engines, handler, name, value)?;
+                    arguments.materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyExpressionVariant::Return(expr) => {
                 expr.materialize_const_generics(engines, handler, name, value)
@@ -494,45 +501,57 @@ impl MaterializeConstGenerics for TyExpression {
                 then,
                 r#else,
             } => {
-                condition.materialize_const_generics(engines, handler, name, value)?;
-                then.materialize_const_generics(engines, handler, name, value)?;
+                let mut has_changes = has_changes! {
+                    condition.materialize_const_generics(engines, handler, name, value)?;
+                    then.materialize_const_generics(engines, handler, name, value)?;
+                };
                 if let Some(e) = r#else.as_mut() {
-                    e.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |= e.materialize_const_generics(engines, handler, name, value)?;
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::WhileLoop { condition, body } => {
-                condition.materialize_const_generics(engines, handler, name, value)?;
-                body.materialize_const_generics(engines, handler, name, value)
+                let has_changes = has_changes! {
+                    condition.materialize_const_generics(engines, handler, name, value)?;
+                    body.materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyExpressionVariant::Reassignment(expr) => expr
                 .rhs
                 .materialize_const_generics(engines, handler, name, value),
             TyExpressionVariant::ArrayIndex { prefix, index } => {
-                prefix.materialize_const_generics(engines, handler, name, value)?;
-                index.materialize_const_generics(engines, handler, name, value)
+                let has_changes = has_changes! {
+                    prefix.materialize_const_generics(engines, handler, name, value)?;
+                    index.materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyExpressionVariant::Literal(_) | TyExpressionVariant::VariableExpression { .. } => {
-                Ok(())
+                Ok(HasChanges::No)
             }
             TyExpressionVariant::ArrayExplicit {
                 elem_type,
                 contents,
             } => {
-                elem_type.materialize_const_generics(engines, handler, name, value)?;
+                let mut has_changes =
+                    elem_type.materialize_const_generics(engines, handler, name, value)?;
                 for item in contents.iter_mut() {
-                    item.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |= item.materialize_const_generics(engines, handler, name, value)?;
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::ArrayRepeat {
                 elem_type,
                 value: elem_value,
                 length,
             } => {
-                elem_type.materialize_const_generics(engines, handler, name, value)?;
-                elem_value.materialize_const_generics(engines, handler, name, value)?;
-                length.materialize_const_generics(engines, handler, name, value)
+                let has_changes = has_changes! {
+                    elem_type.materialize_const_generics(engines, handler, name, value)?;
+                    elem_value.materialize_const_generics(engines, handler, name, value)?;
+                    length.materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyExpressionVariant::Ref(r) => {
                 r.materialize_const_generics(engines, handler, name, value)
@@ -544,64 +563,78 @@ impl MaterializeConstGenerics for TyExpression {
                 desugared.materialize_const_generics(engines, handler, name, value)
             }
             TyExpressionVariant::EnumInstantiation { contents, .. } => {
+                let mut has_changes = HasChanges::No;
                 if let Some(contents) = contents.as_mut() {
-                    contents.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |=
+                        contents.materialize_const_generics(engines, handler, name, value)?;
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::EnumTag { exp } => {
                 exp.materialize_const_generics(engines, handler, name, value)
             }
             TyExpressionVariant::Tuple { fields } => {
+                let mut has_changes = HasChanges::No;
                 for f in fields {
-                    f.materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |= f.materialize_const_generics(engines, handler, name, value)?;
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::TupleElemAccess {
                 prefix,
                 resolved_type_of_parent,
                 ..
             } => {
-                prefix.materialize_const_generics(engines, handler, name, value)?;
-                resolved_type_of_parent
-                    .materialize_const_generics(engines, handler, name, value)?;
-                Ok(())
+                let has_changes = has_changes! {
+                    prefix.materialize_const_generics(engines, handler, name, value)?;
+                    resolved_type_of_parent.materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyExpressionVariant::LazyOperator { lhs, rhs, .. } => {
-                lhs.materialize_const_generics(engines, handler, name, value)?;
-                rhs.materialize_const_generics(engines, handler, name, value)
+                let has_changes = has_changes! {
+                    lhs.materialize_const_generics(engines, handler, name, value)?;
+                    rhs.materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyExpressionVariant::AsmExpression { registers, .. } => {
+                let mut has_changes = HasChanges::No;
                 for r in registers.iter_mut() {
                     if let Some(init) = r.initializer.as_mut() {
-                        init.materialize_const_generics(engines, handler, name, value)?;
+                        has_changes |=
+                            init.materialize_const_generics(engines, handler, name, value)?;
                     }
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::ConstantExpression { decl, .. } => {
                 decl.materialize_const_generics(engines, handler, name, value)
             }
             TyExpressionVariant::StructExpression { fields, .. } => {
+                let mut has_changes = HasChanges::No;
                 for f in fields {
-                    f.value
-                        .materialize_const_generics(engines, handler, name, value)?;
+                    has_changes |=
+                        f.value.materialize_const_generics(engines, handler, name, value)?;
                 }
-                Ok(())
+                Ok(has_changes)
             }
             TyExpressionVariant::StructFieldAccess {
                 prefix,
                 resolved_type_of_parent,
                 ..
             } => {
-                prefix.materialize_const_generics(engines, handler, name, value)?;
-                resolved_type_of_parent.materialize_const_generics(engines, handler, name, value)
+                let has_changes = has_changes! {
+                    prefix.materialize_const_generics(engines, handler, name, value)?;
+                    resolved_type_of_parent
+                    .materialize_const_generics(engines, handler, name, value)?;
+                };
+                Ok(has_changes)
             }
             TyExpressionVariant::UnsafeDowncast { exp, .. } => {
                 exp.materialize_const_generics(engines, handler, name, value)
             }
-            TyExpressionVariant::Continue | TyExpressionVariant::Break => Ok(()),
+            TyExpressionVariant::Continue | TyExpressionVariant::Break => Ok(HasChanges::No),
             TyExpressionVariant::AbiCast { address, .. } => {
                 address.materialize_const_generics(engines, handler, name, value)
             }
@@ -610,7 +643,8 @@ impl MaterializeConstGenerics for TyExpression {
                     span: self.span.clone(),
                 },
             )),
-        }
+        }?;
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -8,6 +8,7 @@ use crate::{
         TypeCheckContext, TypeCheckFinalization, TypeCheckFinalizationContext,
     },
     type_system::*,
+    HasChanges,
 };
 use ast_elements::type_parameter::GenericTypeParameter;
 use indexmap::IndexMap;
@@ -835,18 +836,18 @@ impl ReplaceDecls for TyExpressionVariant {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
             use TyExpressionVariant::*;
             match self {
-                Literal(..) => Ok(false),
+                Literal(..) => Ok(HasChanges::No),
                 FunctionApplication {
                     ref mut fn_ref,
                     ref mut arguments,
                     call_path,
                     ..
                 } => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
 
                     has_changes |= fn_ref.replace_decls(decl_mapping, handler, ctx)?;
 
@@ -928,9 +929,12 @@ impl ReplaceDecls for TyExpressionVariant {
 
                     inner_decl_mapping.extend(decl_mapping);
 
-                    if method.replace_decls(&inner_decl_mapping, handler, ctx)? {
+                    if method
+                        .replace_decls(&inner_decl_mapping, handler, ctx)?
+                        .has_changes()
+                    {
                         decl_engine.replace(*fn_ref.id(), method);
-                        has_changes = true;
+                        has_changes = HasChanges::Yes;
                     }
 
                     Ok(has_changes)
@@ -944,10 +948,10 @@ impl ReplaceDecls for TyExpressionVariant {
                 ConfigurableExpression { decl, .. } => {
                     decl.replace_decls(decl_mapping, handler, ctx)
                 }
-                ConstGenericExpression { .. } => Ok(false),
-                VariableExpression { .. } => Ok(false),
+                ConstGenericExpression { .. } => Ok(HasChanges::No),
+                VariableExpression { .. } => Ok(HasChanges::No),
                 Tuple { fields } => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
                     for item in fields.iter_mut() {
                         if let Ok(r) = item.replace_decls(decl_mapping, handler, ctx) {
                             has_changes |= r;
@@ -959,7 +963,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     elem_type: _,
                     contents,
                 } => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
                     for expr in contents.iter_mut() {
                         if let Ok(r) = expr.replace_decls(decl_mapping, handler, ctx) {
                             has_changes |= r;
@@ -977,7 +981,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     Ok(has_changes)
                 }
                 ArrayIndex { prefix, index } => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
                     if let Ok(r) = (*prefix).replace_decls(decl_mapping, handler, ctx) {
                         has_changes |= r;
                     }
@@ -992,7 +996,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     instantiation_span: _,
                     call_path_binding: _,
                 } => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
                     for field in fields.iter_mut() {
                         if let Ok(r) = field.replace_decls(decl_mapping, handler, ctx) {
                             has_changes |= r;
@@ -1001,14 +1005,14 @@ impl ReplaceDecls for TyExpressionVariant {
                     Ok(has_changes)
                 }
                 CodeBlock(block) => block.replace_decls(decl_mapping, handler, ctx),
-                FunctionParameter => Ok(false),
+                FunctionParameter => Ok(HasChanges::No),
                 MatchExp { desugared, .. } => desugared.replace_decls(decl_mapping, handler, ctx),
                 IfExp {
                     condition,
                     then,
                     r#else,
                 } => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
                     if let Ok(r) = condition.replace_decls(decl_mapping, handler, ctx) {
                         has_changes |= r;
                     }
@@ -1023,7 +1027,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     }
                     Ok(has_changes)
                 }
-                AsmExpression { .. } => Ok(false),
+                AsmExpression { .. } => Ok(HasChanges::No),
                 StructFieldAccess { prefix, .. } => {
                     prefix.replace_decls(decl_mapping, handler, ctx)
                 }
@@ -1038,13 +1042,13 @@ impl ReplaceDecls for TyExpressionVariant {
                     if let Some(ref mut contents) = contents {
                         contents.replace_decls(decl_mapping, handler, ctx)
                     } else {
-                        Ok(false)
+                        Ok(HasChanges::No)
                     }
                 }
                 AbiCast { address, .. } => address.replace_decls(decl_mapping, handler, ctx),
-                StorageAccess { .. } => Ok(false),
+                StorageAccess { .. } => Ok(HasChanges::No),
                 IntrinsicFunction(TyIntrinsicFunctionKind { arguments, .. }) => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
                     for expr in arguments.iter_mut() {
                         if let Ok(r) = expr.replace_decls(decl_mapping, handler, ctx) {
                             has_changes |= r;
@@ -1054,12 +1058,12 @@ impl ReplaceDecls for TyExpressionVariant {
                 }
                 EnumTag { exp } => exp.replace_decls(decl_mapping, handler, ctx),
                 UnsafeDowncast { exp, .. } => exp.replace_decls(decl_mapping, handler, ctx),
-                AbiName(_) => Ok(false),
+                AbiName(_) => Ok(HasChanges::No),
                 WhileLoop {
                     ref mut condition,
                     ref mut body,
                 } => {
-                    let mut has_changes = false;
+                    let mut has_changes = HasChanges::No;
                     if let Ok(r) = condition.replace_decls(decl_mapping, handler, ctx) {
                         has_changes |= r;
                     }
@@ -1071,8 +1075,8 @@ impl ReplaceDecls for TyExpressionVariant {
                 ForLoop { ref mut desugared } => {
                     desugared.replace_decls(decl_mapping, handler, ctx)
                 }
-                Break => Ok(false),
-                Continue => Ok(false),
+                Break => Ok(HasChanges::No),
+                Continue => Ok(HasChanges::No),
                 Reassignment(reassignment) => {
                     reassignment.replace_decls(decl_mapping, handler, ctx)
                 }
@@ -1377,12 +1381,10 @@ impl UpdateConstantExpression for TyExpressionVariant {
         match self {
             Literal(..) => HasChanges::No,
             FunctionApplication { .. } => HasChanges::No,
-            LazyOperator { lhs, rhs, .. } => {
-                has_changes!(
-                    (*lhs).update_constant_expression(engines, implementing_type);
-                    (*rhs).update_constant_expression(engines, implementing_type);
-                )
-            }
+            LazyOperator { lhs, rhs, .. } => has_changes! {
+                (*lhs).update_constant_expression(engines, implementing_type);
+                (*rhs).update_constant_expression(engines, implementing_type);
+            },
             ConstantExpression { ref mut decl, .. } => {
                 if let Some(impl_const) =
                     find_const_decl_from_impl(implementing_type, engines.de(), decl)
@@ -1398,41 +1400,32 @@ impl UpdateConstantExpression for TyExpressionVariant {
             }
             ConstGenericExpression { .. } => HasChanges::No,
             VariableExpression { .. } => HasChanges::No,
-            Tuple { fields } => fields
-                .iter_mut()
-                .map(|field| field.update_constant_expression(engines, implementing_type))
-                .fold(HasChanges::No, |acc, x| acc | x),
+            Tuple { fields } => fields.iter_mut().fold(HasChanges::No, |acc, x| {
+                acc | x.update_constant_expression(engines, implementing_type)
+            }),
             ArrayExplicit {
                 contents,
                 elem_type: _,
-            } => contents
-                .iter_mut()
-                .map(|elem| elem.update_constant_expression(engines, implementing_type))
-                .fold(HasChanges::No, |acc, x| acc | x),
+            } => contents.iter_mut().fold(HasChanges::No, |acc, x| {
+                acc | x.update_constant_expression(engines, implementing_type)
+            }),
             ArrayRepeat {
                 elem_type: _,
                 value,
                 length,
-            } => {
-                has_changes!(
-                    value.update_constant_expression(engines, implementing_type);
-                    length.update_constant_expression(engines, implementing_type);
-                )
-            }
-            ArrayIndex { prefix, index } => {
-                has_changes!(
-                    (*prefix).update_constant_expression(engines, implementing_type);
-                    (*index).update_constant_expression(engines, implementing_type);
-                )
-            }
-            StructExpression { fields, .. } => fields
-                .iter_mut()
-                .map(|field| {
-                    field
-                        .value
-                        .update_constant_expression(engines, implementing_type)
-                })
-                .fold(HasChanges::No, |acc, x| acc | x),
+            } => has_changes! {
+                value.update_constant_expression(engines, implementing_type);
+                length.update_constant_expression(engines, implementing_type);
+            },
+            ArrayIndex { prefix, index } => has_changes! {
+                (*prefix).update_constant_expression(engines, implementing_type);
+                (*index).update_constant_expression(engines, implementing_type);
+            },
+            StructExpression { fields, .. } => fields.iter_mut().fold(HasChanges::No, |acc, x| {
+                acc | x
+                    .value
+                    .update_constant_expression(engines, implementing_type)
+            }),
             CodeBlock(block) => block.update_constant_expression(engines, implementing_type),
             FunctionParameter => HasChanges::No,
             MatchExp { desugared, .. } => {
@@ -1448,8 +1441,7 @@ impl UpdateConstantExpression for TyExpressionVariant {
                     then.update_constant_expression(engines, implementing_type);
                 );
                 if let Some(ref mut r#else) = r#else {
-                    has_changes =
-                        has_changes | r#else.update_constant_expression(engines, implementing_type);
+                    has_changes |= r#else.update_constant_expression(engines, implementing_type);
                 }
                 has_changes
             }
@@ -1464,13 +1456,10 @@ impl UpdateConstantExpression for TyExpressionVariant {
                 enum_ref: _,
                 contents,
                 ..
-            } => {
-                if let Some(ref mut contents) = contents {
-                    contents.update_constant_expression(engines, implementing_type)
-                } else {
-                    HasChanges::No
-                }
-            }
+            } => contents
+                .as_mut()
+                .map(|contents| contents.update_constant_expression(engines, implementing_type))
+                .unwrap_or(HasChanges::No),
             AbiCast { address, .. } => {
                 address.update_constant_expression(engines, implementing_type)
             }
@@ -1484,12 +1473,10 @@ impl UpdateConstantExpression for TyExpressionVariant {
             WhileLoop {
                 ref mut condition,
                 ref mut body,
-            } => {
-                has_changes!(
-                    condition.update_constant_expression(engines, implementing_type);
-                    body.update_constant_expression(engines, implementing_type);
-                )
-            }
+            } => has_changes! {
+                condition.update_constant_expression(engines, implementing_type);
+                body.update_constant_expression(engines, implementing_type);
+            },
             ForLoop { ref mut desugared } => {
                 desugared.update_constant_expression(engines, implementing_type)
             }

--- a/sway-core/src/language/ty/expression/intrinsic_function.rs
+++ b/sway-core/src/language/ty/expression/intrinsic_function.rs
@@ -1,4 +1,6 @@
-use crate::{engine_threading::*, has_changes, language::ty::*, type_system::*, types::*};
+use crate::{
+    engine_threading::*, has_changes, language::ty::*, type_system::*, types::*, HasChanges,
+};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -8,6 +8,7 @@ use crate::{
         TypeCheckFinalizationContext,
     },
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -170,24 +171,26 @@ impl ReplaceDecls for TyReassignmentTarget {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         Ok(match self {
             TyReassignmentTarget::DerefAccess { exp, indices } => {
                 let mut changed = exp.replace_decls(decl_mapping, handler, ctx)?;
                 changed |= indices
                     .iter_mut()
                     .map(|i| i.replace_decls(decl_mapping, handler, ctx))
-                    .collect::<Result<Vec<bool>, _>>()?
+                    .collect::<Result<Vec<HasChanges>, _>>()?
                     .iter()
-                    .any(|is_changed| *is_changed);
+                    .any(|has_changes| has_changes.has_changes())
+                    .into();
                 changed
             }
             TyReassignmentTarget::ElementAccess { indices, .. } => indices
                 .iter_mut()
                 .map(|i| i.replace_decls(decl_mapping, handler, ctx))
-                .collect::<Result<Vec<bool>, _>>()?
+                .collect::<Result<Vec<HasChanges>, _>>()?
                 .iter()
-                .any(|is_changed| *is_changed),
+                .any(|has_changes| has_changes.has_changes())
+                .into(),
         })
     }
 }
@@ -198,11 +201,11 @@ impl ReplaceDecls for TyReassignment {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         let lhs_changed = self.lhs.replace_decls(decl_mapping, handler, ctx)?;
         let rhs_changed = self.rhs.replace_decls(decl_mapping, handler, ctx)?;
 
-        Ok(lhs_changed || rhs_changed)
+        Ok(lhs_changed | rhs_changed)
     }
 }
 
@@ -289,17 +292,19 @@ impl UpdateConstantExpression for TyReassignmentTarget {
         implementing_type: &TyDecl,
     ) -> HasChanges {
         match self {
-            TyReassignmentTarget::DerefAccess { exp, indices } => {
-                exp.update_constant_expression(engines, implementing_type)
-                    | indices
-                        .iter_mut()
-                        .map(|i| i.update_constant_expression(engines, implementing_type))
-                        .fold(HasChanges::No, |acc, x| acc | x)
+            TyReassignmentTarget::DerefAccess { exp, indices } => has_changes! {
+                exp.update_constant_expression(engines, implementing_type);
+                indices
+                    .iter_mut()
+                    .fold(HasChanges::No, |acc, i| {
+                        acc | i.update_constant_expression(engines, implementing_type)
+                    });
+            },
+            TyReassignmentTarget::ElementAccess { indices, .. } => {
+                indices.iter_mut().fold(HasChanges::No, |acc, i| {
+                    acc | i.update_constant_expression(engines, implementing_type)
+                })
             }
-            TyReassignmentTarget::ElementAccess { indices, .. } => indices
-                .iter_mut()
-                .map(|i| i.update_constant_expression(engines, implementing_type))
-                .fold(HasChanges::No, |acc, x| acc | x),
         }
     }
 }
@@ -310,10 +315,10 @@ impl UpdateConstantExpression for TyReassignment {
         engines: &Engines,
         implementing_type: &TyDecl,
     ) -> HasChanges {
-        has_changes!(
+        has_changes! {
             self.lhs.update_constant_expression(engines, implementing_type);
             self.rhs.update_constant_expression(engines, implementing_type);
-        )
+        }
     }
 }
 
@@ -415,11 +420,11 @@ impl ReplaceDecls for ProjectionKind {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         use ProjectionKind::*;
         match self {
             ArrayIndex { index, .. } => index.replace_decls(decl_mapping, handler, ctx),
-            _ => Ok(false),
+            _ => Ok(HasChanges::No),
         }
     }
 }
@@ -459,8 +464,6 @@ impl UpdateConstantExpression for ProjectionKind {
         implementing_type: &TyDecl,
     ) -> HasChanges {
         use ProjectionKind::*;
-        #[allow(clippy::single_match)]
-        // To keep it consistent and same looking as the above implementations.
         match self {
             ArrayIndex { index, .. } => {
                 index.update_constant_expression(engines, implementing_type)

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -4,6 +4,7 @@ use crate::{
     language::ty::*,
     semantic_analysis::{TypeCheckContext, TypeCheckFinalization, TypeCheckFinalizationContext},
     type_system::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
@@ -43,7 +44,7 @@ impl ReplaceDecls for TyStructExpressionField {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-    ) -> Result<bool, ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         self.value.replace_decls(decl_mapping, handler, ctx)
     }
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -15,6 +15,7 @@ mod concurrent_slab;
 mod control_flow_analysis;
 mod debug_generation;
 pub mod decl_engine;
+pub mod has_changes;
 pub mod ir_generation;
 pub mod language;
 pub mod marker_traits;
@@ -79,6 +80,7 @@ use types::{CollectTypesMetadata, CollectTypesMetadataContext, LogId, TypeMetada
 pub use semantic_analysis::namespace::{self, Namespace};
 pub mod types;
 
+pub use has_changes::HasChanges;
 use sway_error::error::{CompileError, TrivialCheckDiagType};
 use sway_types::{ident::Ident, span, Spanned};
 pub use type_system::*;

--- a/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
@@ -147,7 +147,10 @@ impl ty::TyConfigurableDecl {
                 &span,
             )?;
 
-            let decode_fn_ref = if decode_fn_decl.replace_decls(&decl_mapping, handler, &mut ctx)? {
+            let decode_fn_ref = if decode_fn_decl
+                .replace_decls(&decl_mapping, handler, &mut ctx)?
+                .has_changes()
+            {
                 engines
                     .de()
                     .insert(

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -1250,7 +1250,10 @@ fn type_check_trait_implementation(
             TyImplItem::Fn(decl_ref) => {
                 let mut method = (*decl_engine.get_function(decl_ref)).clone();
 
-                let mut has_changes = impl_type_parameters.is_empty().into();
+                // If we have `impl_type_parameters`, the `method.type_parameters`
+                // will be changed below, otherwise not. I.e., if `impl_type_parameters`
+                // are not empty, we will have changes.
+                let mut has_changes = (!impl_type_parameters.is_empty()).into();
 
                 // We need to add impl type parameters to the method's type parameters
                 // so that in-line monomorphization can complete.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -17,6 +17,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 use crate::{
     decl_engine::{parsed_id::ParsedDeclId, *},
     engine_threading::*,
+    has_changes,
     language::{
         parsed::*,
         ty::{
@@ -33,6 +34,7 @@ use crate::{
         TypeCheckFinalization, TypeCheckFinalizationContext,
     },
     type_system::*,
+    HasChanges,
 };
 
 impl TyImplSelfOrTrait {
@@ -1248,11 +1250,7 @@ fn type_check_trait_implementation(
             TyImplItem::Fn(decl_ref) => {
                 let mut method = (*decl_engine.get_function(decl_ref)).clone();
 
-                let mut has_changes = if impl_type_parameters.is_empty() {
-                    HasChanges::No
-                } else {
-                    HasChanges::Yes
-                };
+                let mut has_changes = impl_type_parameters.is_empty().into();
 
                 // We need to add impl type parameters to the method's type parameters
                 // so that in-line monomorphization can complete.
@@ -1278,17 +1276,14 @@ fn type_check_trait_implementation(
                     has_changes = HasChanges::Yes;
                 }
 
-                if method.replace_decls(&decl_mapping, handler, &mut ctx)? {
-                    has_changes = HasChanges::Yes;
-                };
+                has_changes |= method.replace_decls(&decl_mapping, handler, &mut ctx)?;
 
-                has_changes = has_changes
-                    | method.subst(&SubstTypesContext::new(
-                        handler,
-                        engines,
-                        &trait_type_mapping,
-                        !ctx.code_block_first_pass(),
-                    ));
+                has_changes |= method.subst(&SubstTypesContext::new(
+                    handler,
+                    engines,
+                    &trait_type_mapping,
+                    !ctx.code_block_first_pass(),
+                ));
 
                 let decl_ref = if has_changes.has_changes() {
                     decl_engine
@@ -1305,19 +1300,15 @@ fn type_check_trait_implementation(
             }
             TyImplItem::Constant(decl_ref) => {
                 let mut const_decl = (*decl_engine.get_constant(decl_ref)).clone();
-                let mut has_changes =
-                    if const_decl.replace_decls(&decl_mapping, handler, &mut ctx)? {
-                        HasChanges::Yes
-                    } else {
-                        HasChanges::No
-                    };
-                has_changes = has_changes
-                    | const_decl.subst(&SubstTypesContext::new(
+                let has_changes = has_changes! {
+                    const_decl.replace_decls(&decl_mapping, handler, &mut ctx)?;
+                    const_decl.subst(&SubstTypesContext::new(
                         handler,
                         engines,
                         &trait_type_mapping,
                         !ctx.code_block_first_pass(),
                     ));
+                };
 
                 let decl_ref = if has_changes.has_changes() {
                     decl_engine.insert(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -102,7 +102,10 @@ pub(crate) fn instantiate_function_application(
             )?;
 
             let mut new_function_decl = TyFunctionDecl::clone(&*function_decl);
-            if new_function_decl.replace_decls(&decl_mapping, handler, &mut ctx)? {
+            if new_function_decl
+                .replace_decls(&decl_mapping, handler, &mut ctx)?
+                .has_changes()
+            {
                 let return_type_id = new_function_decl.return_type.type_id;
                 let is_type_check_finalized = new_function_decl.is_type_check_finalized;
                 let is_trait_method_dummy = new_function_decl.is_trait_method_dummy;

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     semantic_analysis::*,
     type_system::*,
+    HasChanges,
 };
 use ast_elements::{
     type_argument::GenericTypeArgument,
@@ -771,9 +772,7 @@ pub(crate) fn type_check_method_application(
             .ok();
 
             if let Some(decl_mapping) = decl_mapping {
-                if method.replace_decls(&decl_mapping, handler, &mut ctx)? {
-                    has_changes = HasChanges::Yes;
-                }
+                has_changes |= method.replace_decls(&decl_mapping, handler, &mut ctx)?;
             }
         }
 
@@ -1045,10 +1044,9 @@ pub(crate) fn monomorphize_method(
     )?;
 
     if let Some(implementing_type) = &func_decl.implementing_type {
-        has_changes = has_changes
-            | func_decl
-                .body
-                .update_constant_expression(engines, implementing_type);
+        has_changes |= func_decl
+            .body
+            .update_constant_expression(engines, implementing_type);
     }
 
     // TODO: This change of not re-inserting already inserted declarations

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     type_system::priv_prelude::*,
     types::{CollectTypesMetadata, CollectTypesMetadataContext, TypeMetadata},
-    EnforceTypeArguments, Namespace,
+    EnforceTypeArguments, HasChanges, Namespace,
 };
 use serde::{Deserialize, Serialize};
 use std::{

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -1,7 +1,7 @@
 use super::type_parameter::ConstGenericExpr;
 use crate::{
     decl_engine::MaterializeConstGenerics, engine_threading::*, language::CallPathTree,
-    type_system::priv_prelude::*,
+    type_system::priv_prelude::*, HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -102,7 +102,7 @@ impl MaterializeConstGenerics for GenericTypeArgument {
         handler: &sway_error::handler::Handler,
         name: &str,
         value: &crate::language::ty::TyExpression,
-    ) -> Result<(), sway_error::handler::ErrorEmitted> {
+    ) -> Result<HasChanges, sway_error::handler::ErrorEmitted> {
         self.type_id
             .materialize_const_generics(engines, handler, name, value)
     }
@@ -302,19 +302,22 @@ impl MaterializeConstGenerics for GenericArgument {
         handler: &sway_error::handler::Handler,
         name: &str,
         value: &crate::language::ty::TyExpression,
-    ) -> Result<(), sway_error::handler::ErrorEmitted> {
+    ) -> Result<HasChanges, sway_error::handler::ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         match self {
             GenericArgument::Type(arg) => {
-                arg.materialize_const_generics(engines, handler, name, value)?;
+                has_changes |= arg.materialize_const_generics(engines, handler, name, value)?;
             }
             GenericArgument::Const(arg) => {
                 arg.expr = match arg.expr.clone() {
                     ConstGenericExpr::AmbiguousVariableExpression { ident, mut decl } => {
                         if let Some(decl) = decl.as_mut() {
-                            decl.materialize_const_generics(engines, handler, name, value)?;
+                            has_changes |=
+                                decl.materialize_const_generics(engines, handler, name, value)?;
                         }
 
                         if ident.as_str() == name {
+                            has_changes = HasChanges::Yes;
                             ConstGenericExpr::Literal {
                                 val: value
                                     .extract_literal_value()
@@ -324,6 +327,10 @@ impl MaterializeConstGenerics for GenericArgument {
                                 span: value.span.clone(),
                             }
                         } else {
+                            // If the `decl` got changed, `has_changes` already reflects that.
+                            // Otherwise, this newly created `ConstGenericExpr` is same as
+                            // the original `arg.expr` and there is no need for setting the
+                            // `has_changes` to `Yes`.
                             ConstGenericExpr::AmbiguousVariableExpression { ident, decl }
                         }
                     }
@@ -331,7 +338,7 @@ impl MaterializeConstGenerics for GenericArgument {
                 };
             }
         }
-        Ok(())
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -987,22 +987,34 @@ impl MaterializeConstGenerics for ConstGenericExprTyDecl {
         match self {
             ConstGenericExprTyDecl::ConstGenericDecl(decl) => {
                 let mut decl = TyConstGenericDecl::clone(&*engines.de().get(&decl.decl_id));
-                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
+                let mut has_changes =
+                    decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let decl_ref = engines.de().insert(decl, None); // TODO improve parsed_decl_id
                 *self = ConstGenericExprTyDecl::ConstGenericDecl(ConstGenericDecl {
                     decl_id: *decl_ref.id(),
                 });
+
+                // TODO: Deliberately using `mut has_changes` above and changing it here.
+                //       This will be changed when we inspect returned `HasChanges` and
+                //       remove additional not needed `DeclEngine::insert` calls.
+                has_changes |= HasChanges::Yes;
+
                 Ok(has_changes)
             }
             ConstGenericExprTyDecl::ConstantDecl(decl) => {
                 let mut decl = TyConstantDecl::clone(&*engines.de().get(&decl.decl_id));
-                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
+                let mut has_changes =
+                    decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let decl_ref = engines.de().insert(decl, None); // TODO improve parsed_decl_id
                 *self = ConstGenericExprTyDecl::ConstantDecl(ConstantDecl {
                     decl_id: *decl_ref.id(),
                 });
+
+                // TODO: See above.
+                has_changes |= HasChanges::Yes;
+
                 Ok(has_changes)
             }
         }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -17,6 +17,7 @@ use crate::{
     namespace::TraitMap,
     semantic_analysis::{GenericShadowingMode, TypeCheckContext},
     type_system::priv_prelude::*,
+    HasChanges,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -982,27 +983,27 @@ impl MaterializeConstGenerics for ConstGenericExprTyDecl {
         handler: &sway_error::handler::Handler,
         name: &str,
         value: &crate::language::ty::TyExpression,
-    ) -> Result<(), sway_error::handler::ErrorEmitted> {
+    ) -> Result<HasChanges, sway_error::handler::ErrorEmitted> {
         match self {
             ConstGenericExprTyDecl::ConstGenericDecl(decl) => {
                 let mut decl = TyConstGenericDecl::clone(&*engines.de().get(&decl.decl_id));
-                decl.materialize_const_generics(engines, handler, name, value)?;
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let decl_ref = engines.de().insert(decl, None); // TODO improve parsed_decl_id
                 *self = ConstGenericExprTyDecl::ConstGenericDecl(ConstGenericDecl {
                     decl_id: *decl_ref.id(),
                 });
-                Ok(())
+                Ok(has_changes)
             }
             ConstGenericExprTyDecl::ConstantDecl(decl) => {
                 let mut decl = TyConstantDecl::clone(&*engines.de().get(&decl.decl_id));
-                decl.materialize_const_generics(engines, handler, name, value)?;
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let decl_ref = engines.de().insert(decl, None); // TODO improve parsed_decl_id
                 *self = ConstGenericExprTyDecl::ConstantDecl(ConstantDecl {
                     decl_id: *decl_ref.id(),
                 });
-                Ok(())
+                Ok(has_changes)
             }
         }
     }

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -20,7 +20,7 @@ use crate::{
     semantic_analysis::TypeCheckContext,
     type_system::priv_prelude::*,
     types::{CollectTypesMetadata, CollectTypesMetadataContext, TypeMetadata},
-    EnforceTypeArguments,
+    EnforceTypeArguments, HasChanges,
 };
 
 use std::{
@@ -131,14 +131,15 @@ impl MaterializeConstGenerics for TypeId {
         handler: &Handler,
         name: &str,
         value: &crate::language::ty::TyExpression,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = HasChanges::No;
         match &*engines.te().get(*self) {
             TypeInfo::Array(
                 element_type,
                 Length(ConstGenericExpr::AmbiguousVariableExpression { ident, decl }),
             ) => {
                 let mut elem_type = element_type.clone();
-                elem_type.materialize_const_generics(engines, handler, name, value)?;
+                has_changes |= elem_type.materialize_const_generics(engines, handler, name, value)?;
 
                 if ident.as_str() == name {
                     let val = match &value.expression {
@@ -161,10 +162,12 @@ impl MaterializeConstGenerics for TypeId {
                             span: value.span.clone(),
                         }),
                     );
+                    has_changes = HasChanges::Yes;
                 } else {
                     let mut decl = decl.clone();
                     if let Some(decl) = decl.as_mut() {
-                        decl.materialize_const_generics(engines, handler, name, value)?;
+                        has_changes |=
+                            decl.materialize_const_generics(engines, handler, name, value)?;
                     }
 
                     *self = engines.te().insert_array(
@@ -175,12 +178,13 @@ impl MaterializeConstGenerics for TypeId {
                             decl,
                         }),
                     );
+                    has_changes = HasChanges::Yes;
                 }
             }
             TypeInfo::Enum(id) => {
                 let decl = engines.de().get(id);
                 let mut decl = (*decl).clone();
-                decl.materialize_const_generics(engines, handler, name, value)?;
+                has_changes |= decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let parsed_decl = engines
                     .de()
@@ -191,10 +195,11 @@ impl MaterializeConstGenerics for TypeId {
                 let decl_ref = engines.de().insert(decl, parsed_decl.as_ref());
 
                 *self = engines.te().insert_enum(engines, *decl_ref.id());
+                has_changes = HasChanges::Yes;
             }
             TypeInfo::Struct(id) => {
                 let mut decl = TyStructDecl::clone(&engines.de().get(id));
-                decl.materialize_const_generics(engines, handler, name, value)?;
+                has_changes |= decl.materialize_const_generics(engines, handler, name, value)?;
 
                 let parsed_decl = engines
                     .de()
@@ -205,6 +210,7 @@ impl MaterializeConstGenerics for TypeId {
                 let decl_ref = engines.de().insert(decl, parsed_decl.as_ref());
 
                 *self = engines.te().insert_struct(engines, *decl_ref.id());
+                has_changes = HasChanges::Yes;
             }
             TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression {
                 ident,
@@ -229,6 +235,7 @@ impl MaterializeConstGenerics for TypeId {
                         span: value.span.clone(),
                     }),
                 );
+                has_changes = HasChanges::Yes;
             }
             TypeInfo::Ref {
                 to_mutable_value,
@@ -236,18 +243,19 @@ impl MaterializeConstGenerics for TypeId {
                 ..
             } => {
                 let mut referenced_type = referenced_type.clone();
-                referenced_type
+                has_changes |= referenced_type
                     .type_id
                     .materialize_const_generics(engines, handler, name, value)?;
 
                 *self = engines
                     .te()
                     .insert_ref(engines, *to_mutable_value, referenced_type);
+                has_changes = HasChanges::Yes;
             }
             _ => {}
         }
 
-        Ok(())
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -139,7 +139,8 @@ impl MaterializeConstGenerics for TypeId {
                 Length(ConstGenericExpr::AmbiguousVariableExpression { ident, decl }),
             ) => {
                 let mut elem_type = element_type.clone();
-                has_changes |= elem_type.materialize_const_generics(engines, handler, name, value)?;
+                has_changes |=
+                    elem_type.materialize_const_generics(engines, handler, name, value)?;
 
                 if ident.as_str() == name {
                     let val = match &value.expression {

--- a/sway-core/src/type_system/monomorphization.rs
+++ b/sway-core/src/type_system/monomorphization.rs
@@ -279,25 +279,23 @@ where
     let mut has_changes = HasChanges::No;
 
     let ctx = SubstTypesContext::new(handler, engines, &type_mapping, true);
-    has_changes = has_changes | value.subst(&ctx);
+    has_changes |= value.subst(&ctx);
 
-    // TODO: This is a workaround until we implement `materialize_const_generics`
-    //       that returns `HasChanges`.
-    let mut const_generic_materialization_has_changes = HasChanges::No;
     for (name, expr) in const_generics.iter() {
-        let _ = value.materialize_const_generics(engines, handler, name, expr);
-        const_generic_materialization_has_changes = HasChanges::Yes;
+        if let Ok(materialization_has_changes) =
+            value.materialize_const_generics(engines, handler, name, expr)
+        {
+            has_changes |= materialization_has_changes;
+        }
     }
-    has_changes = has_changes | const_generic_materialization_has_changes;
 
-    // TODO: This is a workaround until we implement `materialize_const_generics`
-    //       that returns `HasChanges`.
-    let mut const_generic_materialization_has_changes = HasChanges::No;
     for (name, expr) in type_mapping.const_generics_materialization.iter() {
-        let _ = value.materialize_const_generics(engines, handler, name, expr);
-        const_generic_materialization_has_changes = HasChanges::Yes;
+        if let Ok(materialization_has_changes) =
+            value.materialize_const_generics(engines, handler, name, expr)
+        {
+            has_changes |= materialization_has_changes;
+        }
     }
-    has_changes = has_changes | const_generic_materialization_has_changes;
 
     Ok(has_changes)
 }

--- a/sway-core/src/type_system/priv_prelude.rs
+++ b/sway-core/src/type_system/priv_prelude.rs
@@ -8,7 +8,6 @@ pub(crate) use super::{
     info::VecSet,
     substitute::{
         subst_map::TypeSubstMap,
-        subst_types::HasChanges,
         subst_types::{SubstTypes, SubstTypesContext},
     },
     unify::unify_check::UnifyCheck,

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -5,6 +5,7 @@ use crate::{
         DebugWithEngines, Engines, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     type_system::priv_prelude::*,
+    HasChanges,
 };
 use std::{collections::BTreeMap, fmt};
 use sway_error::handler::Handler;

--- a/sway-core/src/type_system/substitute/subst_types.rs
+++ b/sway-core/src/type_system/substitute/subst_types.rs
@@ -1,30 +1,6 @@
-use crate::{engine_threading::Engines, type_system::priv_prelude::*};
+use crate::{engine_threading::Engines, type_system::priv_prelude::*, HasChanges};
 use sway_error::handler::Handler;
 use sway_types::Ident;
-
-#[derive(Default)]
-pub enum HasChanges {
-    Yes,
-    #[default]
-    No,
-}
-
-impl HasChanges {
-    pub fn has_changes(&self) -> bool {
-        matches!(self, HasChanges::Yes)
-    }
-}
-
-impl std::ops::BitOr for HasChanges {
-    type Output = HasChanges;
-
-    fn bitor(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (HasChanges::No, HasChanges::No) => HasChanges::No,
-            _ => HasChanges::Yes,
-        }
-    }
-}
 
 pub struct SubstTypesContext<'a> {
     pub handler: &'a Handler,
@@ -112,15 +88,4 @@ impl<T: SubstTypes> SubstTypes for Vec<T> {
         self.iter_mut()
             .fold(HasChanges::No, |has_change, x| x.subst(ctx) | has_change)
     }
-}
-
-#[macro_export]
-macro_rules! has_changes {
-    ($($stmt:expr);* ;) => {{
-        let mut has_changes = $crate::type_system::HasChanges::No;
-        $(
-            has_changes = $stmt | has_changes;
-        )*
-        has_changes
-    }};
 }


### PR DESCRIPTION
## Description

This PR is a continuation of #7659 and implements first two points of the proposed Next Steps by:
- moving `HasChanges` to a separate `has_changes` module,
- returning `HasChanges` from `ReplaceDecls`, instead of `bool`,
- returning `HasChanges` from `UpdateConstantExpression`, instead of `()`,
- returning `HasChanges` from `MaterializeConstGenerics`, instead of `()`.

This PR has a focus on refactoring and not on utilizing the information provided by returned `HasChanges`. Therefore, some implementations could be further simplified but are deliberately left as-is to be as close to straightforward refactoring as possible. E.g., `materialize_const_generics` implementations, like e.g., for `TypeId` can be simplified. Simpler implementation that also check the return value and potentially remove additional unnecessary inserts into `DeclEngine` will be done in a follow up PR.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.