### PR TITLE
Fix nested file search when starter path is a file

### DIFF
--- a/sway-utils/src/helpers.rs
+++ b/sway-utils/src/helpers.rs
@@ -58,7 +58,7 @@ pub fn find_nested_dir_with_file(starter_path: &Path, file_name: &str) -> Option
     } else {
         starter_path.parent()?
     };
-    WalkDir::new(starter_path).into_iter().find_map(|e| {
+    WalkDir::new(starter_dir).into_iter().find_map(|e| {
         let entry = e.ok()?;
         if entry.path() != starter_dir.join(file_name) && entry.file_name() == OsStr::new(file_name)
         {
@@ -116,4 +116,39 @@ where
                 .and_then(|parent_dir| find_parent_manifest_dir_with_check(parent_dir, check))
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs::{self, File},
+        process,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn test_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX_EPOCH")
+            .as_nanos();
+        std::env::temp_dir().join(format!("sway-utils-{name}-{}-{nanos}", process::id()))
+    }
+
+    #[test]
+    fn finds_nested_dir_when_starter_path_is_a_file() {
+        let root = test_dir("finds-nested-dir-from-file");
+        let nested_dir = root.join("nested");
+        fs::create_dir_all(&nested_dir).expect("failed to create nested dir");
+
+        let file_name = "Forc.toml";
+        let starter_file = root.join(file_name);
+        File::create(&starter_file).expect("failed to create root manifest");
+        File::create(nested_dir.join(file_name)).expect("failed to create nested manifest");
+
+        let nested = find_nested_dir_with_file(&starter_file, file_name);
+
+        fs::remove_dir_all(&root).expect("failed to remove test dir");
+        assert_eq!(nested, Some(nested_dir));
+    }
 }


### PR DESCRIPTION
## Description

This fixes `find_nested_dir_with_file` so that, when the provided starter path is a file, the `WalkDir` traversal starts from the file's parent directory.

The function already computed `starter_dir` for this case, but still passed the original `starter_path` to `WalkDir`. As a result, nested files such as `Forc.toml` could be missed when the search started from a manifest file rather than a directory.

A targeted unit test was added to cover searching from a root `Forc.toml` file while skipping that root file and finding a nested `Forc.toml`.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
