### PR TITLE
Extend compiler metrics with `DeclEngine` metrics

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -51,7 +51,7 @@ use sway_core::{set_bytecode_configurables_offset, DbgGeneration, IrCli, PrintAs
 use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning};
 use sway_features::ExperimentalFeatures;
 use sway_types::{Ident, ProgramId, Span, Spanned};
-use sway_utils::{constants, time_expr, PerformanceData, PerformanceMetric};
+use sway_utils::{constants, time_expr, CompilationPhaseMetrics, PerformanceMetrics};
 use tracing::{debug, info};
 
 type GraphIx = u32;
@@ -183,7 +183,7 @@ pub struct CompiledPackage {
     pub bytecode: BuiltPackageBytecode,
     pub namespace: namespace::Package,
     pub warnings: Vec<CompileWarning>,
-    pub metrics: PerformanceData,
+    pub metrics: PerformanceMetrics,
 }
 
 /// Compiled contract dependency parts relevant to calculating a contract's ID.
@@ -1696,7 +1696,7 @@ pub fn compile(
     experimental: ExperimentalFeatures,
     dbg_generation: DbgGeneration,
 ) -> Result<CompiledPackage> {
-    let mut metrics = PerformanceData::default();
+    let mut metrics = PerformanceMetrics::default();
 
     let entry_path = pkg.manifest_file.entry_path();
     let sway_build_config = sway_build_config(
@@ -1919,10 +1919,13 @@ pub fn compile(
     }
 
     metrics.bytecode_size = compiled.bytecode.len();
+    metrics.decl_engine = engines.de().metrics();
+
     let bytecode = BuiltPackageBytecode {
         bytes: compiled.bytecode,
         entries,
     };
+
     let compiled_package = CompiledPackage {
         source_map: source_map.clone(),
         program_abi,
@@ -1933,6 +1936,7 @@ pub fn compile(
         warnings,
         metrics,
     };
+
     if sway_build_config.profile {
         report_assembly_information(&asm, &compiled_package);
     }
@@ -2511,7 +2515,7 @@ pub fn build(
 
             if let Some(outfile) = profile.metrics_outfile {
                 let path = Path::new(&outfile);
-                let metrics_json = serde_json::to_string(&compiled_without_tests.metrics)
+                let metrics_json = serde_json::to_string_pretty(&compiled_without_tests.metrics)
                     .expect("JSON serialization failed");
                 fs::write(path, metrics_json)?;
             }
@@ -2594,7 +2598,7 @@ pub fn build(
         if let Some(outfile) = profile.metrics_outfile {
             let path = Path::new(&outfile);
             let metrics_json =
-                serde_json::to_string(&compiled.metrics).expect("JSON serialization failed");
+                serde_json::to_string_pretty(&compiled.metrics).expect("JSON serialization failed");
             fs::write(path, metrics_json)?;
         }
 

--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -154,8 +154,8 @@ where
             slab,
             length: inner.items.len(),
             capacity: inner.items.capacity(),
-            slab_memory_usage: inner.items.capacity() * size_of::<Option<Arc<T>>>(),
-            slab_content_memory_usage: inner.items.len() * size_of::<T>(),
+            memory_usage: inner.items.capacity() * size_of::<Option<Arc<T>>>(),
+            content_memory_usage: (inner.items.len() - inner.free_list.len()) * size_of::<T>(),
             free_slots_length: inner.free_list.len(),
             free_slots_capacity: inner.free_list.capacity(),
         }

--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -1,5 +1,6 @@
 use parking_lot::RwLock;
 use std::{fmt, sync::Arc};
+use sway_utils::ConcurrentSlabMetrics;
 
 #[derive(Debug, Clone)]
 pub struct Inner<T> {
@@ -145,5 +146,18 @@ where
 
         inner.free_list.clear();
         inner.free_list.shrink_to(0);
+    }
+
+    pub fn metrics(&self, slab: String) -> ConcurrentSlabMetrics {
+        let inner = self.inner.read();
+        ConcurrentSlabMetrics {
+            slab,
+            length: inner.items.len(),
+            capacity: inner.items.capacity(),
+            slab_memory_usage: inner.items.capacity() * size_of::<Option<Arc<T>>>(),
+            slab_content_memory_usage: inner.items.len() * size_of::<T>(),
+            free_slots_length: inner.free_list.len(),
+            free_slots_capacity: inner.free_list.capacity(),
+        }
     }
 }

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -4,6 +4,7 @@ use std::{
     fmt::Write,
     sync::Arc,
 };
+use sway_utils::DeclEngineMetrics;
 
 use sway_types::{Named, ProgramId, SourceId, Spanned};
 
@@ -788,5 +789,27 @@ impl DeclEngine {
         }
         write!(builder, "DeclEngine {{\n{list}\n}}").unwrap();
         builder
+    }
+
+    pub fn metrics(&self) -> DeclEngineMetrics {
+        DeclEngineMetrics {
+            slabs: vec![
+                self.function_slab.metrics("function_slab".into()),
+                self.struct_slab.metrics("struct_slab".into()),
+                self.enum_slab.metrics("enum_slab".into()),
+                self.trait_slab.metrics("trait_slab".into()),
+                self.trait_fn_slab.metrics("trait_fn_slab".into()),
+                self.trait_type_slab.metrics("trait_type_slab".into()),
+                self.impl_self_or_trait_slab
+                    .metrics("impl_self_or_trait_slab".into()),
+                self.storage_slab.metrics("storage_slab".into()),
+                self.abi_slab.metrics("abi_slab".into()),
+                self.constant_slab.metrics("constant_slab".into()),
+                self.configurable_slab.metrics("configurable_slab".into()),
+                self.const_generics_slab
+                    .metrics("const_generics_slab".into()),
+                self.type_alias_slab.metrics("type_alias_slab".into()),
+            ],
+        }
     }
 }

--- a/sway-core/src/language/programs.rs
+++ b/sway-core/src/language/programs.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::{lexed::LexedProgram, parsed::ParseProgram, ty::TyProgram};
 use crate::semantic_analysis::program::TypeCheckFailed;
-use sway_utils::PerformanceData;
+use sway_utils::PerformanceMetrics;
 
 /// Contains the lexed, parsed, typed compilation stages of a program, as well
 /// as compilation metrics.
@@ -11,7 +11,7 @@ pub struct Programs {
     pub lexed: Arc<LexedProgram>,
     pub parsed: Arc<ParseProgram>,
     pub typed: Result<Arc<TyProgram>, TypeCheckFailed>,
-    pub metrics: PerformanceData,
+    pub metrics: PerformanceMetrics,
 }
 
 impl Programs {
@@ -19,7 +19,7 @@ impl Programs {
         lexed: Arc<LexedProgram>,
         parsed: Arc<ParseProgram>,
         typed: Result<Arc<TyProgram>, TypeCheckFailed>,
-        metrics: PerformanceData,
+        metrics: PerformanceMetrics,
     ) -> Programs {
         Programs {
             lexed,

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -73,7 +73,7 @@ use sway_ir::{
 use sway_types::integer_bits::IntegerBits;
 use sway_types::span::Source;
 use sway_types::{SourceEngine, SourceLocation, Span};
-use sway_utils::{time_expr, PerformanceData, PerformanceMetric};
+use sway_utils::{time_expr, CompilationPhaseMetrics, PerformanceMetrics};
 use transform::{ArgsExpectValues, Attribute, AttributeKind, Attributes, ExpectedArgs};
 use types::{CollectTypesMetadata, CollectTypesMetadataContext, LogId, TypeMetadata};
 
@@ -1342,7 +1342,7 @@ pub fn compile_to_ast(
     check_should_abort(handler, retrigger_compilation.clone())?;
 
     let query_engine = engines.qe();
-    let mut metrics = PerformanceData::default();
+    let mut metrics = PerformanceMetrics::default();
     if let Some(config) = build_config {
         let path = config.canonical_root_module();
         let include_tests = config.include_tests;

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -21,7 +21,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use sway_types::{Ident, Spanned};
-use sway_utils::PerformanceData;
+use sway_utils::PerformanceMetrics;
 use tower_lsp::jsonrpc::Result;
 use tracing::metadata::LevelFilter;
 
@@ -510,7 +510,7 @@ pub fn handle_visualize(
 }
 
 /// This method is triggered by the test suite to request the latest compilation metrics.
-pub(crate) fn metrics(state: &ServerState) -> Result<Option<Vec<(String, PerformanceData)>>> {
+pub(crate) fn metrics(state: &ServerState) -> Result<Option<Vec<(String, PerformanceMetrics)>>> {
     let mut metrics = vec![];
     for item in state.compiled_programs.iter() {
         let path = state

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -17,7 +17,7 @@ use lsp_types::{
     SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult,
     TextDocumentIdentifier, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
 };
-use sway_utils::PerformanceData;
+use sway_utils::PerformanceMetrics;
 use tower_lsp::{jsonrpc::Result, LanguageServer};
 
 #[tower_lsp::async_trait]
@@ -160,7 +160,7 @@ impl ServerState {
         request::handle_visualize(self, &params)
     }
 
-    pub async fn metrics(&self) -> Result<Option<Vec<(String, PerformanceData)>>> {
+    pub async fn metrics(&self) -> Result<Option<Vec<(String, PerformanceMetrics)>>> {
         request::metrics(self)
     }
 }

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -17,7 +17,7 @@ use sway_lsp::{
     lsp_ext::{ShowAstParams, VisualizeParams},
     server_state::ServerState,
 };
-use sway_utils::PerformanceData;
+use sway_utils::PerformanceMetrics;
 use tower::{Service, ServiceExt};
 use tower_lsp::{
     jsonrpc::{Id, Request, Response},
@@ -271,7 +271,7 @@ pub(crate) async fn visualize_request(server: &ServerState, uri: &Url, graph_kin
 
 pub(crate) async fn metrics_request(
     service: &mut LspService<ServerState>,
-) -> Vec<(String, PerformanceData)> {
+) -> Vec<(String, PerformanceMetrics)> {
     let request = Request::build("sway/metrics").id(1).finish();
     let result = call_request(service, request.clone())
         .await

--- a/sway-utils/src/performance.rs
+++ b/sway-utils/src/performance.rs
@@ -13,12 +13,12 @@ pub struct ConcurrentSlabMetrics {
     pub length: usize,
     pub capacity: usize,
     /// Approximate memory usage of the content of the slab [Vec].
-    pub slab_memory_usage: usize,
+    pub memory_usage: usize,
     /// Approximate memory usage of the total content of elements of type `T`
     /// the slab slots point to via `Arc<T>`. **This does not
     /// include any additional memory allocated by individual `T` elements,
     /// just the raw size of each `T`.**
-    pub slab_content_memory_usage: usize,
+    pub content_memory_usage: usize,
     pub free_slots_length: usize,
     pub free_slots_capacity: usize,
 }

--- a/sway-utils/src/performance.rs
+++ b/sway-utils/src/performance.rs
@@ -1,17 +1,39 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct PerformanceMetric {
+pub struct CompilationPhaseMetrics {
     pub phase: String,
     pub elapsed: f64,
     pub memory_usage: Option<u64>,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConcurrentSlabMetrics {
+    pub slab: String,
+    pub length: usize,
+    pub capacity: usize,
+    /// Approximate memory usage of the content of the slab [Vec].
+    pub slab_memory_usage: usize,
+    /// Approximate memory usage of the total content of elements of type `T`
+    /// the slab slots point to via `Arc<T>`. **This does not
+    /// include any additional memory allocated by individual `T` elements,
+    /// just the raw size of each `T`.**
+    pub slab_content_memory_usage: usize,
+    pub free_slots_length: usize,
+    pub free_slots_capacity: usize,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct PerformanceData {
+pub struct DeclEngineMetrics {
+    pub slabs: Vec<ConcurrentSlabMetrics>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PerformanceMetrics {
     pub bytecode_size: usize,
-    pub metrics: Vec<PerformanceMetric>,
     pub reused_programs: u64,
+    pub compilation_phases: Vec<CompilationPhaseMetrics>,
+    pub decl_engine: DeclEngineMetrics,
 }
 
 #[derive(serde::Serialize, Clone)]
@@ -53,7 +75,7 @@ macro_rules! time_expr {
                     #[cfg(target_os = "macos")]
                     let memory_usage = None;
 
-                    $data.metrics.push(PerformanceMetric {
+                    $data.compilation_phases.push(CompilationPhaseMetrics {
                         phase: $key.to_string(),
                         elapsed: elapsed.as_secs_f64(),
                         memory_usage,


### PR DESCRIPTION
## Description

This PR adds basic `DeclEngine` metrics to compiler metrics, available via `--metrics-outfile` `forc` CLI option. The metrics give information about slab occupancy and approximate memory usage.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.