### PR TITLE
Remove cloning of parsed tree elements during type checking

### DIFF
--- a/sway-ast/src/intrinsics.rs
+++ b/sway-ast/src/intrinsics.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash, Serialize, Deserialize)]
 pub enum Intrinsic {
     IsReferenceType,
     SizeOfType,

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -420,7 +420,7 @@ impl CallPath {
     /// This function is intended to be used while typechecking the identifier declaration, i.e.,
     /// before the identifier is added to the environment.
     pub fn ident_to_fullpath(suffix: Ident, namespace: &Namespace) -> CallPath {
-        let mut res: Self = suffix.clone().into();
+        let mut res: Self = suffix.into();
         for mod_path in namespace.current_mod_path() {
             res.prefixes.push(mod_path.clone())
         }

--- a/sway-core/src/language/lazy_op.rs
+++ b/sway-core/src/language/lazy_op.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum LazyOp {
     And,
     Or,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -59,7 +59,7 @@ impl ty::TyAbiDecl {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        abi_decl: AbiDeclaration,
+        abi_decl: &AbiDeclaration,
     ) -> Result<Self, ErrorEmitted> {
         let engines = ctx.engines();
         let AbiDeclaration {
@@ -96,7 +96,7 @@ impl ty::TyAbiDecl {
                     handler,
                     ctx.by_ref(),
                     self_type_id,
-                    &supertraits,
+                    supertraits,
                     &SupertraitOf::Abi(span.clone()),
                 )?;
 
@@ -110,7 +110,7 @@ impl ty::TyAbiDecl {
                             &Handler::default(),
                             self_type_id,
                             &mod_path,
-                            &method_name.clone(),
+                            method_name,
                             ctx.type_annotation(),
                             &[],
                             None,
@@ -129,20 +129,19 @@ impl ty::TyAbiDecl {
                         }
                     };
 
-                for item in interface_surface.into_iter() {
+                for item in interface_surface.iter() {
                     let decl_name = match item {
                         TraitItem::TraitFn(decl_id) => {
-                            let method = engines.pe().get_trait_fn(&decl_id);
+                            let method = &*engines.pe().get_trait_fn(decl_id);
                             // check that a super-trait does not define a method
                             // with the same name as the current interface method
                             error_on_shadowing_superabi_method(&method.name, ctx);
-                            let method = ty::TyTraitFn::type_check(handler, ctx.by_ref(), &method)?;
+                            let method = ty::TyTraitFn::type_check(handler, ctx.by_ref(), method)?;
                             for param in &method.parameters {
                                 if param.is_reference || param.is_mutable {
                                     handler.emit_err(
                                         CompileError::RefMutableNotAllowedInContractAbi {
-                                            param_name: param.name.clone(),
-                                            span: param.name.span(),
+                                            param_name: (&param.name).into(),
                                         },
                                     );
                                 }
@@ -151,26 +150,26 @@ impl ty::TyAbiDecl {
                             let method_name = method.name.clone();
 
                             new_interface_surface.push(ty::TyTraitInterfaceItem::TraitFn(
-                                ctx.engines.de().insert(method, Some(&decl_id)),
+                                ctx.engines.de().insert(method, Some(decl_id)),
                             ));
 
                             method_name
                         }
                         TraitItem::Constant(decl_id) => {
-                            let const_decl = engines.pe().get_constant(&decl_id).as_ref().clone();
+                            let const_decl = &*engines.pe().get_constant(decl_id);
                             let const_decl =
                                 ty::TyConstantDecl::type_check(handler, ctx.by_ref(), const_decl)?;
 
                             let const_name = const_decl.call_path.suffix.clone();
 
-                            let decl_ref = ctx.engines.de().insert(const_decl, Some(&decl_id));
+                            let decl_ref = ctx.engines.de().insert(const_decl, Some(decl_id));
                             new_interface_surface
-                                .push(ty::TyTraitInterfaceItem::Constant(decl_ref.clone()));
+                                .push(ty::TyTraitInterfaceItem::Constant(decl_ref));
 
                             const_name
                         }
                         TraitItem::Type(decl_id) => {
-                            let type_decl = engines.pe().get_trait_type(&decl_id).as_ref().clone();
+                            let type_decl = &*engines.pe().get_trait_type(decl_id);
                             handler.emit_err(CompileError::AssociatedTypeNotSupportedInAbi {
                                 span: type_decl.span.clone(),
                             });
@@ -178,9 +177,8 @@ impl ty::TyAbiDecl {
                                 ty::TyTraitType::type_check(handler, ctx.by_ref(), type_decl)?;
 
                             let type_name = type_decl.name.clone();
-                            let decl_ref = ctx.engines().de().insert(type_decl, Some(&decl_id));
-                            new_interface_surface
-                                .push(ty::TyTraitInterfaceItem::Type(decl_ref.clone()));
+                            let decl_ref = ctx.engines().de().insert(type_decl, Some(decl_id));
+                            new_interface_surface.push(ty::TyTraitInterfaceItem::Type(decl_ref));
 
                             type_name
                         }
@@ -191,16 +189,15 @@ impl ty::TyAbiDecl {
 
                     if !ids.insert(decl_name.clone()) {
                         handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                            name: decl_name.clone(),
-                            span: decl_name.span(),
+                            name: decl_name.into(),
                         });
                     }
                 }
 
                 // Type check the items.
                 let mut new_items = vec![];
-                for method_id in methods.into_iter() {
-                    let method = engines.pe().get_function(&method_id);
+                for method_id in methods.iter() {
+                    let method = engines.pe().get_function(method_id);
                     let method = ty::TyFunctionDecl::type_check(
                         handler,
                         ctx.by_ref(),
@@ -214,19 +211,17 @@ impl ty::TyAbiDecl {
                     for param in method.parameters.iter() {
                         if param.is_reference || param.is_mutable {
                             handler.emit_err(CompileError::RefMutableNotAllowedInContractAbi {
-                                param_name: param.name.clone(),
-                                span: param.name.span(),
+                                param_name: (&param.name).into(),
                             });
                         }
                     }
                     if !ids.insert(method.name.clone()) {
                         handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                            name: method.name.clone(),
-                            span: method.name.span(),
+                            name: (&method.name).into(),
                         });
                     }
                     new_items.push(TyTraitItem::Fn(
-                        ctx.engines.de().insert(method, Some(&method_id)),
+                        ctx.engines.de().insert(method, Some(method_id)),
                     ));
                 }
 
@@ -235,11 +230,11 @@ impl ty::TyAbiDecl {
                 // the ABI user, only the contract methods can use supertrait methods
                 let abi_decl = ty::TyAbiDecl {
                     interface_surface: new_interface_surface,
-                    supertraits,
+                    supertraits: supertraits.clone(),
                     items: new_items,
-                    name,
-                    span,
-                    attributes,
+                    name: name.clone(),
+                    span: span.clone(),
+                    attributes: attributes.clone(),
                 };
 
                 abi_decl.forbid_const_generics(handler, engines)?;

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
@@ -196,7 +196,7 @@ where
             &handler,
             engines,
             ctx.collection_ctx,
-            Declaration::FunctionDeclaration(decl),
+            &Declaration::FunctionDeclaration(decl),
         );
         if handler.has_errors() {
             return Err(handler);
@@ -206,7 +206,7 @@ where
             TyDecl::type_check(
                 &handler,
                 &mut ctx.by_ref(),
-                parsed::Declaration::FunctionDeclaration(decl),
+                &parsed::Declaration::FunctionDeclaration(decl),
             )
         });
 
@@ -258,19 +258,15 @@ where
             return Err(handler);
         }
 
+        let decl = Declaration::ImplSelfOrTrait(decl);
         let mut ctx = self.ctx.by_ref();
-        let _r = TyDecl::collect(
-            &handler,
-            engines,
-            ctx.collection_ctx,
-            Declaration::ImplSelfOrTrait(decl),
-        );
+        let _r = TyDecl::collect(&handler, engines, ctx.collection_ctx, &decl);
         if handler.has_errors() {
             return Err(handler);
         }
 
         let r = ctx.scoped(&handler, None, |ctx| {
-            TyDecl::type_check(&handler, ctx, Declaration::ImplSelfOrTrait(decl))
+            TyDecl::type_check(&handler, ctx, &decl)
         });
 
         // Uncomment this to understand why auto impl failed for a type.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
@@ -45,7 +45,7 @@ impl ty::TyConfigurableDecl {
     pub fn type_check(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        decl: ConfigurableDeclaration,
+        decl: &ConfigurableDeclaration,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
         let engines = ctx.engines();
@@ -53,12 +53,14 @@ impl ty::TyConfigurableDecl {
         let ConfigurableDeclaration {
             name,
             span,
-            mut type_ascription,
+            type_ascription,
             value,
             attributes,
             visibility,
             block_keyword_span,
         } = decl;
+
+        let mut type_ascription = type_ascription.clone();
 
         type_ascription.type_id = ctx
             .resolve_type(
@@ -87,8 +89,8 @@ impl ty::TyConfigurableDecl {
                 .with_type_annotation(type_engine.id_of_raw_slice())
                 .with_help_text("Configurables must evaluate to slices.");
 
-            let value = value.map(|value| {
-                ty::TyExpression::type_check(handler, ctx.by_ref(), &value)
+            let value = value.as_ref().map(|value| {
+                ty::TyExpression::type_check(handler, ctx.by_ref(), value)
                     .unwrap_or_else(|err| ty::TyExpression::error(err, name.span(), engines))
             });
 
@@ -144,7 +146,7 @@ impl ty::TyConfigurableDecl {
                 ctx.by_ref(),
                 &decode_fn_decl.type_parameters,
                 decode_fn_decl.name.as_str(),
-                &span,
+                span,
             )?;
 
             let decode_fn_ref = if decode_fn_decl
@@ -173,26 +175,25 @@ impl ty::TyConfigurableDecl {
             expression's type.",
                 );
 
-            let value = value.map(|value| {
-                ty::TyExpression::type_check(handler, ctx.by_ref(), &value)
+            let value = value.as_ref().map(|value| {
+                ty::TyExpression::type_check(handler, ctx.by_ref(), value)
                     .unwrap_or_else(|err| ty::TyExpression::error(err, name.span(), engines))
             });
 
             (value, None)
         };
 
-        let mut call_path: CallPath = name.into();
-        call_path = call_path.to_fullpath(engines, ctx.namespace());
+        let call_path = CallPath::ident_to_fullpath(name.clone(), ctx.namespace());
 
         Ok(ty::TyConfigurableDecl {
             call_path,
-            attributes,
+            attributes: attributes.clone(),
             return_type: type_ascription.type_id,
             type_ascription,
-            span,
+            span: span.clone(),
             value,
             decode_fn,
-            visibility,
+            visibility: *visibility,
         })
     }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
@@ -39,7 +39,7 @@ impl ty::TyConstantDecl {
     pub fn type_check(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        decl: ConstantDeclaration,
+        decl: &ConstantDeclaration,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
         let engines = ctx.engines();
@@ -47,11 +47,13 @@ impl ty::TyConstantDecl {
         let ConstantDeclaration {
             name,
             span,
-            mut type_ascription,
+            type_ascription,
             value,
             attributes,
             visibility,
-        } = decl.clone();
+        } = decl;
+
+        let mut type_ascription = type_ascription.clone();
 
         type_ascription.type_id = ctx
             .resolve_type(
@@ -81,8 +83,8 @@ impl ty::TyConstantDecl {
         expression's type.",
             );
 
-        let value = value.map(|value| {
-            ty::TyExpression::type_check(handler, ctx.by_ref(), &value)
+        let value = value.as_ref().map(|value| {
+            ty::TyExpression::type_check(handler, ctx.by_ref(), value)
                 .unwrap_or_else(|err| ty::TyExpression::error(err, name.span(), engines))
         });
 
@@ -98,17 +100,16 @@ impl ty::TyConstantDecl {
             },
         };
 
-        let mut call_path: CallPath = name.into();
-        call_path = call_path.to_fullpath(engines, ctx.namespace());
+        let call_path = CallPath::ident_to_fullpath(name.clone(), ctx.namespace());
 
         Ok(ty::TyConstantDecl {
             call_path,
-            attributes,
+            attributes: attributes.clone(),
             return_type,
             type_ascription,
-            span,
+            span: span.clone(),
             value,
-            visibility,
+            visibility: *visibility,
         })
     }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -8,7 +8,7 @@ use sway_types::{Ident, Named, Spanned};
 use crate::{
     decl_engine::{DeclEngineGet, DeclEngineInsert, DeclRef, ReplaceFunctionImplementingType},
     language::{
-        parsed::{self, StorageEntry},
+        parsed::{self, Declaration, StorageEntry},
         ty::{
             self, FunctionDecl, TyAbiDecl, TyConfigurableDecl, TyConstantDecl, TyDecl, TyEnumDecl,
             TyFunctionDecl, TyImplSelfOrTrait, TyStorageDecl, TyStorageField, TyStructDecl,
@@ -31,50 +31,50 @@ impl TyDecl {
         handler: &Handler,
         engines: &Engines,
         ctx: &mut SymbolCollectionContext,
-        decl: parsed::Declaration,
+        decl: &Declaration,
     ) -> Result<(), ErrorEmitted> {
-        match &decl {
-            parsed::Declaration::VariableDeclaration(decl_id) => {
+        match decl {
+            Declaration::VariableDeclaration(decl_id) => {
                 TyVariableDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::ConstantDeclaration(decl_id) => {
+            Declaration::ConstantDeclaration(decl_id) => {
                 TyConstantDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::ConfigurableDeclaration(decl_id) => {
+            Declaration::ConfigurableDeclaration(decl_id) => {
                 TyConfigurableDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::TraitTypeDeclaration(decl_id) => {
+            Declaration::TraitTypeDeclaration(decl_id) => {
                 TyTraitType::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::TraitFnDeclaration(decl_id) => {
+            Declaration::TraitFnDeclaration(decl_id) => {
                 TyTraitFn::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::EnumDeclaration(decl_id) => {
+            Declaration::EnumDeclaration(decl_id) => {
                 TyEnumDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::EnumVariantDeclaration(_decl) => {}
-            parsed::Declaration::FunctionDeclaration(decl_id) => {
+            Declaration::EnumVariantDeclaration(_decl) => {}
+            Declaration::FunctionDeclaration(decl_id) => {
                 TyFunctionDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::TraitDeclaration(decl_id) => {
+            Declaration::TraitDeclaration(decl_id) => {
                 TyTraitDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::ImplSelfOrTrait(decl_id) => {
+            Declaration::ImplSelfOrTrait(decl_id) => {
                 TyImplSelfOrTrait::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::StructDeclaration(decl_id) => {
+            Declaration::StructDeclaration(decl_id) => {
                 TyStructDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::AbiDeclaration(decl_id) => {
+            Declaration::AbiDeclaration(decl_id) => {
                 TyAbiDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::StorageDeclaration(decl_id) => {
+            Declaration::StorageDeclaration(decl_id) => {
                 TyStorageDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::TypeAliasDeclaration(decl_id) => {
+            Declaration::TypeAliasDeclaration(decl_id) => {
                 TyTypeAliasDecl::collect(handler, engines, ctx, decl_id)?
             }
-            parsed::Declaration::ConstGenericDeclaration(_) => {
+            Declaration::ConstGenericDeclaration(_) => {
                 return Err(handler.emit_err(CompileError::Internal(
                     "Unexpected error on const generics",
                     decl.span(engines),
@@ -88,111 +88,103 @@ impl TyDecl {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: &mut TypeCheckContext,
-        decl: parsed::Declaration,
+        decl: &Declaration,
     ) -> Result<ty::TyDecl, ErrorEmitted> {
         let type_engine = ctx.engines.te();
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
 
         let decl = match decl {
-            parsed::Declaration::VariableDeclaration(decl_id) => {
-                let decl = engines.pe().get_variable(&decl_id).as_ref().clone();
-                let name = decl.name.clone();
-                let span = decl.name.span();
+            Declaration::VariableDeclaration(decl_id) => {
+                let decl = &*engines.pe().get_variable(decl_id);
                 let var_decl = match ty::TyVariableDecl::type_check(handler, ctx.by_ref(), decl) {
                     Ok(res) => res,
-                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(decl.name.span(), err)),
                 };
                 let typed_var_decl = ty::TyDecl::VariableDecl(Box::new(var_decl));
-                ctx.insert_symbol(handler, name, typed_var_decl.clone())?;
+                ctx.insert_symbol(handler, decl.name.clone(), typed_var_decl.clone())?;
                 typed_var_decl
             }
-            parsed::Declaration::ConstantDeclaration(decl_id) => {
-                let decl = engines.pe().get_constant(&decl_id).as_ref().clone();
-                let span = decl.span.clone();
+            Declaration::ConstantDeclaration(decl_id) => {
+                let decl = &*engines.pe().get_constant(decl_id);
                 let const_decl = match ty::TyConstantDecl::type_check(handler, ctx.by_ref(), decl) {
                     Ok(res) => res,
-                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(decl.span.clone(), err)),
                 };
                 let name = const_decl.name().clone();
                 let typed_const_decl: ty::TyDecl =
-                    decl_engine.insert(const_decl, Some(&decl_id)).into();
+                    decl_engine.insert(const_decl, Some(decl_id)).into();
                 ctx.insert_symbol(handler, name, typed_const_decl.clone())?;
                 typed_const_decl
             }
-            parsed::Declaration::ConfigurableDeclaration(decl_id) => {
-                let decl = engines.pe().get_configurable(&decl_id).as_ref().clone();
-                let span = decl.span.clone();
-                let name = decl.name.clone();
+            Declaration::ConfigurableDeclaration(decl_id) => {
+                let decl = &*engines.pe().get_configurable(decl_id);
                 let typed_const_decl =
                     match ty::TyConfigurableDecl::type_check(handler, ctx.by_ref(), decl) {
                         Ok(config_decl) => {
                             config_decl.forbid_const_generics(handler, engines)?;
-                            ty::TyDecl::from(decl_engine.insert(config_decl, Some(&decl_id)))
+                            ty::TyDecl::from(decl_engine.insert(config_decl, Some(decl_id)))
                         }
-                        Err(err) => ty::TyDecl::ErrorRecovery(span, err),
+                        Err(err) => ty::TyDecl::ErrorRecovery(decl.span.clone(), err),
                     };
-                ctx.insert_symbol(handler, name, typed_const_decl.clone())?;
+                ctx.insert_symbol(handler, decl.name.clone(), typed_const_decl.clone())?;
                 typed_const_decl
             }
-            parsed::Declaration::TraitTypeDeclaration(decl_id) => {
-                let decl = engines.pe().get_trait_type(&decl_id).as_ref().clone();
-                let span = decl.span.clone();
+            Declaration::TraitTypeDeclaration(decl_id) => {
+                let decl = &*engines.pe().get_trait_type(decl_id);
                 let type_decl = match ty::TyTraitType::type_check(handler, ctx.by_ref(), decl) {
                     Ok(res) => res,
-                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(decl.span.clone(), err)),
                 };
                 let name = type_decl.name().clone();
                 let typed_type_decl: ty::TyDecl =
-                    decl_engine.insert(type_decl, Some(&decl_id)).into();
+                    decl_engine.insert(type_decl, Some(decl_id)).into();
                 ctx.insert_symbol(handler, name, typed_type_decl.clone())?;
                 typed_type_decl
             }
-            parsed::Declaration::EnumDeclaration(decl_id) => {
-                let decl = engines.pe().get_enum(&decl_id).as_ref().clone();
-                let span = decl.span.clone();
+            Declaration::EnumDeclaration(decl_id) => {
+                let decl = &*engines.pe().get_enum(decl_id);
                 let enum_decl = match ty::TyEnumDecl::type_check(handler, ctx.by_ref(), decl) {
                     Ok(res) => res,
-                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(decl.span.clone(), err)),
                 };
                 let name = enum_decl.call_path.suffix.clone();
                 let typed_enum_decl: ty::TyDecl =
-                    decl_engine.insert(enum_decl, Some(&decl_id)).into();
+                    decl_engine.insert(enum_decl, Some(decl_id)).into();
                 ctx.insert_symbol(handler, name, typed_enum_decl.clone())?;
                 typed_enum_decl
             }
-            parsed::Declaration::EnumVariantDeclaration(_decl) => {
+            Declaration::EnumVariantDeclaration(_decl) => {
                 unreachable!("Type-checked above as part of the containing enum.")
             }
-            parsed::Declaration::FunctionDeclaration(decl_id) => {
-                let fn_decl = engines.pe().get_function(&decl_id);
-                let span = fn_decl.span.clone();
-
+            Declaration::FunctionDeclaration(decl_id) => {
+                let fn_decl = &*engines.pe().get_function(decl_id);
                 let mut ctx = ctx.by_ref().with_type_annotation(type_engine.new_unknown());
                 let fn_decl = match ty::TyFunctionDecl::type_check(
                     handler,
                     ctx.by_ref(),
-                    &fn_decl,
+                    fn_decl,
                     false,
                     false,
                     None,
                 ) {
                     Ok(res) => res,
-                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(fn_decl.span.clone(), err)),
                 };
 
                 let name = fn_decl.name.clone();
-                let decl: ty::TyDecl = decl_engine.insert(fn_decl, Some(&decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(fn_decl, Some(decl_id)).into();
                 let _ = ctx.insert_symbol(handler, name, decl.clone());
                 decl
             }
-            parsed::Declaration::TraitDeclaration(decl_id) => {
-                let trait_decl = engines.pe().get_trait(&decl_id).as_ref().clone();
-                let span = trait_decl.span.clone();
+            Declaration::TraitDeclaration(decl_id) => {
+                let trait_decl = &*engines.pe().get_trait(decl_id);
                 let mut trait_decl =
                     match ty::TyTraitDecl::type_check(handler, ctx.by_ref(), trait_decl) {
                         Ok(res) => res,
-                        Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                        Err(err) => {
+                            return Ok(ty::TyDecl::ErrorRecovery(trait_decl.span.clone(), err))
+                        }
                     };
                 let name = trait_decl.name.clone();
 
@@ -205,18 +197,17 @@ impl TyDecl {
                                     decl_id: supertrait_decl_id,
                                 }) = supertrait_decl
                                 {
+                                    let supertrait_decl = engines.de().get(&supertrait_decl_id);
                                     supertrait.decl_ref = Some(DeclRef::new(
-                                        engines.de().get(&supertrait_decl_id).name.clone(),
+                                        supertrait_decl.name.clone(),
                                         supertrait_decl_id,
-                                        engines.de().get(&supertrait_decl_id).span.clone(),
+                                        supertrait_decl.span.clone(),
                                     ));
                                 }
                             });
                 }
 
-                let decl: ty::TyDecl = decl_engine
-                    .insert(trait_decl.clone(), Some(&decl_id))
-                    .into();
+                let decl: ty::TyDecl = decl_engine.insert(trait_decl.clone(), Some(decl_id)).into();
 
                 trait_decl
                     .items
@@ -226,22 +217,22 @@ impl TyDecl {
                 ctx.insert_symbol(handler, name, decl.clone())?;
                 decl
             }
-            parsed::Declaration::ImplSelfOrTrait(decl_id) => {
-                let impl_self_or_trait = engines
-                    .pe()
-                    .get_impl_self_or_trait(&decl_id)
-                    .as_ref()
-                    .clone();
-                let span = impl_self_or_trait.block_span.clone();
+            Declaration::ImplSelfOrTrait(decl_id) => {
+                let impl_self_or_trait = &*engines.pe().get_impl_self_or_trait(decl_id);
                 let mut impl_trait = if impl_self_or_trait.is_self {
                     let impl_trait_decl = match ty::TyImplSelfOrTrait::type_check_impl_self(
                         handler,
                         ctx.by_ref(),
-                        &decl_id,
+                        decl_id,
                         impl_self_or_trait,
                     ) {
                         Ok(val) => val,
-                        Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                        Err(err) => {
+                            return Ok(ty::TyDecl::ErrorRecovery(
+                                impl_self_or_trait.block_span.clone(),
+                                err,
+                            ))
+                        }
                     };
 
                     let impl_trait =
@@ -275,7 +266,12 @@ impl TyDecl {
                         impl_self_or_trait,
                     ) {
                         Ok(res) => res,
-                        Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                        Err(err) => {
+                            return Ok(ty::TyDecl::ErrorRecovery(
+                                impl_self_or_trait.block_span.clone(),
+                                err,
+                            ))
+                        }
                     }
                 };
 
@@ -335,37 +331,34 @@ impl TyDecl {
                     IsExtendingExistingImpl::No,
                     IsImplInterfaceSurface::No,
                 )?;
-                let impl_trait_decl: ty::TyDecl = decl_engine
-                    .insert(impl_trait.clone(), Some(&decl_id))
-                    .into();
+                let impl_trait_decl: ty::TyDecl =
+                    decl_engine.insert(impl_trait.clone(), Some(decl_id)).into();
                 impl_trait.items.iter_mut().for_each(|item| {
                     item.replace_implementing_type(engines, impl_trait_decl.clone());
                 });
                 impl_trait_decl
             }
-            parsed::Declaration::StructDeclaration(decl_id) => {
-                let decl = engines.pe().get_struct(&decl_id).as_ref().clone();
-                let span = decl.span.clone();
+            Declaration::StructDeclaration(decl_id) => {
+                let decl = &*engines.pe().get_struct(decl_id);
                 let decl: ty::TyStructDecl =
                     match ty::TyStructDecl::type_check(handler, ctx.by_ref(), decl) {
                         Ok(res) => res,
                         Err(err) => {
-                            return Ok(ty::TyDecl::ErrorRecovery(span, err));
+                            return Ok(ty::TyDecl::ErrorRecovery(decl.span.clone(), err));
                         }
                     };
                 let name = decl.call_path.suffix.clone();
-                let decl: ty::TyDecl = decl_engine.insert(decl, Some(&decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(decl, Some(decl_id)).into();
                 ctx.insert_symbol(handler, name, decl.clone())?;
                 decl
             }
-            parsed::Declaration::AbiDeclaration(decl_id) => {
-                let abi_decl = engines.pe().get_abi(&decl_id).as_ref().clone();
-                let span = abi_decl.span.clone();
+            Declaration::AbiDeclaration(decl_id) => {
+                let abi_decl = &*engines.pe().get_abi(decl_id);
                 let mut abi_decl = match ty::TyAbiDecl::type_check(handler, ctx.by_ref(), abi_decl)
                 {
                     Ok(res) => res,
                     Err(err) => {
-                        return Ok(ty::TyDecl::ErrorRecovery(span, err));
+                        return Ok(ty::TyDecl::ErrorRecovery(abi_decl.span.clone(), err));
                     }
                 };
                 let name = abi_decl.name.clone();
@@ -379,16 +372,17 @@ impl TyDecl {
                                     decl_id: supertrait_decl_id,
                                 }) = supertrait_decl
                                 {
+                                    let supertrait_decl = engines.de().get(&supertrait_decl_id);
                                     supertrait.decl_ref = Some(DeclRef::new(
-                                        engines.de().get(&supertrait_decl_id).name.clone(),
+                                        supertrait_decl.name.clone(),
                                         supertrait_decl_id,
-                                        engines.de().get(&supertrait_decl_id).span.clone(),
+                                        supertrait_decl.span.clone(),
                                     ));
                                 }
                             });
                 }
 
-                let decl: ty::TyDecl = decl_engine.insert(abi_decl.clone(), Some(&decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(abi_decl.clone(), Some(decl_id)).into();
                 abi_decl
                     .items
                     .iter_mut()
@@ -396,33 +390,27 @@ impl TyDecl {
                 ctx.insert_symbol(handler, name, decl.clone())?;
                 decl
             }
-            parsed::Declaration::StorageDeclaration(decl_id) => {
-                let parsed::StorageDeclaration {
-                    span,
-                    entries,
-                    attributes,
-                    storage_keyword,
-                } = engines.pe().get_storage(&decl_id).as_ref().clone();
-                let mut fields_buf = vec![];
+            Declaration::StorageDeclaration(decl_id) => {
                 fn type_check_storage_entries(
                     handler: &Handler,
                     mut ctx: TypeCheckContext,
-                    entries: Vec<StorageEntry>,
+                    entries: &[StorageEntry],
                     fields_buf: &mut Vec<TyStorageField>,
-                    namespace_names: Vec<Ident>,
+                    namespace_names: &[Ident],
                 ) -> Result<(), ErrorEmitted> {
                     let engines = ctx.engines;
-                    for entry in entries {
+                    for entry in entries.iter() {
                         if let StorageEntry::Field(parsed::StorageField {
                             name,
                             key_expression,
                             initializer,
-                            mut type_argument,
+                            type_argument,
                             attributes,
                             span: field_span,
                             ..
                         }) = entry
                         {
+                            let mut type_argument = type_argument.clone();
                             type_argument.type_id = ctx.by_ref().resolve_type(
                                 handler,
                                 type_argument.type_id,
@@ -436,7 +424,7 @@ impl TyDecl {
                                 .with_type_annotation(type_argument.type_id)
                                 .with_storage_declaration();
                             let initializer =
-                                ty::TyExpression::type_check(handler, ctx.by_ref(), &initializer)?;
+                                ty::TyExpression::type_check(handler, ctx.by_ref(), initializer)?;
 
                             let key_expression = match key_expression {
                                 Some(key_expression) => {
@@ -451,7 +439,7 @@ impl TyDecl {
                                         ty::TyExpression::type_check(
                                             handler,
                                             key_ctx,
-                                            &key_expression,
+                                            key_expression,
                                         )
                                     })?;
 
@@ -461,27 +449,27 @@ impl TyDecl {
                             };
 
                             fields_buf.push(ty::TyStorageField {
-                                name,
-                                namespace_names: namespace_names.clone(),
+                                name: name.clone(),
+                                namespace_names: namespace_names.to_vec(),
                                 key_expression,
                                 type_argument,
                                 initializer,
-                                span: field_span,
-                                attributes,
+                                span: field_span.clone(),
+                                attributes: attributes.clone(),
                             });
                         } else if let StorageEntry::Namespace(namespace) = entry {
-                            let mut new_namespace_names = namespace_names.clone();
-                            new_namespace_names.push(namespace.name);
+                            let mut new_namespace_names = namespace_names.to_vec();
+                            new_namespace_names.push(namespace.name.clone());
                             type_check_storage_entries(
                                 handler,
                                 ctx.by_ref(),
-                                namespace
+                                &namespace
                                     .entries
                                     .iter()
                                     .map(|e| (**e).clone())
                                     .collect::<Vec<_>>(),
                                 fields_buf,
-                                new_namespace_names,
+                                &new_namespace_names,
                             )?;
                         }
                     }
@@ -489,22 +477,25 @@ impl TyDecl {
                     Ok(())
                 }
 
-                type_check_storage_entries(
-                    handler,
-                    ctx.by_ref(),
+                let parsed::StorageDeclaration {
+                    span,
                     entries,
-                    &mut fields_buf,
-                    vec![],
-                )?;
+                    attributes,
+                    storage_keyword,
+                } = &*engines.pe().get_storage(decl_id);
+
+                let mut fields_buf = vec![];
+
+                type_check_storage_entries(handler, ctx.by_ref(), entries, &mut fields_buf, &[])?;
 
                 let decl = ty::TyStorageDecl {
                     fields: fields_buf,
-                    span,
-                    attributes,
-                    storage_keyword,
+                    span: span.clone(),
+                    attributes: attributes.clone(),
+                    storage_keyword: storage_keyword.clone(),
                 };
 
-                let decl_ref = decl_engine.insert(decl, Some(&decl_id));
+                let decl_ref = decl_engine.insert(decl, Some(decl_id));
 
                 // insert the storage declaration into the symbols
                 // if there already was one, return an error that duplicate storage
@@ -518,8 +509,8 @@ impl TyDecl {
 
                 decl_ref.into()
             }
-            parsed::Declaration::TypeAliasDeclaration(decl_id) => {
-                let decl = engines.pe().get_type_alias(&decl_id);
+            Declaration::TypeAliasDeclaration(decl_id) => {
+                let decl = engines.pe().get_type_alias(decl_id);
                 let span = decl.name.span();
                 let name = decl.name.clone();
                 let ty = &decl.ty;
@@ -544,15 +535,15 @@ impl TyDecl {
                     span,
                 };
 
-                let decl: ty::TyDecl = decl_engine.insert(decl, Some(&decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(decl, Some(decl_id)).into();
 
                 ctx.insert_symbol(handler, name, decl.clone())?;
                 decl
             }
-            parsed::Declaration::TraitFnDeclaration(_decl_id) => {
+            Declaration::TraitFnDeclaration(_decl_id) => {
                 unreachable!();
             }
-            parsed::Declaration::ConstGenericDeclaration(_) => {
+            Declaration::ConstGenericDeclaration(_) => {
                 unreachable!("ConstGenericDecl is not reachable from AstNode")
             }
         };

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -31,7 +31,7 @@ impl ty::TyEnumDecl {
     pub fn type_check(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        decl: EnumDeclaration,
+        decl: &EnumDeclaration,
     ) -> Result<Self, ErrorEmitted> {
         let EnumDeclaration {
             name,
@@ -57,24 +57,24 @@ impl ty::TyEnumDecl {
             let mut variants_buf = vec![];
             for variant in variants {
                 variants_buf.push(
-                    match ty::TyEnumVariant::type_check(handler, ctx.by_ref(), variant.clone()) {
+                    match ty::TyEnumVariant::type_check(handler, ctx.by_ref(), variant) {
                         Ok(res) => res,
                         Err(_) => continue,
                     },
                 );
             }
 
-            let call_path = CallPath::ident_to_fullpath(name, ctx.namespace());
+            let call_path = CallPath::ident_to_fullpath(name.clone(), ctx.namespace());
 
-            // create the enum decl
             let decl = ty::TyEnumDecl {
                 call_path,
                 generic_parameters: new_type_parameters,
                 variants: variants_buf,
-                span,
-                attributes,
-                visibility,
+                span: span.clone(),
+                attributes: attributes.clone(),
+                visibility: *visibility,
             };
+
             Ok(decl)
         })
     }
@@ -84,10 +84,10 @@ impl ty::TyEnumVariant {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        variant: EnumVariant,
+        variant: &EnumVariant,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
-        let mut type_argument = variant.type_argument;
+        let mut type_argument = variant.type_argument.clone();
         type_argument.type_id = ctx
             .resolve_type(
                 handler,
@@ -101,8 +101,8 @@ impl ty::TyEnumVariant {
             name: variant.name.clone(),
             type_argument,
             tag: variant.tag,
-            span: variant.span,
-            attributes: variant.attributes,
+            span: variant.span.clone(),
+            attributes: variant.attributes.clone(),
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -129,7 +129,7 @@ impl ty::TyFunctionDecl {
                 let new_type_parameters = GenericTypeParameter::type_check_type_params(
                     handler,
                     ctx.by_ref(),
-                    type_parameters.clone(),
+                    type_parameters,
                     None,
                 )?;
 
@@ -188,7 +188,7 @@ impl ty::TyFunctionDecl {
                             let param = match ty::TyFunctionParameter::type_check(
                                 handler,
                                 ctx.by_ref(),
-                                parameter.clone(),
+                                parameter,
                             ) {
                                 Ok(val) => val,
                                 Err(_) => continue,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -14,7 +14,7 @@ impl ty::TyFunctionParameter {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        parameter: FunctionParameter,
+        parameter: &FunctionParameter,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
 
@@ -23,8 +23,10 @@ impl ty::TyFunctionParameter {
             is_reference,
             is_mutable,
             mutability_span,
-            mut type_argument,
+            type_argument,
         } = parameter;
+
+        let mut type_argument = type_argument.clone();
 
         type_argument.type_id = ctx
             .resolve_type(
@@ -43,7 +45,7 @@ impl ty::TyFunctionParameter {
             None,
         )?;
 
-        let mutability = ty::VariableMutability::new_from_ref_mut(is_reference, is_mutable);
+        let mutability = ty::VariableMutability::new_from_ref_mut(*is_reference, *is_mutable);
         if mutability == ty::VariableMutability::Mutable {
             return Err(
                 handler.emit_err(CompileError::MutableParameterNotSupported {
@@ -54,10 +56,10 @@ impl ty::TyFunctionParameter {
         }
 
         let typed_parameter = ty::TyFunctionParameter {
-            name,
-            is_reference,
-            is_mutable,
-            mutability_span,
+            name: name.clone(),
+            is_reference: *is_reference,
+            is_mutable: *is_mutable,
+            mutability_span: mutability_span.clone(),
             type_argument,
         };
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -95,7 +95,7 @@ impl TyImplSelfOrTrait {
     pub(crate) fn type_check_impl_trait(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        impl_trait: ImplSelfOrTrait,
+        impl_trait: &ImplSelfOrTrait,
     ) -> Result<Self, ErrorEmitted> {
         // If the impl trait represents an attempt to explicit implement a marker trait
         // we will emit an error, but do not want to bail out. We still want to check
@@ -133,9 +133,9 @@ impl TyImplSelfOrTrait {
         let ImplSelfOrTrait {
             impl_type_parameters,
             trait_name,
-            mut trait_type_arguments,
+            trait_type_arguments,
             trait_decl_ref: _,
-            mut implementing_for,
+            implementing_for,
             items,
             block_span,
             ..
@@ -144,6 +144,9 @@ impl TyImplSelfOrTrait {
         let type_engine = ctx.engines.te();
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
+
+        let mut trait_type_arguments = trait_type_arguments.clone();
+        let mut implementing_for = implementing_for.clone();
 
         // Create a new type parameter for the Self type.
         // For the `use_site_span` of the self type parameter we take the `block_span`.
@@ -195,7 +198,7 @@ impl TyImplSelfOrTrait {
                     handler,
                     ctx.by_ref(),
                     impl_type_parameters,
-                    Some(self_type_param),
+                    Some(&self_type_param),
                 )?;
 
                 // resolve the types of the trait type arguments
@@ -258,7 +261,7 @@ impl TyImplSelfOrTrait {
                     .with_type_annotation(type_engine.new_unknown())
                     .with_self_type(Some(implementing_for.type_id));
 
-                let impl_trait = match ctx.resolve_call_path(handler, &trait_name).ok() {
+                let impl_trait = match ctx.resolve_call_path(handler, trait_name).ok() {
                     Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
                         let mut trait_decl = (*decl_engine.get_trait(&decl_id)).clone();
 
@@ -288,7 +291,7 @@ impl TyImplSelfOrTrait {
                         trait_decl.insert_interface_surface_and_items_into_namespace(
                             handler,
                             ctx.by_ref(),
-                            &trait_name,
+                            trait_name,
                             &trait_type_arguments,
                             implementing_for.type_id,
                         );
@@ -303,10 +306,10 @@ impl TyImplSelfOrTrait {
                             &trait_decl.supertraits,
                             &trait_decl.interface_surface,
                             &trait_decl.items,
-                            &items,
-                            &trait_name,
+                            items,
+                            trait_name,
                             &trait_decl.span(),
-                            &block_span,
+                            block_span,
                             false,
                         )?;
                         ty::TyImplSelfOrTrait {
@@ -318,7 +321,7 @@ impl TyImplSelfOrTrait {
                                 decl_id.into(),
                                 trait_decl.span.clone(),
                             )),
-                            span: block_span,
+                            span: block_span.clone(),
                             items: new_items,
                             supertrait_items,
                             implementing_for,
@@ -381,10 +384,10 @@ impl TyImplSelfOrTrait {
                             &abi.supertraits,
                             &abi.interface_surface,
                             &abi.items,
-                            &items,
-                            &trait_name,
+                            items,
+                            trait_name,
                             &abi.span(),
-                            &block_span,
+                            block_span,
                             true,
                         )?;
 
@@ -397,14 +400,14 @@ impl TyImplSelfOrTrait {
 
                         ty::TyImplSelfOrTrait {
                             impl_type_parameters: vec![], // this is empty because abi definitions don't support generics
-                            trait_name,
+                            trait_name: trait_name.clone(),
                             trait_type_arguments: vec![], // this is empty because abi definitions don't support generics
                             trait_decl_ref: Some(DeclRef::new(
                                 abi.name.clone(),
                                 decl_id.into(),
                                 abi.span.clone(),
                             )),
-                            span: block_span,
+                            span: block_span.clone(),
                             items: new_items,
                             supertrait_items,
                             implementing_for,
@@ -431,11 +434,11 @@ impl TyImplSelfOrTrait {
         handler: &Handler,
         ctx: TypeCheckContext,
         parsed_decl_id: &ParsedDeclId<ImplSelfOrTrait>,
-        impl_self: ImplSelfOrTrait,
+        impl_self: &ImplSelfOrTrait,
     ) -> Result<ty::TyDecl, ErrorEmitted> {
         let ImplSelfOrTrait {
             impl_type_parameters,
-            mut implementing_for,
+            implementing_for,
             items,
             block_span,
             ..
@@ -444,6 +447,8 @@ impl TyImplSelfOrTrait {
         let type_engine = ctx.engines.te();
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
+
+        let mut implementing_for = implementing_for.clone();
 
         // create the namespace for the impl
         ctx.with_const_shadowing_mode(ConstShadowingMode::ItemStyle)
@@ -500,7 +505,7 @@ impl TyImplSelfOrTrait {
                     handler,
                     ctx.by_ref(),
                     impl_type_parameters,
-                    Some(self_type_param),
+                    Some(&self_type_param),
                 )?;
 
                 // type check the type that we are implementing for
@@ -633,8 +638,7 @@ impl TyImplSelfOrTrait {
                                     .push(TyImplItem::Fn(decl_engine.insert(fn_decl, Some(id))));
                             }
                             ImplItem::Constant(decl_id) => {
-                                let const_decl =
-                                    engines.pe().get_constant(decl_id).as_ref().clone();
+                                let const_decl = &*engines.pe().get_constant(decl_id);
                                 let const_decl = match ty::TyConstantDecl::type_check(
                                     handler,
                                     ctx.by_ref(),
@@ -644,7 +648,6 @@ impl TyImplSelfOrTrait {
                                     Err(_) => continue,
                                 };
                                 let decl_ref = decl_engine.insert(const_decl, Some(decl_id));
-                                new_items.push(TyImplItem::Constant(decl_ref.clone()));
 
                                 ctx.insert_symbol(
                                     handler,
@@ -653,20 +656,21 @@ impl TyImplSelfOrTrait {
                                         decl_id: *decl_ref.id(),
                                     }),
                                 )?;
+
+                                new_items.push(TyImplItem::Constant(decl_ref));
                             }
                             ImplItem::Type(decl_id) => {
-                                let type_decl =
-                                    engines.pe().get_trait_type(decl_id).as_ref().clone();
+                                let type_decl = &*engines.pe().get_trait_type(decl_id);
                                 let type_decl = match ty::TyTraitType::type_check(
                                     handler,
                                     ctx.by_ref(),
-                                    type_decl.clone(),
+                                    type_decl,
                                 ) {
                                     Ok(res) => res,
                                     Err(_) => continue,
                                 };
                                 let decl_ref = decl_engine.insert(type_decl, Some(decl_id));
-                                new_items.push(TyImplItem::Type(decl_ref.clone()));
+                                new_items.push(TyImplItem::Type(decl_ref));
                             }
                         }
                     }
@@ -676,7 +680,7 @@ impl TyImplSelfOrTrait {
                         trait_name,
                         trait_type_arguments: vec![], // this is empty because impl self's don't support generics on the "Self" trait,
                         trait_decl_ref: None,
-                        span: block_span,
+                        span: block_span.clone(),
                         items: new_items,
                         supertrait_items: vec![],
                         implementing_for,
@@ -1709,7 +1713,7 @@ fn type_check_const_decl(
     };
 
     // type check the constant declaration
-    let mut const_decl = ty::TyConstantDecl::type_check(handler, ctx.by_ref(), const_decl.clone())?;
+    let mut const_decl = ty::TyConstantDecl::type_check(handler, ctx.by_ref(), const_decl)?;
 
     let const_name = const_decl.call_path.suffix.clone();
 
@@ -1806,7 +1810,7 @@ fn type_check_type_decl(
     };
 
     // type check the type declaration
-    let type_decl = ty::TyTraitType::type_check(handler, ctx.by_ref(), type_decl.clone())?;
+    let type_decl = ty::TyTraitType::type_check(handler, ctx.by_ref(), type_decl)?;
 
     let type_name = type_decl.name.clone();
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -36,7 +36,7 @@ impl ty::TyStructDecl {
     pub(crate) fn type_check(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        decl: StructDeclaration,
+        decl: &StructDeclaration,
     ) -> Result<Self, ErrorEmitted> {
         let StructDeclaration {
             name,
@@ -61,7 +61,7 @@ impl ty::TyStructDecl {
             // type check the fields
             let mut new_fields = vec![];
             let mut encountered_non_indexed_field = false;
-            for field in fields.into_iter() {
+            for field in fields.iter() {
                 let ty_field = ty::TyStructField::type_check(handler, ctx.by_ref(), field)?;
                 if ty_field.attributes.indexed().is_some() && attributes.event().is_none() {
                     return Err(
@@ -99,16 +99,16 @@ impl ty::TyStructDecl {
                 new_fields.push(ty_field);
             }
 
-            let path = CallPath::ident_to_fullpath(name, ctx.namespace());
+            let path = CallPath::ident_to_fullpath(name.clone(), ctx.namespace());
 
             // create the struct decl
             let decl = ty::TyStructDecl {
                 call_path: path,
                 generic_parameters: new_type_parameters,
                 fields: new_fields,
-                visibility,
-                span,
-                attributes,
+                visibility: *visibility,
+                span: span.clone(),
+                attributes: attributes.clone(),
             };
 
             Ok(decl)
@@ -120,11 +120,11 @@ impl ty::TyStructField {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        field: StructField,
+        field: &StructField,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
 
-        let mut type_argument = field.type_argument;
+        let mut type_argument = field.type_argument.clone();
         type_argument.type_id = ctx
             .resolve_type(
                 handler,
@@ -136,10 +136,10 @@ impl ty::TyStructField {
             .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
         let field = ty::TyStructField {
             visibility: field.visibility,
-            name: field.name,
-            span: field.span,
+            name: field.name.clone(),
+            span: field.span.clone(),
             type_argument,
-            attributes: field.attributes,
+            attributes: field.attributes.clone(),
         };
         Ok(field)
     }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -74,7 +74,7 @@ impl TyTraitDecl {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        trait_decl: TraitDeclaration,
+        trait_decl: &TraitDeclaration,
     ) -> Result<Self, ErrorEmitted> {
         let TraitDeclaration {
             name,
@@ -111,7 +111,7 @@ impl TyTraitDecl {
                     handler,
                     ctx.by_ref(),
                     type_parameters,
-                    Some(self_type_param.clone()),
+                    Some(&self_type_param),
                 )?;
 
                 // Recursively make the interface surfaces and methods of the
@@ -120,7 +120,7 @@ impl TyTraitDecl {
                     handler,
                     ctx.by_ref(),
                     self_type,
-                    &supertraits,
+                    supertraits,
                     &SupertraitOf::Trait,
                 )?;
 
@@ -135,7 +135,7 @@ impl TyTraitDecl {
                         TraitItem::TraitFn(_) => None,
                         TraitItem::Constant(_) => None,
                         TraitItem::Type(decl_id) => {
-                            let type_decl = engines.pe().get_trait_type(&decl_id).as_ref().clone();
+                            let type_decl = &*engines.pe().get_trait_type(&decl_id);
                             let type_decl =
                                 ty::TyTraitType::type_check(handler, ctx.by_ref(), type_decl)?;
 
@@ -153,8 +153,7 @@ impl TyTraitDecl {
                     if let Some(decl_name) = decl_name {
                         if !ids.insert(decl_name.clone()) {
                             handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                                name: decl_name.clone(),
-                                span: decl_name.span(),
+                                name: decl_name.into(),
                             });
                         }
                     }
@@ -169,7 +168,7 @@ impl TyTraitDecl {
                     self_type,
                     vec![],
                     &dummy_interface_surface,
-                    &span,
+                    span,
                     None,
                     IsImplSelf::No,
                     IsExtendingExistingImpl::No,
@@ -177,12 +176,12 @@ impl TyTraitDecl {
                 )?;
                 let mut dummy_interface_surface = vec![];
 
-                for item in interface_surface.into_iter() {
+                for item in interface_surface.iter() {
                     let decl_name = match item {
                         TraitItem::TraitFn(decl_id) => {
-                            let method = engines.pe().get_trait_fn(&decl_id);
+                            let method = engines.pe().get_trait_fn(decl_id);
                             let method = ty::TyTraitFn::type_check(handler, ctx.by_ref(), &method)?;
-                            let decl_ref = decl_engine.insert(method.clone(), Some(&decl_id));
+                            let decl_ref = decl_engine.insert(method.clone(), Some(decl_id));
                             dummy_interface_surface.push(ty::TyImplItem::Fn(
                                 decl_engine
                                     .insert(
@@ -195,11 +194,11 @@ impl TyTraitDecl {
                             Some(method.name.clone())
                         }
                         TraitItem::Constant(decl_id) => {
-                            let const_decl = engines.pe().get_constant(&decl_id).as_ref().clone();
+                            let const_decl = &*engines.pe().get_constant(decl_id);
                             let const_decl =
                                 ty::TyConstantDecl::type_check(handler, ctx.by_ref(), const_decl)?;
                             let decl_ref =
-                                ctx.engines.de().insert(const_decl.clone(), Some(&decl_id));
+                                ctx.engines.de().insert(const_decl.clone(), Some(decl_id));
                             new_interface_surface
                                 .push(ty::TyTraitInterfaceItem::Constant(decl_ref.clone()));
 
@@ -223,8 +222,7 @@ impl TyTraitDecl {
                     if let Some(decl_name) = decl_name {
                         if !ids.insert(decl_name.clone()) {
                             handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                                name: decl_name.clone(),
-                                span: decl_name.span(),
+                                name: decl_name.into(),
                             });
                         }
                     }
@@ -239,7 +237,7 @@ impl TyTraitDecl {
                     self_type,
                     vec![],
                     &dummy_interface_surface,
-                    &span,
+                    span,
                     None,
                     IsImplSelf::No,
                     IsExtendingExistingImpl::Yes,
@@ -248,8 +246,8 @@ impl TyTraitDecl {
 
                 // Type check the items.
                 let mut new_items = vec![];
-                for method_decl_id in methods.into_iter() {
-                    let method = engines.pe().get_function(&method_decl_id);
+                for method_decl_id in methods.iter() {
+                    let method = engines.pe().get_function(method_decl_id);
                     let method = ty::TyFunctionDecl::type_check(
                         handler,
                         ctx.by_ref(),
@@ -260,7 +258,7 @@ impl TyTraitDecl {
                     )
                     .unwrap_or_else(|_| ty::TyFunctionDecl::error(&method));
                     new_items.push(ty::TyTraitItem::Fn(
-                        decl_engine.insert(method, Some(&method_decl_id)),
+                        decl_engine.insert(method, Some(method_decl_id)),
                     ));
                 }
 
@@ -270,11 +268,12 @@ impl TyTraitDecl {
                     self_type: TypeParameter::Type(self_type_param),
                     interface_surface: new_interface_surface,
                     items: new_items,
-                    supertraits,
-                    visibility,
-                    attributes,
-                    call_path: CallPath::from(name).to_fullpath(ctx.engines(), ctx.namespace()),
-                    span,
+                    supertraits: supertraits.clone(),
+                    visibility: *visibility,
+                    attributes: attributes.clone(),
+                    call_path: CallPath::from(name.clone())
+                        .to_fullpath(ctx.engines(), ctx.namespace()),
+                    span: span.clone(),
                 };
                 Ok(typed_trait_decl)
             })

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
@@ -3,7 +3,7 @@ use sway_types::Spanned;
 use crate::{
     decl_engine::{parsed_id::ParsedDeclId, DeclId},
     language::{
-        parsed::{self, Declaration, TraitFn},
+        parsed::{Declaration, TraitFn},
         ty, CallPath, Visibility,
     },
     semantic_analysis::symbol_collection_context::SymbolCollectionContext,
@@ -35,9 +35,9 @@ impl ty::TyTraitFn {
     pub(crate) fn type_check(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        trait_fn: &parsed::TraitFn,
+        trait_fn: &TraitFn,
     ) -> Result<ty::TyTraitFn, ErrorEmitted> {
-        let parsed::TraitFn {
+        let TraitFn {
             name,
             span,
             purity,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
@@ -7,7 +7,7 @@ use sway_types::{Span, Spanned};
 use crate::{
     decl_engine::parsed_id::ParsedDeclId,
     language::{
-        parsed::{self, Declaration, TraitTypeDeclaration},
+        parsed::{Declaration, TraitTypeDeclaration},
         ty::{self, TyTraitType},
     },
     semantic_analysis::{
@@ -36,9 +36,9 @@ impl ty::TyTraitType {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        trait_type: parsed::TraitTypeDeclaration,
+        trait_type: &TraitTypeDeclaration,
     ) -> Result<Self, ErrorEmitted> {
-        let parsed::TraitTypeDeclaration {
+        let TraitTypeDeclaration {
             name,
             attributes,
             ty_opt,
@@ -48,7 +48,8 @@ impl ty::TyTraitType {
         let engines = ctx.engines();
         let type_engine = engines.te();
 
-        let ty = if let Some(mut ty) = ty_opt {
+        let ty_opt = ty_opt.as_ref().cloned();
+        let ty = ty_opt.map(|mut ty| {
             *ty.type_id_mut() = ctx
                 .resolve_type(
                     handler,
@@ -58,28 +59,29 @@ impl ty::TyTraitType {
                     None,
                 )
                 .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
-            Some(ty)
-        } else {
-            None
-        };
+            ty
+        });
 
         if let Some(implementing_type) = ctx.self_type() {
             Ok(ty::TyTraitType {
-                name,
-                attributes,
+                name: name.clone(),
+                attributes: attributes.clone(),
                 ty,
                 implementing_type,
-                span,
+                span: span.clone(),
             })
         } else {
-            Err(handler.emit_err(CompileError::Internal("Self type not provided.", span)))
+            Err(handler.emit_err(CompileError::Internal(
+                "Self type not provided.",
+                span.clone(),
+            )))
         }
     }
 
     /// Used to create a stubbed out constant when the constant fails to
     /// compile, preventing cascading namespace errors.
-    pub(crate) fn error(engines: &Engines, decl: parsed::TraitTypeDeclaration) -> TyTraitType {
-        let parsed::TraitTypeDeclaration {
+    pub(crate) fn error(engines: &Engines, decl: TraitTypeDeclaration) -> TyTraitType {
+        let TraitTypeDeclaration {
             name,
             attributes,
             ty_opt,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -33,7 +33,7 @@ impl ty::TyVariableDecl {
     pub fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        var_decl: VariableDeclaration,
+        var_decl: &VariableDeclaration,
     ) -> Result<Self, ErrorEmitted> {
         let engines = &ctx.engines();
         let type_engine = engines.te();
@@ -94,7 +94,7 @@ impl ty::TyVariableDecl {
                 .namespace()
                 .current_module()
                 .current_items()
-                .check_symbols_unique_while_collecting_unifications(&var_decl.name.clone())
+                .check_symbols_unique_while_collecting_unifications(&var_decl.name)
                 .ok();
 
             if let Some(ResolvedDeclaration::Typed(ty::TyDecl::VariableDecl(variable_decl))) =

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -24,7 +24,7 @@ impl ty::TyIntrinsicFunctionKind {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        kind_binding: TypeBinding<Intrinsic>,
+        kind_binding: &TypeBinding<Intrinsic>,
         arguments: &[Expression],
         span: Span,
     ) -> Result<(Self, TypeId), ErrorEmitted> {
@@ -34,6 +34,7 @@ impl ty::TyIntrinsicFunctionKind {
             ..
         } = kind_binding;
         let type_arguments = type_arguments.as_slice();
+        let kind = *kind;
         match kind {
             Intrinsic::SizeOfVal => {
                 type_check_size_of_val(handler, ctx, kind, arguments, type_arguments, span)

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -27,7 +27,7 @@ impl ty::TyMatchBranch {
         handler: &Handler,
         mut ctx: TypeCheckContext,
         typed_value: &ty::TyExpression,
-        branch: MatchBranch,
+        branch: &MatchBranch,
     ) -> Result<(ty::TyMatchBranch, ty::TyScrutinee), ErrorEmitted> {
         let MatchBranch {
             scrutinee,
@@ -159,7 +159,7 @@ impl ty::TyMatchBranch {
                     type_annotation,
                     None,
                 ));
-                ty::TyExpression::type_check(handler, branch_ctx, &result)?
+                ty::TyExpression::type_check(handler, branch_ctx, result)?
             };
 
             // Check if return type is Never if it is we don't unify as it would replace the Unknown annotation with Never.
@@ -216,7 +216,7 @@ impl ty::TyMatchBranch {
                 matched_or_variant_index_vars: or_variant_vars,
                 condition,
                 result: new_result,
-                span: branch_span,
+                span: branch_span.clone(),
             };
 
             Ok((typed_branch, typed_scrutinee))

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
@@ -52,8 +52,8 @@ impl ty::TyMatchExpression {
     pub(crate) fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        typed_value: ty::TyExpression,
-        branches: Vec<MatchBranch>,
+        typed_value: &ty::TyExpression,
+        branches: &[MatchBranch],
         span: Span,
     ) -> Result<(ty::TyMatchExpression, Vec<ty::TyScrutinee>), ErrorEmitted> {
         // type check all of the branches
@@ -63,16 +63,13 @@ impl ty::TyMatchExpression {
             ctx.with_help_text("all branches of a match statement must return the same type");
 
         handler.scope(|handler| {
-            for branch in branches.into_iter() {
-                let (typed_branch, typed_scrutinee) = match ty::TyMatchBranch::type_check(
-                    handler,
-                    ctx.by_ref(),
-                    &typed_value,
-                    branch,
-                ) {
-                    Ok(res) => res,
-                    Err(_) => continue,
-                };
+            for branch in branches.iter() {
+                let (typed_branch, typed_scrutinee) =
+                    match ty::TyMatchBranch::type_check(handler, ctx.by_ref(), typed_value, branch)
+                    {
+                        Ok(res) => res,
+                        Err(_) => continue,
+                    };
                 typed_branches.push(typed_branch);
                 typed_scrutinees.push(typed_scrutinee);
             }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -23,7 +23,7 @@ impl TyScrutinee {
     pub(crate) fn type_check(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        scrutinee: Scrutinee,
+        scrutinee: &Scrutinee,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
         let engines = ctx.engines();
@@ -40,7 +40,7 @@ impl TyScrutinee {
                 let typed_scrutinee = ty::TyScrutinee {
                     variant: ty::TyScrutineeVariant::Or(typed_elems),
                     type_id: type_engine.new_unknown(),
-                    span,
+                    span: span.clone(),
                 };
                 Ok(typed_scrutinee)
             }
@@ -57,7 +57,7 @@ impl TyScrutinee {
                             span.clone(),
                         ),
                     )),
-                    span,
+                    span: span.clone(),
                 };
                 Ok(typed_scrutinee)
             }
@@ -65,31 +65,39 @@ impl TyScrutinee {
                 let typed_scrutinee = ty::TyScrutinee {
                     variant: ty::TyScrutineeVariant::Literal(value.clone()),
                     type_id: type_engine.insert(engines, value.to_typeinfo(), span.source_id()),
-                    span,
+                    span: span.clone(),
                 };
                 Ok(typed_scrutinee)
             }
-            Scrutinee::Variable { name, span } => type_check_variable(handler, ctx, name, span),
+            Scrutinee::Variable { name, span } => {
+                type_check_variable(handler, ctx, name.clone(), span.clone())
+            }
             Scrutinee::StructScrutinee {
                 struct_name,
                 fields,
                 span,
-            } => type_check_struct(handler, ctx, struct_name.suffix, &fields, span),
+            } => type_check_struct(
+                handler,
+                ctx,
+                struct_name.suffix.clone(),
+                fields,
+                span.clone(),
+            ),
             Scrutinee::EnumScrutinee {
                 call_path,
                 value,
                 span,
-            } => type_check_enum(handler, ctx, call_path, *value, span),
+            } => type_check_enum(handler, ctx, call_path, value, span.clone()),
             Scrutinee::AmbiguousSingleIdent(ident) => {
                 let maybe_enum = type_check_enum(
                     &Handler::default(),
                     ctx.by_ref(),
-                    CallPath {
+                    &CallPath {
                         prefixes: vec![],
                         suffix: ident.clone(),
                         callpath_type: CallPathType::Ambiguous,
                     },
-                    Scrutinee::Tuple {
+                    &Scrutinee::Tuple {
                         elems: vec![],
                         span: ident.span(),
                     },
@@ -102,8 +110,8 @@ impl TyScrutinee {
                     type_check_variable(handler, ctx, ident.clone(), ident.span())
                 }
             }
-            Scrutinee::Tuple { elems, span } => type_check_tuple(handler, ctx, elems, span),
-            Scrutinee::Error { err, .. } => Err(err),
+            Scrutinee::Tuple { elems, span } => type_check_tuple(handler, ctx, elems, span.clone()),
+            Scrutinee::Error { err, .. } => Err(*err),
         }
     }
 
@@ -273,7 +281,7 @@ fn type_check_struct(
                         Some(scrutinee) => Some(ty::TyScrutinee::type_check(
                             handler,
                             ctx.by_ref(),
-                            scrutinee.clone(),
+                            scrutinee,
                         )?),
                     };
 
@@ -474,8 +482,8 @@ impl TypeCheckFinalization for TyScrutinee {
 fn type_check_enum(
     handler: &Handler,
     mut ctx: TypeCheckContext,
-    call_path: CallPath<Ident>,
-    value: Scrutinee,
+    call_path: &CallPath<Ident>,
+    value: &Scrutinee,
     span: Span,
 ) -> Result<ty::TyScrutinee, ErrorEmitted> {
     let type_engine = ctx.engines.te();
@@ -497,13 +505,12 @@ fn type_check_enum(
         }
         None => {
             // we may have an imported variant
-            let decl = ctx.resolve_call_path(handler, &call_path)?;
+            let decl = ctx.resolve_call_path(handler, call_path)?;
             if let TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) = decl.clone() {
                 (call_path.suffix.span(), *enum_ref.id(), decl)
             } else {
                 return Err(handler.emit_err(CompileError::EnumNotFound {
-                    name: call_path.suffix.clone(),
-                    span: call_path.suffix.span(),
+                    name: (&call_path.suffix).into(),
                 }));
             }
         }
@@ -544,7 +551,7 @@ fn type_check_enum(
             variant: Box::new(variant),
             call_path_decl,
             value: Box::new(typed_value),
-            instantiation_call_path: call_path,
+            instantiation_call_path: call_path.clone(),
         },
         span,
     };
@@ -555,14 +562,14 @@ fn type_check_enum(
 fn type_check_tuple(
     handler: &Handler,
     mut ctx: TypeCheckContext,
-    elems: Vec<Scrutinee>,
+    elems: &[Scrutinee],
     span: Span,
 ) -> Result<ty::TyScrutinee, ErrorEmitted> {
     let type_engine = ctx.engines.te();
     let engines = ctx.engines();
 
     let mut typed_elems = vec![];
-    for elem in elems.into_iter() {
+    for elem in elems.iter() {
         typed_elems.push(
             match ty::TyScrutinee::type_check(handler, ctx.by_ref(), elem) {
                 Ok(res) => res,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -157,16 +157,14 @@ impl ty::TyExpression {
             ExpressionKind::Error(_, _) => {}
             ExpressionKind::Literal(_) => {}
             ExpressionKind::AmbiguousPathExpression(expr) => {
-                expr.args
-                    .iter()
-                    .map(|arg_expr| Self::collect(handler, engines, ctx, arg_expr))
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                for arg_expr in &expr.args {
+                    Self::collect(handler, engines, ctx, arg_expr)?;
+                }
             }
             ExpressionKind::FunctionApplication(expr) => {
-                expr.arguments
-                    .iter()
-                    .map(|arg_expr| Self::collect(handler, engines, ctx, arg_expr))
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                for arg_expr in &expr.arguments {
+                    Self::collect(handler, engines, ctx, arg_expr)?;
+                }
             }
             ExpressionKind::LazyOperator(expr) => {
                 Self::collect(handler, engines, ctx, &expr.lhs)?;
@@ -175,32 +173,29 @@ impl ty::TyExpression {
             ExpressionKind::AmbiguousVariableExpression(_) => {}
             ExpressionKind::Variable(_) => {}
             ExpressionKind::Tuple(exprs) => {
-                exprs
-                    .iter()
-                    .map(|expr| Self::collect(handler, engines, ctx, expr))
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                for expr in exprs {
+                    Self::collect(handler, engines, ctx, expr)?;
+                }
             }
             ExpressionKind::TupleIndex(expr) => {
                 Self::collect(handler, engines, ctx, &expr.prefix)?;
             }
             ExpressionKind::Array(ArrayExpression::Explicit { contents, .. }) => {
-                contents
-                    .iter()
-                    .map(|expr| Self::collect(handler, engines, ctx, expr))
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                for expr in contents {
+                    Self::collect(handler, engines, ctx, expr)?;
+                }
             }
             ExpressionKind::Array(ArrayExpression::Repeat { value, length }) => {
                 Self::collect(handler, engines, ctx, value)?;
                 Self::collect(handler, engines, ctx, length)?;
             }
             ExpressionKind::Struct(expr) => {
-                expr.fields
-                    .iter()
-                    .map(|field| Self::collect(handler, engines, ctx, &field.value))
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                for field in &expr.fields {
+                    Self::collect(handler, engines, ctx, &field.value)?;
+                }
             }
             ExpressionKind::CodeBlock(code_block) => {
-                TyCodeBlock::collect(handler, engines, ctx, code_block)?
+                TyCodeBlock::collect(handler, engines, ctx, code_block)?;
             }
             ExpressionKind::If(if_expr) => {
                 Self::collect(handler, engines, ctx, &if_expr.condition)?;
@@ -211,33 +206,28 @@ impl ty::TyExpression {
             }
             ExpressionKind::Match(expr) => {
                 Self::collect(handler, engines, ctx, &expr.value)?;
-                expr.branches
-                    .iter()
-                    .map(|branch| {
-                        // create a new namespace for this branch result
-                        ctx.scoped(engines, branch.span.clone(), None, |scoped_ctx| {
-                            Self::collect(handler, engines, scoped_ctx, &branch.result)
-                        })
-                        .0
+                for branch in &expr.branches {
+                    // create a new namespace for this branch result
+                    ctx.scoped(engines, branch.span.clone(), None, |scoped_ctx| {
+                        Self::collect(handler, engines, scoped_ctx, &branch.result)
                     })
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                    .0?;
+                }
             }
             ExpressionKind::Asm(_) => {}
             ExpressionKind::MethodApplication(expr) => {
-                expr.arguments
-                    .iter()
-                    .map(|expr| Self::collect(handler, engines, ctx, expr))
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                for expr in &expr.arguments {
+                    Self::collect(handler, engines, ctx, expr)?;
+                }
             }
             ExpressionKind::Subfield(expr) => {
                 Self::collect(handler, engines, ctx, &expr.prefix)?;
             }
             ExpressionKind::DelineatedPath(expr) => {
                 if let Some(expr_args) = &expr.args {
-                    expr_args
-                        .iter()
-                        .map(|arg_expr| Self::collect(handler, engines, ctx, arg_expr))
-                        .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                    for arg_expr in expr_args {
+                        Self::collect(handler, engines, ctx, arg_expr)?;
+                    }
                 }
             }
             ExpressionKind::AbiCast(expr) => {
@@ -249,14 +239,13 @@ impl ty::TyExpression {
             }
             ExpressionKind::StorageAccess(_) => {}
             ExpressionKind::IntrinsicFunction(expr) => {
-                expr.arguments
-                    .iter()
-                    .map(|arg_expr| Self::collect(handler, engines, ctx, arg_expr))
-                    .collect::<Result<Vec<_>, ErrorEmitted>>()?;
+                for arg_expr in &expr.arguments {
+                    Self::collect(handler, engines, ctx, arg_expr)?;
+                }
             }
             ExpressionKind::WhileLoop(expr) => {
                 Self::collect(handler, engines, ctx, &expr.condition)?;
-                TyCodeBlock::collect(handler, engines, ctx, &expr.body)?
+                TyCodeBlock::collect(handler, engines, ctx, &expr.body)?;
             }
             ExpressionKind::ForLoop(expr) => {
                 Self::collect(handler, engines, ctx, &expr.desugared)?;
@@ -320,7 +309,7 @@ impl ty::TyExpression {
                     Self::type_check_delineated_path(
                         handler,
                         ctx.by_ref(),
-                        TypeBinding {
+                        &TypeBinding {
                             span: call_path.span(),
                             inner: QualifiedCallPath {
                                 call_path,
@@ -342,19 +331,19 @@ impl ty::TyExpression {
                 let FunctionApplicationExpression {
                     call_path_binding,
                     resolved_call_path_binding: _,
-                    ref arguments,
-                } = *function_application_expression.clone();
+                    arguments,
+                } = &**function_application_expression;
                 Self::type_check_function_application(
                     handler,
                     ctx.by_ref(),
-                    call_path_binding,
+                    call_path_binding.clone(),
                     arguments,
                     span,
                 )
             }
             ExpressionKind::LazyOperator(LazyOperatorExpression { op, lhs, rhs }) => {
                 let ctx = ctx.by_ref().with_type_annotation(type_engine.id_of_bool());
-                Self::type_check_lazy_operator(handler, ctx, op.clone(), lhs, rhs, span)
+                Self::type_check_lazy_operator(handler, ctx, *op, lhs, rhs, span)
             }
             ExpressionKind::CodeBlock(contents) => {
                 Self::type_check_code_block(handler, ctx.by_ref(), contents, span)
@@ -369,9 +358,9 @@ impl ty::TyExpression {
             }) => Self::type_check_if_expression(
                 handler,
                 ctx.by_ref().with_help_text(""),
-                *condition.clone(),
-                *then.clone(),
-                r#else.as_ref().map(|e| *e.clone()),
+                condition,
+                then,
+                r#else.as_deref(),
                 span,
             ),
             ExpressionKind::Match(MatchExpression { value, branches }) => {
@@ -379,12 +368,12 @@ impl ty::TyExpression {
                     handler,
                     ctx.by_ref().with_help_text(""),
                     value,
-                    branches.clone(),
+                    branches,
                     span,
                 )
             }
             ExpressionKind::Asm(asm) => {
-                Self::type_check_asm_expression(handler, ctx.by_ref(), *asm.clone(), span)
+                Self::type_check_asm_expression(handler, ctx.by_ref(), asm, span)
             }
             ExpressionKind::Struct(struct_expression) => struct_instantiation(
                 handler,
@@ -407,8 +396,8 @@ impl ty::TyExpression {
                 let MethodApplicationExpression {
                     method_name_binding,
                     contract_call_params,
-                    ref arguments,
-                } = *method_application_expression.clone();
+                    arguments,
+                } = &**method_application_expression;
                 type_check_method_application(
                     handler,
                     ctx.by_ref(),
@@ -428,31 +417,31 @@ impl ty::TyExpression {
             }) => Self::type_check_tuple_index(
                 handler,
                 ctx.by_ref(),
-                *prefix.clone(),
+                prefix,
                 *index,
                 index_span.clone(),
                 span,
             ),
-            ExpressionKind::AmbiguousPathExpression(e) => {
+            ExpressionKind::AmbiguousPathExpression(ambiguous_path_expression) => {
                 let AmbiguousPathExpression {
                     call_path_binding,
                     ref args,
                     qualified_path_root,
-                } = *e.clone();
+                } = &**ambiguous_path_expression;
                 Self::type_check_ambiguous_path(
                     handler,
                     ctx.by_ref(),
                     call_path_binding,
                     span,
                     args,
-                    qualified_path_root,
+                    qualified_path_root.as_ref(),
                 )
             }
             ExpressionKind::DelineatedPath(delineated_path_expression) => {
                 let DelineatedPathExpression {
                     call_path_binding,
                     args,
-                } = *delineated_path_expression.clone();
+                } = &**delineated_path_expression;
                 Self::type_check_delineated_path(
                     handler,
                     ctx.by_ref(),
@@ -463,7 +452,7 @@ impl ty::TyExpression {
             }
             ExpressionKind::AbiCast(abi_cast_expression) => {
                 let AbiCastExpression { abi_name, address } = &**abi_cast_expression;
-                Self::type_check_abi_cast(handler, ctx.by_ref(), abi_name.clone(), address, span)
+                Self::type_check_abi_cast(handler, ctx.by_ref(), abi_name, address, span)
             }
             ExpressionKind::Array(ArrayExpression::Explicit { contents, .. }) => {
                 Self::type_check_array_explicit(handler, ctx.by_ref(), contents, span)
@@ -492,7 +481,7 @@ impl ty::TyExpression {
                     ctx,
                     namespace_names,
                     field_names,
-                    storage_keyword_span.clone(),
+                    storage_keyword_span,
                     &span,
                 )
             }
@@ -503,7 +492,7 @@ impl ty::TyExpression {
             }) => Self::type_check_intrinsic_function(
                 handler,
                 ctx.by_ref(),
-                kind_binding.clone(),
+                kind_binding,
                 arguments,
                 span,
             ),
@@ -539,7 +528,7 @@ impl ty::TyExpression {
                 Ok(expr)
             }
             ExpressionKind::Reassignment(ReassignmentExpression { lhs, rhs }) => {
-                Self::type_check_reassignment(handler, ctx.by_ref(), lhs.clone(), rhs, span)
+                Self::type_check_reassignment(handler, ctx.by_ref(), lhs, rhs, span)
             }
             ExpressionKind::ImplicitReturn(expr) => {
                 let ctx = ctx
@@ -822,9 +811,9 @@ impl ty::TyExpression {
     fn type_check_if_expression(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        condition: Expression,
-        then: Expression,
-        r#else: Option<Expression>,
+        condition: &Expression,
+        then: &Expression,
+        r#else: Option<&Expression>,
         span: Span,
     ) -> Result<ty::TyExpression, ErrorEmitted> {
         let type_engine = ctx.engines.te();
@@ -835,7 +824,7 @@ impl ty::TyExpression {
                 .by_ref()
                 .with_help_text("The condition of an if expression must be a boolean expression.")
                 .with_type_annotation(type_engine.id_of_bool());
-            ty::TyExpression::type_check(handler, ctx, &condition)
+            ty::TyExpression::type_check(handler, ctx, condition)
                 .unwrap_or_else(|err| ty::TyExpression::error(err, condition.span(), engines))
         };
 
@@ -860,7 +849,7 @@ impl ty::TyExpression {
                     type_annotation.clone(),
                     then.span().source_id(),
                 ));
-            ty::TyExpression::type_check(handler, ctx, &then)
+            ty::TyExpression::type_check(handler, ctx, then)
                 .unwrap_or_else(|err| ty::TyExpression::error(err, then.span(), engines))
         };
 
@@ -873,11 +862,11 @@ impl ty::TyExpression {
                     type_annotation,
                     expr.span().source_id(),
                 ));
-            ty::TyExpression::type_check(handler, ctx, &expr)
+            ty::TyExpression::type_check(handler, ctx, expr)
                 .unwrap_or_else(|err| ty::TyExpression::error(err, expr.span(), engines))
         });
 
-        let exp = instantiate_if_expression(handler, ctx, condition, then.clone(), r#else, span)?;
+        let exp = instantiate_if_expression(handler, ctx, condition, then, r#else, span)?;
 
         Ok(exp)
     }
@@ -886,7 +875,7 @@ impl ty::TyExpression {
         handler: &Handler,
         mut ctx: TypeCheckContext,
         value: &Expression,
-        branches: Vec<MatchBranch>,
+        branches: &[MatchBranch],
         span: Span,
     ) -> Result<ty::TyExpression, ErrorEmitted> {
         let type_engine = ctx.engines.te();
@@ -899,7 +888,7 @@ impl ty::TyExpression {
                 .with_help_text("")
                 .with_type_annotation(type_engine.new_unknown());
             ty::TyExpression::type_check(handler, ctx, value)
-                .unwrap_or_else(|err| ty::TyExpression::error(err, value.span().clone(), engines))
+                .unwrap_or_else(|err| ty::TyExpression::error(err, value.span(), engines))
         };
         let type_id = typed_value.return_type;
 
@@ -912,7 +901,7 @@ impl ty::TyExpression {
         let (typed_match_expression, typed_scrutinees) = ty::TyMatchExpression::type_check(
             handler,
             ctx.by_ref().with_help_text(""),
-            typed_value,
+            &typed_value,
             branches,
             span.clone(),
         )?;
@@ -1066,7 +1055,7 @@ impl ty::TyExpression {
     fn type_check_asm_expression(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        asm: AsmExpression,
+        asm: &AsmExpression,
         span: Span,
     ) -> Result<ty::TyExpression, ErrorEmitted> {
         let type_engine = ctx.engines.te();
@@ -1083,7 +1072,7 @@ impl ty::TyExpression {
         // this includes two checks:
         // 1. Check that no control flow opcodes are used.
         // 2. Check that initialized registers are not reassigned in the `asm` block.
-        check_asm_block_validity(handler, &asm, &ctx)?;
+        check_asm_block_validity(handler, asm, &ctx)?;
 
         // Take the span of the returns register, or as a fallback, the span of the
         // whole ASM block.
@@ -1110,18 +1099,17 @@ impl ty::TyExpression {
         // type check the initializers
         let typed_registers = asm
             .registers
-            .clone()
-            .into_iter()
+            .iter()
             .map(
                 |AsmRegisterDeclaration { name, initializer }| ty::TyAsmRegisterDeclaration {
-                    name,
-                    initializer: initializer.map(|initializer| {
+                    name: name.clone(),
+                    initializer: initializer.as_ref().map(|initializer| {
                         let ctx = ctx
                             .by_ref()
                             .with_help_text("")
                             .with_type_annotation(type_engine.new_unknown());
 
-                        ty::TyExpression::type_check(handler, ctx, &initializer).unwrap_or_else(
+                        ty::TyExpression::type_check(handler, ctx, initializer).unwrap_or_else(
                             |err| ty::TyExpression::error(err, initializer.span(), engines),
                         )
                     }),
@@ -1131,10 +1119,10 @@ impl ty::TyExpression {
 
         let exp = ty::TyExpression {
             expression: ty::TyExpressionVariant::AsmExpression {
-                whole_block_span: asm.whole_block_span,
-                body: asm.body,
+                whole_block_span: asm.whole_block_span.clone(),
+                body: asm.body.clone(),
                 registers: typed_registers,
-                returns: asm.returns,
+                returns: asm.returns.clone(),
             },
             return_type,
             span,
@@ -1235,7 +1223,7 @@ impl ty::TyExpression {
         ctx: TypeCheckContext,
         namespace_names: &[Ident],
         field_names: &[Ident],
-        storage_keyword_span: Span,
+        storage_keyword_span: &Span,
         span: &Span,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
@@ -1341,7 +1329,7 @@ impl ty::TyExpression {
     fn type_check_tuple_index(
         handler: &Handler,
         ctx: TypeCheckContext,
-        prefix: Expression,
+        prefix: &Expression,
         index: usize,
         index_span: Span,
         span: Span,
@@ -1352,7 +1340,7 @@ impl ty::TyExpression {
         let ctx = ctx
             .with_help_text("")
             .with_type_annotation(type_engine.new_unknown());
-        let parent = ty::TyExpression::type_check(handler, ctx, &prefix)?;
+        let parent = ty::TyExpression::type_check(handler, ctx, prefix)?;
         let exp =
             instantiate_tuple_index_access(handler, engines, parent, index, index_span, span)?;
         Ok(exp)
@@ -1361,7 +1349,17 @@ impl ty::TyExpression {
     fn type_check_ambiguous_path(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        TypeBinding {
+        type_binding: &TypeBinding<CallPath<AmbiguousSuffix>>,
+        span: Span,
+        args: &[Expression],
+        qualified_path_root: Option<&QualifiedPathType>,
+    ) -> Result<ty::TyExpression, ErrorEmitted> {
+        let engines = ctx.engines;
+        let decl_engine = engines.de();
+
+        // We anyhow need to clone all of the fields in the algorithm
+        // below, so we do it here once, and not field by field.
+        let TypeBinding {
             inner:
                 CallPath {
                     prefixes,
@@ -1370,15 +1368,9 @@ impl ty::TyExpression {
                 },
             type_arguments,
             span: path_span,
-        }: TypeBinding<CallPath<AmbiguousSuffix>>,
-        span: Span,
-        args: &[Expression],
-        qualified_path_root: Option<QualifiedPathType>,
-    ) -> Result<ty::TyExpression, ErrorEmitted> {
-        let engines = ctx.engines;
-        let decl_engine = engines.de();
+        } = type_binding.clone();
 
-        if let Some(QualifiedPathType { ty, as_trait, .. }) = qualified_path_root.clone() {
+        if let Some(QualifiedPathType { ty, as_trait, .. }) = qualified_path_root {
             let method_name_binding = if !prefixes.is_empty() || before.is_some() {
                 let mut prefixes_and_before = prefixes.clone();
                 if let Some(before) = before {
@@ -1393,7 +1385,7 @@ impl ty::TyExpression {
                         suffix: prefixes_and_before_last.clone(),
                         callpath_type,
                     },
-                    qualified_path_root: qualified_path_root.map(Box::new),
+                    qualified_path_root: qualified_path_root.map(|path| Box::new(path.clone())),
                 };
                 let type_info = TypeInfo::Custom {
                     qualified_call_path: qualified_call_path.clone(),
@@ -1419,8 +1411,8 @@ impl ty::TyExpression {
             } else {
                 TypeBinding {
                     inner: MethodName::FromQualifiedPathRoot {
-                        ty,
-                        as_trait,
+                        ty: ty.clone(),
+                        as_trait: *as_trait,
                         method_name: suffix,
                     },
                     type_arguments,
@@ -1431,8 +1423,8 @@ impl ty::TyExpression {
             return type_check_method_application(
                 handler,
                 ctx.by_ref(),
-                method_name_binding,
-                Vec::new(),
+                &method_name_binding,
+                &[],
                 args,
                 span,
             );
@@ -1465,7 +1457,7 @@ impl ty::TyExpression {
                 return Self::type_check_delineated_path(
                     handler,
                     ctx,
-                    call_path_binding,
+                    &call_path_binding,
                     span,
                     Some(args),
                 );
@@ -1548,8 +1540,8 @@ impl ty::TyExpression {
             type_check_method_application(
                 handler,
                 ctx.by_ref(),
-                method_name_binding,
-                Vec::new(),
+                &method_name_binding,
+                &[],
                 args,
                 span,
             )
@@ -1578,14 +1570,14 @@ impl ty::TyExpression {
                 type_arguments,
                 span: path_span,
             };
-            Self::type_check_delineated_path(handler, ctx, call_path_binding, span, Some(args))
+            Self::type_check_delineated_path(handler, ctx, &call_path_binding, span, Some(args))
         }
     }
 
     fn type_check_delineated_path(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        unknown_call_path_binding: TypeBinding<QualifiedCallPath>,
+        unknown_call_path_binding: &TypeBinding<QualifiedCallPath>,
         span: Span,
         args: Option<&[Expression]>,
     ) -> Result<ty::TyExpression, ErrorEmitted> {
@@ -1727,7 +1719,7 @@ impl ty::TyExpression {
 
         // Check if this could be a constant
         let maybe_const =
-            { Self::probe_const_decl(&unknown_call_path_binding, &mut ctx, &const_probe_handler) };
+            { Self::probe_const_decl(unknown_call_path_binding, &mut ctx, &const_probe_handler) };
 
         // compare the results of the checks
         let exp = match (
@@ -1816,8 +1808,7 @@ impl ty::TyExpression {
             }
             (false, None, None, None, None) => {
                 return Err(handler.emit_err(CompileError::SymbolNotFound {
-                    name: unknown_call_path_binding.inner.call_path.suffix.clone(),
-                    span: unknown_call_path_binding.inner.call_path.suffix.span(),
+                    name: (&unknown_call_path_binding.inner.call_path.suffix).into(),
                 }));
             }
             _ => {
@@ -1884,7 +1875,7 @@ impl ty::TyExpression {
     fn type_check_abi_cast(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        abi_name: CallPath,
+        abi_name: &CallPath,
         address: &Expression,
         span: Span,
     ) -> Result<Self, ErrorEmitted> {
@@ -1905,7 +1896,7 @@ impl ty::TyExpression {
         };
 
         // look up the call path and get the declaration it references
-        let abi = ctx.resolve_call_path(handler, &abi_name)?;
+        let abi = ctx.resolve_call_path(handler, abi_name)?;
         let abi_ref = match abi {
             ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id }) => {
                 let abi_decl = engines.de().get(&decl_id);
@@ -2033,7 +2024,7 @@ impl ty::TyExpression {
 
         let exp = ty::TyExpression {
             expression: ty::TyExpressionVariant::AbiCast {
-                abi_name,
+                abi_name: abi_name.clone(),
                 address: Box::new(address_expr),
                 span: span.clone(),
             },
@@ -2274,7 +2265,7 @@ impl ty::TyExpression {
     fn type_check_intrinsic_function(
         handler: &Handler,
         ctx: TypeCheckContext,
-        kind_binding: TypeBinding<Intrinsic>,
+        kind_binding: &TypeBinding<Intrinsic>,
         arguments: &[Expression],
         span: Span,
     ) -> Result<Self, ErrorEmitted> {
@@ -2347,7 +2338,7 @@ impl ty::TyExpression {
     fn type_check_reassignment(
         handler: &Handler,
         ctx: TypeCheckContext,
-        lhs: ReassignmentTarget,
+        lhs: &ReassignmentTarget,
         rhs: &Expression,
         span: Span,
     ) -> Result<Self, ErrorEmitted> {
@@ -2370,7 +2361,7 @@ impl ty::TyExpression {
                 let Expression {
                     kind: ExpressionKind::Deref(reference_exp),
                     ..
-                } = &*dereference_exp
+                } = &**dereference_exp
                 else {
                     return internal_compiler_error();
                 };
@@ -2459,7 +2450,7 @@ impl ty::TyExpression {
                 let mut expr = path;
                 let mut indices = Vec::new();
 
-                // This variaable is used after the loop.
+                // This variable is used after the loop.
                 #[allow(unused_assignments)]
                 let mut base_deref_expr = None;
                 // Loop through the LHS "backwards" starting from the outermost expression
@@ -2467,10 +2458,10 @@ impl ty::TyExpression {
                 // be a mutable variable.
                 let (base_name, base_type) = loop {
                     base_deref_expr = None;
-                    match expr.kind {
+                    match &expr.kind {
                         ExpressionKind::Variable(name) => {
                             // check that the reassigned name exists
-                            let unknown_decl = ctx.resolve_symbol(handler, &name)?;
+                            let unknown_decl = ctx.resolve_symbol(handler, name)?;
 
                             match unknown_decl {
                                 TyDecl::VariableDecl(variable_decl) => {
@@ -2483,7 +2474,7 @@ impl ty::TyExpression {
                                         ));
                                     }
 
-                                    break (name, variable_decl.return_type);
+                                    break (name.clone(), variable_decl.return_type);
                                 }
                                 TyDecl::ConstantDecl(constant_decl) => {
                                     let constant_decl =
@@ -2536,13 +2527,13 @@ impl ty::TyExpression {
                             {
                                 TypeInfo::Struct(decl_ref) => {
                                     let struct_decl = engines.de().get_struct(decl_ref);
-                                    struct_decl.find_field(&idx_name).cloned()
+                                    struct_decl.find_field(idx_name).cloned()
                                 }
                                 _ => None,
                             };
 
                             indices.push(ty::ProjectionKind::StructField {
-                                name: idx_name,
+                                name: idx_name.clone(),
                                 field_to_access: field_to_access.map(Box::new),
                             });
                             expr = prefix;
@@ -2553,7 +2544,10 @@ impl ty::TyExpression {
                             index_span,
                             ..
                         }) => {
-                            indices.push(ty::ProjectionKind::TupleField { index, index_span });
+                            indices.push(ty::ProjectionKind::TupleField {
+                                index: *index,
+                                index_span: index_span.clone(),
+                            });
                             expr = prefix;
                         }
                         ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index }) => {
@@ -2577,12 +2571,14 @@ impl ty::TyExpression {
                             let deref_expr = Self::type_check_deref(
                                 handler,
                                 ctx.by_ref(),
-                                &reference_exp,
-                                reference_exp_span.clone(),
+                                reference_exp,
+                                reference_exp_span,
                             )?;
-                            base_deref_expr = Some(deref_expr.clone());
+                            let deref_expr_span = deref_expr.span.clone();
+                            let deref_expr_return_type = deref_expr.return_type;
+                            base_deref_expr = Some(deref_expr);
 
-                            break (BaseIdent::new(deref_expr.span), deref_expr.return_type);
+                            break (BaseIdent::new(deref_expr_span), deref_expr_return_type);
                         }
                         _ => {
                             return Err(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -32,8 +32,8 @@ use sway_types::{Ident, Span};
 pub(crate) fn type_check_method_application(
     handler: &Handler,
     mut ctx: TypeCheckContext,
-    mut method_name_binding: TypeBinding<MethodName>,
-    contract_call_params: Vec<StructExpressionField>,
+    method_name_binding: &TypeBinding<MethodName>,
+    contract_call_params: &[StructExpressionField],
     arguments: &[Expression],
     span: Span,
 ) -> Result<ty::TyExpression, ErrorEmitted> {
@@ -96,12 +96,8 @@ pub(crate) fn type_check_method_application(
             None => type_engine.new_unknown(),
         })
         .collect::<Vec<_>>();
-    let method_result = resolve_method_name(
-        handler,
-        ctx.by_ref(),
-        &method_name_binding,
-        &arguments_types,
-    );
+    let method_result =
+        resolve_method_name(handler, ctx.by_ref(), method_name_binding, &arguments_types);
 
     // In case resolve_method_name fails throw argument errors.
     let (original_decl_ref, method_target) = if let Err(e) = method_result {
@@ -127,6 +123,8 @@ pub(crate) fn type_check_method_application(
         original_decl.type_parameters.iter(),
     );
 
+    let mut method_name_binding = method_name_binding.clone();
+
     let mut fn_ref = monomorphize_method(
         handler,
         ctx.by_ref(),
@@ -134,6 +132,9 @@ pub(crate) fn type_check_method_application(
         method_name_binding.type_arguments.to_vec_mut(),
         const_generics,
     )?;
+
+    // Remove mutability.
+    let method_name_binding = method_name_binding;
 
     let method = &*decl_engine.get_function(&fn_ref);
 
@@ -259,8 +260,7 @@ pub(crate) fn type_check_method_application(
                 }
                 _ => {
                     handler.emit_err(CompileError::UnrecognizedContractParam {
-                        param_name: param.name.to_string(),
-                        span: param.name.span().clone(),
+                        param_name: (&param.name).into(),
                     });
                 }
             };
@@ -445,7 +445,7 @@ pub(crate) fn type_check_method_application(
         };
         Some(ty::ContractCallParams {
             func_selector,
-            contract_address: contract_address.clone(),
+            contract_address,
             contract_caller: Box::new(contract_caller.unwrap()),
         })
     } else {
@@ -466,13 +466,12 @@ pub(crate) fn type_check_method_application(
     let arguments = method
         .parameters
         .iter()
-        .map(|m| m.name.clone())
-        .zip(args_buf)
-        .collect::<Vec<_>>();
+        .map(|m| &m.name)
+        .zip(args_buf.iter());
 
     // unify the types of the arguments with the types of the parameters from the function declaration
     let arguments =
-        unify_arguments_and_parameters(handler, ctx.by_ref(), &arguments, &method.parameters)?;
+        unify_arguments_and_parameters(handler, ctx.by_ref(), arguments, &method.parameters)?;
 
     if ctx.experimental.new_encoding && method.is_contract_call {
         fn call_contract_call(
@@ -643,14 +642,15 @@ pub(crate) fn type_check_method_application(
                 }
                 let implementing_type_parameters = implementing_for.get_type_parameters(engines);
                 if let Some(implementing_type_parameters) = implementing_type_parameters {
-                    for p in method.type_parameters.clone() {
-                        let Some(p) = p.as_type_parameter() else {
+                    for type_param in method.type_parameters.iter() {
+                        let Some(type_param) = type_param.as_type_parameter() else {
                             continue;
                         };
 
-                        if p.is_from_parent {
-                            if let Some(impl_type_param) =
-                                names_index.get(&p.name).and_then(|type_param_index| {
+                        if type_param.is_from_parent {
+                            if let Some(impl_type_param) = names_index
+                                .get(&type_param.name)
+                                .and_then(|type_param_index| {
                                     implementing_type_parameters.get(*type_param_index)
                                 })
                             {
@@ -661,7 +661,7 @@ pub(crate) fn type_check_method_application(
                                     type_engine.unify_with_generic(
                                         handler,
                                         engines,
-                                        p.type_id,
+                                        type_param.type_id,
                                         impl_type_param.type_id,
                                         &call_path.span(),
                                         "Function type parameter does not match up with implementing type type parameter.",
@@ -878,10 +878,10 @@ pub(crate) fn prepare_const_generics_materialization<'a>(
 
 /// Unifies the types of the arguments with the types of the parameters. Returns
 /// a list of the arguments with the names of the corresponding parameters.
-fn unify_arguments_and_parameters(
+fn unify_arguments_and_parameters<'a>(
     handler: &Handler,
     ctx: TypeCheckContext,
-    arguments: &[(BaseIdent, ty::TyExpression)],
+    arguments: impl Iterator<Item = (&'a BaseIdent, &'a ty::TyExpression)>,
     parameters: &[ty::TyFunctionParameter],
 ) -> Result<Vec<(Ident, ty::TyExpression)>, ErrorEmitted> {
     let type_engine = ctx.engines.te();
@@ -889,7 +889,7 @@ fn unify_arguments_and_parameters(
     let mut typed_arguments_and_names = vec![];
 
     handler.scope(|handler| {
-        for ((_, arg), param) in arguments.iter().zip(parameters.iter()) {
+        for ((_, arg), param) in arguments.zip(parameters.iter()) {
             // unify the type of the argument with the type of the param
             let unify_res = handler.scope(|handler| {
                 type_engine.unify_with_generic(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
@@ -13,11 +13,11 @@ pub(crate) fn instantiate_tuple_index_access(
 ) -> Result<ty::TyExpression, ErrorEmitted> {
     let type_engine = engines.te();
 
-    let mut current_prefix_te = Box::new(parent);
-    let mut current_type = type_engine.get_unaliased(current_prefix_te.return_type);
+    let mut current_prefix = Box::new(parent);
+    let mut current_type = type_engine.get_unaliased(current_prefix.return_type);
 
-    let prefix_type_id = current_prefix_te.return_type;
-    let prefix_span = current_prefix_te.span.clone();
+    let prefix_type_id = current_prefix.return_type;
+    let prefix_span = current_prefix.span.clone();
 
     // Create the prefix part of the final tuple element access expression.
     // This might be an expression that directly evaluates to a tuple type,
@@ -33,8 +33,8 @@ pub(crate) fn instantiate_tuple_index_access(
             } => {
                 let referenced_type_id = referenced_type.type_id;
 
-                current_prefix_te = Box::new(ty::TyExpression {
-                    expression: ty::TyExpressionVariant::Deref(current_prefix_te),
+                current_prefix = Box::new(ty::TyExpression {
+                    expression: ty::TyExpressionVariant::Deref(current_prefix),
                     return_type: referenced_type_id,
                     span: prefix_span.clone(),
                 });
@@ -71,8 +71,8 @@ pub(crate) fn instantiate_tuple_index_access(
 
     Ok(ty::TyExpression {
         expression: ty::TyExpressionVariant::TupleElemAccess {
-            resolved_type_of_parent: current_prefix_te.return_type,
-            prefix: current_prefix_te,
+            resolved_type_of_parent: current_prefix.return_type,
+            prefix: current_prefix,
             elem_to_access_num: index,
             elem_to_access_span: index_span,
         },

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -28,14 +28,14 @@ impl ty::TyAstNode {
         ctx: &mut SymbolCollectionContext,
         node: &AstNode,
     ) -> Result<(), ErrorEmitted> {
-        match node.content.clone() {
+        match &node.content {
             AstNodeContent::UseStatement(stmt) => {
-                collect_use_statement(handler, engines, ctx, &stmt);
+                collect_use_statement(handler, engines, ctx, stmt);
             }
             AstNodeContent::IncludeStatement(_i) => (),
             AstNodeContent::Declaration(decl) => ty::TyDecl::collect(handler, engines, ctx, decl)?,
             AstNodeContent::Expression(expr) => {
-                ty::TyExpression::collect(handler, engines, ctx, &expr)?
+                ty::TyExpression::collect(handler, engines, ctx, expr)?
             }
             AstNodeContent::Error(_spans, _err) => (),
         };
@@ -53,16 +53,16 @@ impl ty::TyAstNode {
         let engines = ctx.engines();
 
         let node = ty::TyAstNode {
-            content: match node.content.clone() {
+            content: match &node.content {
                 AstNodeContent::UseStatement(stmt) => {
-                    handle_use_statement(&mut ctx, &stmt, handler);
+                    handle_use_statement(&mut ctx, stmt, handler);
                     ty::TyAstNodeContent::SideEffect(ty::TySideEffect {
                         side_effect: ty::TySideEffectVariant::UseStatement(ty::TyUseStatement {
-                            alias: stmt.alias,
-                            call_path: stmt.call_path,
-                            span: stmt.span,
+                            alias: stmt.alias.clone(),
+                            call_path: stmt.call_path.clone(),
+                            span: stmt.span.clone(),
                             is_relative_to_package_root: stmt.is_relative_to_package_root,
-                            import_type: stmt.import_type,
+                            import_type: stmt.import_type.clone(),
                         }),
                     })
                 }
@@ -70,8 +70,8 @@ impl ty::TyAstNode {
                     ty::TyAstNodeContent::SideEffect(ty::TySideEffect {
                         side_effect: ty::TySideEffectVariant::IncludeStatement(
                             ty::TyIncludeStatement {
-                                mod_name: i.mod_name,
-                                span: i.span,
+                                mod_name: i.mod_name.clone(),
+                                span: i.span.clone(),
                                 visibility: i.visibility,
                             },
                         ),
@@ -94,11 +94,13 @@ impl ty::TyAstNode {
                                 .with_type_annotation(type_engine.new_unknown());
                         }
                     }
-                    let inner = ty::TyExpression::type_check(handler, ctx, &expr)
+                    let inner = ty::TyExpression::type_check(handler, ctx, expr)
                         .unwrap_or_else(|err| ty::TyExpression::error(err, expr.span(), engines));
                     ty::TyAstNodeContent::Expression(inner)
                 }
-                AstNodeContent::Error(spans, err) => ty::TyAstNodeContent::Error(spans, err),
+                AstNodeContent::Error(spans, err) => {
+                    ty::TyAstNodeContent::Error(spans.clone(), *err)
+                }
             },
             span: node.span.clone(),
         };
@@ -144,7 +146,7 @@ fn collect_use_statement(
 
     let _ = match stmt.import_type {
         ImportType::Star => {
-            // try a standard starimport first
+            // try a standard star import first
             let star_import_handler = Handler::default();
             let import = ctx.star_import(&star_import_handler, engines, &path, stmt.reexport);
             if import.is_ok() {

--- a/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
+++ b/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
@@ -463,8 +463,7 @@ impl Items {
                         _,
                     ) => {
                         handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                            name: name.clone(),
-                            span: name.span(),
+                            name: (&name).into(),
                         });
                     }
                     _ => {}
@@ -642,8 +641,7 @@ impl Items {
                         _,
                     ) => {
                         handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                            name: name.clone(),
-                            span: name.span(),
+                            name: (&name).into(),
                         });
                     }
                     // generic parameter shadowing another generic parameter
@@ -778,10 +776,7 @@ impl Items {
         self.symbols
             .get(name)
             .cloned()
-            .ok_or_else(|| CompileError::SymbolNotFound {
-                name: name.clone(),
-                span: name.span(),
-            })
+            .ok_or_else(|| CompileError::SymbolNotFound { name: name.into() })
     }
 
     pub(crate) fn check_symbols_unique_while_collecting_unifications(
@@ -792,10 +787,7 @@ impl Items {
             .read()
             .get(&name.into())
             .cloned()
-            .ok_or_else(|| CompileError::SymbolNotFound {
-                name: name.clone(),
-                span: name.span(),
-            })
+            .ok_or_else(|| CompileError::SymbolNotFound { name: name.into() })
     }
 
     pub(crate) fn clear_symbols_unique_while_collecting_unifications(&self) {

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -358,8 +358,7 @@ impl Module {
         } else {
             // Symbol not found
             Err(handler.emit_err(CompileError::SymbolNotFound {
-                name: symbol.clone(),
-                span: symbol.span(),
+                name: symbol.into(),
             }))
         }
     }

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -805,8 +805,7 @@ impl Namespace {
                         };
                     } else {
                         return Err(handler.emit_err(CompileError::SymbolNotFound {
-                            name: variant_name.clone(),
-                            span: variant_name.span(),
+                            name: variant_name.into(),
                         }));
                     }
                 }
@@ -873,8 +872,7 @@ impl Namespace {
                         };
                     } else {
                         return Err(handler.emit_err(CompileError::SymbolNotFound {
-                            name: variant_name.clone(),
-                            span: variant_name.span(),
+                            name: variant_name.into(),
                         }));
                     }
                 } else {
@@ -947,17 +945,11 @@ impl Namespace {
             }
         } else {
             // Symbol not found
-            return Err(handler.emit_err(CompileError::SymbolNotFound {
-                name: item.clone(),
-                span: item.span(),
-            }));
+            return Err(handler.emit_err(CompileError::SymbolNotFound { name: item.into() }));
         };
 
         if !ignore_visibility && !src_visibility.is_public() {
-            handler.emit_err(CompileError::ImportPrivateSymbol {
-                name: item.clone(),
-                span: item.span(),
-            });
+            handler.emit_err(CompileError::ImportPrivateSymbol { name: item.into() });
         }
 
         Ok((decl, path))

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -386,8 +386,7 @@ impl TraitMap {
                             {
                                 // duplicate method name
                                 handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                                    name: decl_ref.name().clone(),
-                                    span: decl_ref.span(),
+                                    name: decl_ref.name().into(),
                                 });
                             }
                         }
@@ -1523,8 +1522,7 @@ impl TraitMap {
                 },
             )),
             Ordering::Less => Err(handler.emit_err(CompileError::SymbolNotFound {
-                name: symbol.clone(),
-                span: symbol.span(),
+                name: symbol.into(),
             })),
             Ordering::Equal => Ok(candidates.values().next().unwrap().clone()),
         }

--- a/sway-core/src/semantic_analysis/type_resolve.rs
+++ b/sway-core/src/semantic_analysis/type_resolve.rs
@@ -379,8 +379,7 @@ pub fn resolve_call_path(
     // Otherwise, check the visibility modifier
     if !decl.visibility(engines).is_public() && is_self_type == IsSelfType::No {
         handler.emit_err(CompileError::ImportPrivateSymbol {
-            name: call_path.suffix.clone(),
-            span: call_path.suffix.span(),
+            name: (&call_path.suffix).into(),
         });
     }
 
@@ -538,8 +537,7 @@ fn decl_to_type_info(
             }
             _ => {
                 return Err(handler.emit_err(CompileError::SymbolNotFound {
-                    name: symbol.clone(),
-                    span: symbol.span(),
+                    name: symbol.into(),
                 }))
             }
         }),

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -551,12 +551,12 @@ impl GenericTypeParameter {
     pub(crate) fn type_check_type_params(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        generic_params: Vec<TypeParameter>,
-        self_type_param: Option<GenericTypeParameter>,
+        generic_params: &[TypeParameter],
+        self_type_param: Option<&GenericTypeParameter>,
     ) -> Result<Vec<TypeParameter>, ErrorEmitted> {
         let mut new_generic_params: Vec<TypeParameter> = vec![];
 
-        if let Some(self_type_param) = self_type_param.clone() {
+        if let Some(self_type_param) = self_type_param {
             self_type_param.insert_self_type_into_namespace(handler, ctx.by_ref());
         }
 
@@ -652,7 +652,7 @@ impl GenericTypeParameter {
     fn type_check(
         handler: &Handler,
         ctx: TypeCheckContext,
-        type_parameter: GenericTypeParameter,
+        type_parameter: &GenericTypeParameter,
     ) -> Result<TypeParameter, ErrorEmitted> {
         let type_engine = ctx.engines.te();
 
@@ -675,7 +675,7 @@ impl GenericTypeParameter {
             trait_constraints: _,
             parent,
             is_from_type_parameter: _,
-        } = &*type_engine.get(type_id)
+        } = &*type_engine.get(*type_id)
         {
             *parent
         } else {
@@ -686,18 +686,18 @@ impl GenericTypeParameter {
         // This order is required because a trait constraint may depend on its own type parameter.
         let type_id = type_engine.new_unknown_generic(
             name.clone(),
-            VecSet(trait_constraints_with_supertraits.clone()),
+            VecSet(trait_constraints_with_supertraits),
             parent,
             true,
         );
 
         let type_parameter = GenericTypeParameter {
-            name,
+            name: name.clone(),
             type_id,
-            initial_type_id,
-            trait_constraints,
+            initial_type_id: *initial_type_id,
+            trait_constraints: trait_constraints.clone(),
             trait_constraints_span: trait_constraints_span.clone(),
-            is_from_parent,
+            is_from_parent: *is_from_parent,
         };
 
         // Insert the type parameter into the namespace

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -123,7 +123,7 @@ pub enum CompileError {
     #[error("Function \"{name}\" was already defined in scope.")]
     MultipleDefinitionsOfFunction { name: Ident, span: Span },
     #[error("Name \"{name}\" is defined multiple times.")]
-    MultipleDefinitionsOfName { name: Ident, span: Span },
+    MultipleDefinitionsOfName { name: IdentUnique },
     #[error("Constant \"{name}\" was already defined in scope.")]
     MultipleDefinitionsOfConstant { name: Ident, new: Span, old: Span },
     #[error("Type \"{name}\" was already defined in scope.")]
@@ -214,7 +214,7 @@ pub enum CompileError {
     #[error("Cannot pass immutable argument to mutable parameter.")]
     ImmutableArgumentToMutableParameter { span: Span },
     #[error("ref mut or mut parameter is not allowed for contract ABI function.")]
-    RefMutableNotAllowedInContractAbi { param_name: Ident, span: Span },
+    RefMutableNotAllowedInContractAbi { param_name: IdentUnique },
     #[error("Reference to a mutable value cannot reference a constant.")]
     RefMutCannotReferenceConstant {
         /// Constant, as accessed in code. E.g.:
@@ -323,7 +323,7 @@ pub enum CompileError {
         "Enum with name \"{name}\" could not be found in this scope. Perhaps you need to import \
          it?"
     )]
-    EnumNotFound { name: Ident, span: Span },
+    EnumNotFound { name: IdentUnique },
     /// This error is used only for error recovery and is not emitted as a compiler
     /// error to the final compilation output. The compiler emits the cumulative error
     /// [CompileError::StructInstantiationMissingFields] given below, and that one also
@@ -453,7 +453,7 @@ pub enum CompileError {
     #[error("This is a {actually}, not a type alias")]
     DeclIsNotATypeAlias { actually: String, span: Span },
     #[error("Could not find symbol \"{name}\" in this scope.")]
-    SymbolNotFound { name: Ident, span: Span },
+    SymbolNotFound { name: IdentUnique },
     #[error("Found multiple bindings for \"{name}\" in this scope.")]
     SymbolWithMultipleBindings {
         name: Ident,
@@ -461,7 +461,7 @@ pub enum CompileError {
         span: Span,
     },
     #[error("Symbol \"{name}\" is private.")]
-    ImportPrivateSymbol { name: Ident, span: Span },
+    ImportPrivateSymbol { name: IdentUnique },
     #[error("Module \"{name}\" is private.")]
     ImportPrivateModule { name: Ident, span: Span },
     #[error(
@@ -879,7 +879,7 @@ pub enum CompileError {
     #[error(
         "Unrecognized contract ABI method parameter \"{param_name}\". The only available parameters are \"gas\", \"coins\", and \"asset_id\""
     )]
-    UnrecognizedContractParam { param_name: String, span: Span },
+    UnrecognizedContractParam { param_name: IdentUnique },
     #[error("Attempting to specify a contract method parameter for a non-contract function call")]
     CallParamForNonContractCallMethod { span: Span },
     #[error("Storage field \"{field_name}\" does not exist.")]
@@ -1270,7 +1270,7 @@ impl Spanned for CompileError {
             PredicateMainDoesNotReturnBool(span) => span.clone(),
             NoScriptMainFunction(span) => span.clone(),
             MultipleDefinitionsOfFunction { span, .. } => span.clone(),
-            MultipleDefinitionsOfName { span, .. } => span.clone(),
+            MultipleDefinitionsOfName { name } => name.span(),
             MultipleDefinitionsOfConstant { new: span, .. } => span.clone(),
             MultipleDefinitionsOfType { span, .. } => span.clone(),
             MultipleDefinitionsOfMatchArmVariable { duplicate, .. } => duplicate.clone(),
@@ -1281,7 +1281,7 @@ impl Spanned for CompileError {
             AssignmentViaNonMutableReference { span, .. } => span.clone(),
             MutableParameterNotSupported { span, .. } => span.clone(),
             ImmutableArgumentToMutableParameter { span } => span.clone(),
-            RefMutableNotAllowedInContractAbi { span, .. } => span.clone(),
+            RefMutableNotAllowedInContractAbi { param_name } => param_name.span(),
             RefMutCannotReferenceConstant { span, .. } => span.clone(),
             RefMutCannotReferenceImmutableVariable { span, .. } => span.clone(),
             MethodRequiresMutableSelf { span, .. } => span.clone(),
@@ -1312,9 +1312,9 @@ impl Spanned for CompileError {
             NotAStruct { span, .. } => span.clone(),
             NotIndexable { span, .. } => span.clone(),
             FieldAccessOnNonStruct { span, .. } => span.clone(),
-            SymbolNotFound { span, .. } => span.clone(),
+            SymbolNotFound { name } => name.span(),
             SymbolWithMultipleBindings { span, .. } => span.clone(),
-            ImportPrivateSymbol { span, .. } => span.clone(),
+            ImportPrivateSymbol { name } => name.span(),
             ImportPrivateModule { span, .. } => span.clone(),
             NoElseBranch { span, .. } => span.clone(),
             NotAType { span, .. } => span.clone(),
@@ -1412,7 +1412,7 @@ impl Spanned for CompileError {
             AbiAsSupertrait { span, .. } => span.clone(),
             SupertraitImplRequired { span, .. } => span.clone(),
             ContractCallParamRepeated { span, .. } => span.clone(),
-            UnrecognizedContractParam { span, .. } => span.clone(),
+            UnrecognizedContractParam { param_name } => param_name.span(),
             CallParamForNonContractCallMethod { span, .. } => span.clone(),
             StorageFieldDoesNotExist { field_name, .. } => field_name.span(),
             InvalidStorageOnlyTypeDecl { span, .. } => span.clone(),
@@ -1423,7 +1423,7 @@ impl Spanned for CompileError {
             ConvertParseTree { error } => error.span(),
             Lex { error } => error.span(),
             Parse { error } => error.span.clone(),
-            EnumNotFound { span, .. } => span.clone(),
+            EnumNotFound { name } => name.span(),
             TupleIndexOutOfBounds { span, .. } => span.clone(),
             NonConstantDeclValue { span, .. } => span.clone(),
             StorageDeclarationInNonContract { span, .. } => span.clone(),

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -399,7 +399,7 @@ impl Parse for IntrinsicFunctionExpression {
         ctx.tokens.insert(
             ctx.ident(&self.name),
             Token::from_parsed(
-                ParsedAstToken::Intrinsic(self.kind_binding.inner.clone()),
+                ParsedAstToken::Intrinsic(self.kind_binding.inner),
                 SymbolKind::Intrinsic,
             ),
         );


### PR DESCRIPTION
## Description

This PR removes excessive unnecessary cloning of parsed tree elements (parsed declarations and expressions) during type checking.

Removing cloning further reduces compilation time of the `order-book` contract **from ~4.3 to ~4.1 seconds**.

Here is the number of `clone()` calls (taken from the `order-book` contract) for several parsed tree elements, _given just for the highest levels of transformation_:

| Parsed element               | Number of `clone()`s |
| ---------------------------- | -------------------: |
| AstNodeContent               |                23778 |
| VariableDeclaration          |                 9321 |
| ImplSelfOrTrait              |                 1244 |
| ConstantDeclaration          |                  308 |
| StructDeclaration            |                  104 |
| EnumDeclaration              |                   48 |
| TraitDeclaration             |                   43 |
| AbiDeclaration               |                   27 |
| ConfigurableDeclaration      |                   22 |

Note that these is only the cloning at the highest level of transformation from the parsed to typed tree. **Those cloned element or their contained elements were later repeatedly cloned on lower steps, especially parsed `Expression`s.**

When creating final typed tree elements, we still clone some parts of their corresponding parsed tree elements. Those are mostly `Span`s, `Attributes` (only `Arc` clone), and `Indent`s. Removing those clones would require additional changes in the compiler architecture, and at least for cheep clones like `Span`s and `Arc`s it wouldn't bring much. E.g., see: #6602. The goal of this PR was to remove unnecessary double-cloning of parsed elements, where the final (cheeper) clones taken into typed tree were cloned from expensive parsed element clones.

Additionally, the PR:
- removes additional unnecessary `clone()` calls unrelated to cloning of parsed declarations.
- changes `collect` for `Expression` to always bail out on first error. This behavior was inconsistent for different `ExpressionKind`s. We might consider doing it other way around continuing collections on errors, but it must be consistent for all `ExpressionKind`s. (Note that only `TyCodeBlock::collect` actually collects, and always returns `Ok`.)  


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.