### PR TITLE
Extract all perf data from in-language tests run in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,21 +510,21 @@ jobs:
       - name: Forbid Std Unit Tests in sway-lib-std # All `std` tests must live in the in-language tests.
         run: ./sway-lib-std/forbid-tests.sh
       - name: Run In Language Unit Tests (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel
+        run: ./test/src/in_language_tests/run_in_language_tests.sh
       - name: Run In Language Unit Tests (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --release
       - name: Run In Language Unit Tests - ['new_hashing' disabled] (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --no-experimental new_hashing --filter 'hash|sha256|keccak256'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --no-experimental new_hashing --filter 'hash|sha256|keccak256'
       - name: Run In Language Unit Tests - ['new_hashing' disabled] (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release --no-experimental new_hashing --filter 'hash|sha256|keccak256'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --release --no-experimental new_hashing --filter 'hash|sha256|keccak256'
       - name: Run In Language Unit Tests - ['str_array_no_padding' enabled] (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --experimental str_array_no_padding --filter 'str\['
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --experimental str_array_no_padding --filter 'str\['
       - name: Run In Language Unit Tests - ['str_array_no_padding' enabled] (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release --experimental str_array_no_padding --filter 'str\['
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --release --experimental str_array_no_padding --filter 'str\['
       - name: Run In Language Unit Tests - ['dynamic_storage' enabled] (Debug)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --experimental dynamic_storage --filter 'storage'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --experimental dynamic_storage --filter 'storage'
       - name: Run In Language Unit Tests - ['dynamic_storage' enabled] (Release)
-        run: ./test/src/in_language_tests/run_in_language_tests.sh --parallel --release --experimental dynamic_storage --filter 'storage'
+        run: ./test/src/in_language_tests/run_in_language_tests.sh --release --experimental dynamic_storage --filter 'storage'
 
   forc-pkg-fuels-deps-check:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -47,14 +47,23 @@ perf-e2e filter='':
     cargo r -r -p test -- --release --kind e2e --perf-only --perf {{filter}}
 
 alias pil := perf-in-lang
-# collect gas usages from in-language tests
+# collect gas usages and bytecode sizes from in-language tests
 [group('performance')]
 perf-in-lang filter='':
     #!/usr/bin/env bash
     branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); [[ "$branch" == "HEAD" || -z "$branch" ]] && branch="unknown-branch"; branch=${branch//\//-};
-    outfile="./test/perf_out/$(date '+%m%d%H%M%S')-in-language-gas-usages-release-$branch.csv"
-    ./test/src/in_language_tests/run_in_language_tests.sh --release {{filter}} | tee /dev/stderr | ./scripts/perf/extract-gas-usages.sh > "$outfile"
-    echo "Gas usages written to:      $outfile"
+    ts="$(date '+%m%d%H%M%S')"
+    gas_outfile="./test/perf_out/$ts-in-language-gas-usages-release-$branch.csv"
+    size_outfile="./test/perf_out/$ts-in-language-bytecode-sizes-release-$branch.csv"
+    filter_args=(); [[ -n "{{filter}}" ]] && filter_args=(--filter "{{filter}}");
+    # Capture the test run output once and feed it to both extractors, so the
+    # (expensive) test run happens only once.
+    tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+    ./test/src/in_language_tests/run_in_language_tests.sh --print-output "${filter_args[@]}" --release | tee /dev/stderr > "$tmp"
+    ./scripts/perf/extract-gas-usages.sh < "$tmp" > "$gas_outfile"
+    ./scripts/perf/extract-bytecode-sizes.sh < "$tmp" > "$size_outfile"
+    echo "Gas usages written to:      $gas_outfile"
+    echo "Bytecode sizes written to:  $size_outfile"
 
 alias pst := perf-storage
 # run storage benchmarks (storage fields and StorageVec), optionally filtered by project name substring

--- a/scripts/perf/extract-bytecode-sizes.sh
+++ b/scripts/perf/extract-bytecode-sizes.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# This script extracts project names and bytecode sizes from a `forc test` or
+# `forc build` output.
+# The output is a CSV with two columns, project name, and bytecode size in bytes.
+# E.g.: `forc test --release | extract-bytecode-sizes.sh`.
+# If $1 is not empty it will be appended as a new column to the resulting CSV.
+#
+# Only sizes from RELEASE builds are extracted, i.e. from lines of the form:
+#   Finished release [optimized + fuel] target(s) [<size>] in ???
+# (debug builds, `Finished debug ...`, are ignored).
+#
+# The project name for a size is resolved as:
+#   - the project from the preceding `tested -- <project>` line, which
+#     `run_in_language_tests.sh` emits for each project (`forc test` output), or
+#   - if there is none, the project from the last `Compiling <type> <project> ...`
+#     line before the `Finished` line (`forc build` output).
+#
+# Note on sizes: `forc` pretty-prints the size using DECIMAL (base-1000) units, so
+# the printed value is misleading if interpreted as base-1024. For example,
+# `[21.68 KB]` is exactly 21680 bytes (21.68 * 1000), NOT 21.68 * 1024. This script
+# converts the printed value back to the exact byte count.
+
+esc=$'\e'
+ansi_re="$esc\[[0-9;]*[a-zA-Z]"
+
+tested_suite=""
+last_compiling=""
+results=()
+
+while IFS= read -r line; do
+    # Strip ANSI escape sequences (`forc` colorizes its output even when piped).
+    while [[ $line =~ $ansi_re ]]; do
+        line="${line/"${BASH_REMATCH[0]}"/}"
+    done
+
+    if [[ $line =~ ^tested\ --\ ([^[:space:]]+) ]]; then
+        tested_suite="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ $line =~ ^[[:space:]]*Compiling[[:space:]]+[A-Za-z]+[[:space:]]+([^[:space:]]+) ]]; then
+        last_compiling="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ $line =~ Finished[[:space:]]+release[[:space:]].*target\(s\)[[:space:]]+\[([0-9]+(\.[0-9]+)?)[[:space:]]*([A-Za-z]+)?\] ]]; then
+        num="${BASH_REMATCH[1]}"
+        unit="${BASH_REMATCH[3]}"
+
+        # Prefer the `tested --` project (forc test), fall back to the last
+        # `Compiling` project (forc build).
+        suite="$tested_suite"
+        [[ -z "$suite" ]] && suite="$last_compiling"
+
+        # Convert the decimal (base-1000) unit back to an exact byte count.
+        case "$unit" in
+            "" | B) mult=1 ;;
+            KB) mult=1000 ;;
+            MB) mult=1000000 ;;
+            GB) mult=1000000000 ;;
+            TB) mult=1000000000000 ;;
+            *) mult=1 ;;
+        esac
+
+        size="$(LC_ALL=C awk -v n="$num" -v m="$mult" 'BEGIN { printf "%.0f", n * m }')"
+
+        # Only emit a row once we know which project the size belongs to.
+        if [ -n "$suite" ]; then
+            if [ "$1" = "" ]; then
+                results+=("${suite},${size}")
+            else
+                results+=("${suite},${size},$1")
+            fi
+        fi
+
+        # Reset so the next `Finished` line is attributed to its own project.
+        tested_suite=""
+        last_compiling=""
+    fi
+done
+
+printf '%s\n' "${results[@]}" | sort

--- a/sway-lib-std/forbid-tests.sh
+++ b/sway-lib-std/forbid-tests.sh
@@ -19,13 +19,18 @@ cd "$SCRIPT_DIR"
 #
 # We assume that `#[` and `test` always appear on the same line, and treat
 # that as enough to denote a test. Whitespace is allowed anywhere within the
-# attribute (e.g. `#  [   test ]`). The leading `^\s*` anchor also ensures the
-# attribute is not behind a `//` comment, since a comment would put `//`
-# before the `#`.
+# attribute (e.g. `#  [   test ]`). The leading `^[[:space:]]*` anchor also
+# ensures the attribute is not behind a `//` comment, since a comment would
+# put `//` before the `#`.
+#
+# We use the POSIX `[[:space:]]` class rather than the `\s` shorthand: `\s`
+# is a GNU extension that BSD/macOS `grep` does not support, so a pattern
+# using `\s` would silently fail to match (and forbidden tests would slip
+# through) when running this script locally on macOS.
 #
 # `grep` exits with 1 when there are no matches. We invert that here:
 # no matches means no forbidden tests, which is the success case.
-FOUND="$(grep -rn --include='*.sw' -E '^\s*#\s*\[\s*test' src || true)"
+FOUND="$(grep -rn --include='*.sw' -E '^[[:space:]]*#[[:space:]]*\[[[:space:]]*test' src || true)"
 
 if [[ -n "$FOUND" ]]; then
     count="$(printf '%s\n' "$FOUND" | wc -l)"

--- a/test/src/in_language_tests/README.md
+++ b/test/src/in_language_tests/README.md
@@ -9,11 +9,15 @@ the workspace [`Forc.toml`](./Forc.toml).
 Use [`run_in_language_tests.sh`](./run_in_language_tests.sh):
 
 ```sh
-# Run all test projects (concise per-project results; fastest for "do all tests pass?").
-./run_in_language_tests.sh --parallel
+# Run all test projects (parallel by default; concise per-project results, fastest
+# for "do all tests pass?").
+./run_in_language_tests.sh
 
 # Run only the projects matching a regex (matches project dir names and *.sw contents).
-./run_in_language_tests.sh --parallel --filter '^alloc_$'
+./run_in_language_tests.sh --filter '^alloc_$'
+
+# Run sequentially, printing the full `forc test` output as it runs.
+./run_in_language_tests.sh --sequential
 ```
 
 Extra arguments are forwarded to `forc test` (e.g. `--release`, `--experimental ...`).

--- a/test/src/in_language_tests/run_in_language_tests.sh
+++ b/test/src/in_language_tests/run_in_language_tests.sh
@@ -2,7 +2,7 @@
 
 # Run `forc test` individually for each project under test_programs/.
 #
-# Usage: ./run_in_language_tests.sh [--parallel] [--filter REGEX] [extra `forc test` args, e.g. --release --experimental ...]
+# Usage: ./run_in_language_tests.sh [--sequential] [--print-output] [--filter REGEX] [extra `forc test` args, e.g. --release --experimental ...]
 #
 # Note: --error-on-warnings arg is always passed to `forc test`.
 #       When --filter is provided, projects are selected if either:
@@ -10,15 +10,22 @@
 #       - any *.sw file in the project matches REGEX.
 #
 # Run modes:
-#   Default (sequential): projects are run one after another and the full
-#       `forc test` output (compilation and tests output) is printed. This mode
-#       must remain the default because tooling extracts gas costs from this output.
-#   --parallel: projects are run concurrently and only a concise per-project
+#   Default (parallel): projects are run concurrently and only a concise per-project
 #       result is printed (green check mark on success, red cross mark on failure).
-#       The full output of failing projects is printed at the end. Intended for
-#       CI and local "do all tests pass?" checks where speed matters.
-#       Concurrency defaults to half of the available CPU cores (at least 1) and
-#       can be overridden via the PARALLEL_JOBS environment variable.
+#       The full output of failing projects is printed at the end. This is the
+#       default because it is fast, which suits CI and local "do all tests pass?"
+#       checks. Concurrency defaults to half of the available CPU cores (at least 1)
+#       and can be overridden via the PARALLEL_JOBS environment variable.
+#       (For backward compatibility, an explicit `--parallel` is still accepted.)
+#   --sequential: projects are run one after another and the full `forc test` output
+#       (compilation and tests output) is printed as it runs.
+#
+# --print-output: print the full `forc test` output of every project at the end,
+#       in a stable (sorted) order. This makes the otherwise concise --parallel
+#       mode usable for gas-usage extraction: run with `--parallel --print-output`
+#       and pipe the output into `scripts/perf/extract-gas-usages.sh`. In the
+#       default sequential mode the full output is already printed, so this flag
+#       has no additional effect there.
 #
 # The script continues even when individual test projects fail, and exits with
 # a non-zero code at the end if any project failed.
@@ -27,13 +34,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_PROGRAMS_DIR="$SCRIPT_DIR/test_programs"
 
 FILTER_REGEX=""
-PARALLEL=false
+PARALLEL=true
+PRINT_OUTPUT=false
 FORC_TEST_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --sequential)
+            PARALLEL=false
+            shift
+            ;;
         --parallel)
+            # Parallel is now the default; accepted for backward compatibility.
             PARALLEL=true
+            shift
+            ;;
+        --print-output)
+            PRINT_OUTPUT=true
             shift
             ;;
         --filter)
@@ -84,6 +101,25 @@ failed=()
 passed=()
 
 start_time=$SECONDS
+
+# The package name (suite) as printed by `forc test` when run on a workspace.
+# When `forc test` is run on a single package (as this script does, via `--path`),
+# it does NOT print the `tested -- <suite>` line that the gas-usage extraction relies
+# on to prefix test names with their suite. We therefore emit that line ourselves,
+# using the package `name` from `Forc.toml` (falling back to the directory name).
+suite_name() {
+    local project_dir="$1"
+    local project_name="$2"
+    local name
+    name="$(grep -E '^[[:space:]]*name[[:space:]]*=' "$project_dir/Forc.toml" 2>/dev/null \
+        | head -n1 \
+        | sed -E 's/^[[:space:]]*name[[:space:]]*=[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')"
+    if [[ -n "$name" ]]; then
+        printf '%s' "$name"
+    else
+        printf '%s' "$project_name"
+    fi
+}
 
 should_run_project() {
     local project_name="$1"
@@ -168,7 +204,16 @@ if [[ "$PARALLEL" == true ]]; then
         local project_dir="$2"
         local log_file="$logs_dir/$project_name.log"
 
-        if "$FORC" test --error-on-warnings "${FORC_TEST_ARGS[@]}" --path "$project_dir" > "$log_file" 2>&1; then
+        # Emit the `tested -- <suite>` line into the log so it is self-contained and
+        # gas-usage extraction can prefix test names with their suite when the logs
+        # are later printed (see `suite_name` above for why this is needed).
+        {
+            echo ""
+            echo "tested -- $(suite_name "$project_dir" "$project_name")"
+            echo ""
+        } > "$log_file"
+
+        if "$FORC" test --error-on-warnings "${FORC_TEST_ARGS[@]}" --path "$project_dir" >> "$log_file" 2>&1; then
             printf '%b %s\n' "${GREEN}✓${NC}" "$project_name"
             echo "pass" > "$logs_dir/$project_name.status"
         else
@@ -200,8 +245,20 @@ if [[ "$PARALLEL" == true ]]; then
         fi
     done
 
-    # Print the full output of any failing project to aid debugging on CI.
-    if [[ ${#failed[@]} -gt 0 ]]; then
+    if [[ "$PRINT_OUTPUT" == true ]]; then
+        # Print the full output of every project (in stable order) so that the
+        # otherwise concise parallel mode can be piped into gas-usage extraction.
+        # Each log already starts with its `tested -- <suite>` line.
+        echo ""
+        echo "================================================"
+        echo "Full output of all test projects:"
+        echo "================================================"
+        for project_name in "${project_names[@]}"; do
+            echo ""
+            cat "$logs_dir/$project_name.log" 2>/dev/null
+        done
+    elif [[ ${#failed[@]} -gt 0 ]]; then
+        # Print the full output of any failing project to aid debugging on CI.
         echo ""
         echo "================================================"
         echo "Output of failing test projects:"
@@ -213,15 +270,20 @@ if [[ "$PARALLEL" == true ]]; then
         done
     fi
 else
-    # Sequential mode (default): run projects one by one and print the full
-    # `forc test` output. This mode must stay the default because tooling
-    # extracts gas costs from this output.
+    # Sequential mode (opt-in via --sequential): run projects one by one and
+    # print the full `forc test` output as it runs.
     for i in "${!project_names[@]}"; do
         project_name="${project_names[$i]}"
         project_dir="${project_dirs[$i]}"
 
         echo ""
         echo "==> Testing: $project_name"
+
+        # Emit the `tested -- <suite>` line so that gas-usage extraction can prefix
+        # test names with their suite (see `suite_name` above for why this is needed).
+        echo ""
+        echo "tested -- $(suite_name "$project_dir" "$project_name")"
+        echo ""
 
         if "$FORC" test --error-on-warnings "${FORC_TEST_ARGS[@]}" --path "$project_dir"; then
             passed+=("$project_name")


### PR DESCRIPTION
## Description

This PR:
- implements extraction of performance data from in-language tests when they are run in parallel.
- implements extraction of bytecode sizes from in-language tests.
- fixes the `--filter` passing issue in `justfile` discussed in https://github.com/FuelLabs/sway/pull/7669#discussion_r3488023317.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.