### PR TITLE
Removing verify-ir from the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
         run: |
           fuel-core run --db-type in-memory --debug &
           sleep 5 &&
-          cargo run --locked --release --bin test -- --locked --release --verify-ir all --kind e2e
+          cargo run --locked --release --bin test -- --locked --release --kind e2e
 
   # TODO: Remove this upon merging std tests with the rest of the E2E tests.
   cargo-test-lib-std:

--- a/forc-pkg/src/manifest/build_profile.rs
+++ b/forc-pkg/src/manifest/build_profile.rs
@@ -17,8 +17,6 @@ pub struct BuildProfile {
     #[serde(default)]
     pub print_ir: IrCli,
     #[serde(default)]
-    pub verify_ir: IrCli,
-    #[serde(default)]
     pub print_asm: PrintAsm,
     #[serde(default)]
     pub print_bytecode: bool,
@@ -57,7 +55,6 @@ impl BuildProfile {
             print_dca_graph: None,
             print_dca_graph_url_format: None,
             print_ir: IrCli::default(),
-            verify_ir: IrCli::default(),
             print_asm: PrintAsm::default(),
             print_bytecode: false,
             print_bytecode_spans: false,
@@ -81,7 +78,6 @@ impl BuildProfile {
             print_dca_graph: None,
             print_dca_graph_url_format: None,
             print_ir: IrCli::default(),
-            verify_ir: IrCli::default(),
             print_asm: PrintAsm::default(),
             print_bytecode: false,
             print_bytecode_spans: false,
@@ -168,7 +164,6 @@ mod tests {
             print_dca_graph: Some("dca_graph".into()),
             print_dca_graph_url_format: Some("print_dca_graph_url_format".into()),
             print_ir: IrCli::r#final(),
-            verify_ir: IrCli::none(),
             print_asm: PrintAsm::all(),
             print_bytecode: true,
             print_bytecode_spans: false,

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -290,7 +290,6 @@ pub struct DumpOpts {
 pub struct BuildOpts {
     pub pkg: PkgOpts,
     pub print: PrintOpts,
-    pub verify_ir: IrCli,
     pub minify: MinifyOpts,
     pub dump: DumpOpts,
     /// If set, generates a JSON file containing the hex-encoded script binary.
@@ -1582,7 +1581,6 @@ pub fn sway_build_config(
         build_profile.print_bytecode_spans,
     )
     .with_print_ir(build_profile.print_ir.clone())
-    .with_verify_ir(build_profile.verify_ir.clone())
     .with_include_tests(build_profile.include_tests)
     .with_time_phases(build_profile.time_phases)
     .with_profile(build_profile.profile)
@@ -2125,7 +2123,6 @@ fn build_profile_from_opts(
     let BuildOpts {
         pkg,
         print,
-        verify_ir,
         time_phases,
         profile: profile_opt,
         build_profile,
@@ -2165,7 +2162,6 @@ fn build_profile_from_opts(
             .clone_from(&print.dca_graph_url_format);
     }
     profile.print_ir |= print.ir.clone();
-    profile.verify_ir |= verify_ir.clone();
     profile.print_asm |= print.asm;
     profile.print_bytecode |= print.bytecode;
     profile.print_bytecode_spans |= print.bytecode_spans;

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -18,7 +18,7 @@ use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
 use std::str::FromStr;
 use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
-use sway_core::{BuildTarget, IrCli};
+use sway_core::BuildTarget;
 use sway_types::Span;
 use tx::consensus_parameters::ConsensusParametersV1;
 use tx::{ConsensusParameters, ContractParameters, ScriptParameters, TxParameters};
@@ -143,7 +143,6 @@ pub enum PackageWithDeploymentToTest {
 pub struct TestOpts {
     pub pkg: pkg::PkgOpts,
     pub print: pkg::PrintOpts,
-    pub verify_ir: IrCli,
     pub minify: pkg::MinifyOpts,
     /// If set, outputs a binary file representing the script bytes.
     pub binary_outfile: Option<String>,
@@ -518,7 +517,6 @@ impl From<TestOpts> for pkg::BuildOpts {
         pkg::BuildOpts {
             pkg: val.pkg,
             print: val.print,
-            verify_ir: val.verify_ir,
             minify: val.minify,
             dump: DumpOpts::default(),
             binary_outfile: val.binary_outfile,
@@ -546,7 +544,6 @@ impl TestOpts {
         pkg::BuildOpts {
             pkg: self.pkg,
             print: self.print,
-            verify_ir: self.verify_ir,
             minify: self.minify,
             dump: DumpOpts::default(),
             binary_outfile: self.binary_outfile,

--- a/forc/src/cli/commands/contract_id.rs
+++ b/forc/src/cli/commands/contract_id.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::shared::{BuildOutput, BuildProfile, IrCliOpt, Minify, Pkg, Print},
+    cli::shared::{BuildOutput, BuildProfile, Minify, Pkg, Print},
     ops::forc_contract_id,
 };
 use clap::Parser;
@@ -22,8 +22,6 @@ pub struct Command {
     pub minify: Minify,
     #[clap(flatten)]
     pub print: Print,
-    #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(IrCliOpt::cli_options()))]
-    pub verify_ir: Option<Vec<String>>,
     #[clap(flatten)]
     pub build_output: BuildOutput,
     #[clap(flatten)]

--- a/forc/src/cli/commands/predicate_root.rs
+++ b/forc/src/cli/commands/predicate_root.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use forc_util::ForcResult;
 
 pub use crate::cli::shared::{BuildOutput, BuildProfile, Minify, Pkg, Print};
-use crate::{cli::shared::IrCliOpt, ops::forc_predicate_root};
+use crate::ops::forc_predicate_root;
 
 forc_util::cli_examples! {
     crate::cli::Opt {
@@ -21,8 +21,6 @@ pub struct Command {
     pub minify: Minify,
     #[clap(flatten)]
     pub print: Print,
-    #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(IrCliOpt::cli_options()))]
-    pub verify_ir: Option<Vec<String>>,
     #[clap(flatten)]
     pub build_output: BuildOutput,
     #[clap(flatten)]

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -1,4 +1,4 @@
-use crate::cli::{self, shared::IrCliOpt};
+use crate::cli;
 use ansiterm::Colour;
 use clap::Parser;
 use forc_pkg as pkg;
@@ -11,7 +11,7 @@ use forc_util::{
     ForcError, ForcResult,
 };
 use fuel_abi_types::{abi::program::PanickingCall, revert_info::RevertKind};
-use sway_core::{asm_generation::ProgramABI, fuel_prelude::fuel_tx::Receipt, IrCli};
+use sway_core::{asm_generation::ProgramABI, fuel_prelude::fuel_tx::Receipt};
 use tracing::info;
 
 forc_util::cli_examples! {
@@ -379,11 +379,6 @@ fn opts_from_cmd(cmd: Command) -> forc_test::TestOpts {
             ir: cmd.build.print.ir(),
             reverse_order: cmd.build.print.reverse_order,
         },
-        verify_ir: cmd
-            .build
-            .verify_ir
-            .as_ref()
-            .map_or(IrCli::default(), |opts| IrCliOpt::from(opts).0),
         time_phases: cmd.build.print.time_phases,
         profile: cmd.build.print.profile,
         metrics_outfile: cmd.build.print.metrics_outfile,

--- a/forc/src/cli/shared.rs
+++ b/forc/src/cli/shared.rs
@@ -82,16 +82,6 @@ pub struct Build {
     pub pkg: Pkg,
     #[clap(flatten)]
     pub print: Print,
-    /// Verify the generated Sway IR (Intermediate Representation).
-    ///
-    /// Values that can be combined:
-    ///  - initial:     initial IR prior to any optimization passes.
-    ///  - final:       final IR after applying all optimization passes.
-    ///  - <pass name>: the name of an optimization pass. Verifies the IR state after that pass.
-    ///  - all:         short for initial, final, and all the optimization passes.
-    ///  - modified:    verify a requested optimization pass only if it has modified the IR.
-    #[arg(long, verbatim_doc_comment, num_args(1..=IrCliOpt::max_num_args()), value_parser = clap::builder::PossibleValuesParser::new(IrCliOpt::cli_options()))]
-    pub verify_ir: Option<Vec<String>>,
     #[clap(flatten)]
     pub minify: Minify,
     #[clap(flatten)]

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -1,8 +1,7 @@
-use crate::cli::{shared::IrCliOpt, BuildCommand};
+use crate::cli::BuildCommand;
 use forc_pkg as pkg;
 use forc_util::ForcResult;
 use pkg::MemberFilter;
-use sway_core::IrCli;
 
 pub fn build(cmd: BuildCommand) -> ForcResult<pkg::Built> {
     let opts = opts_from_cmd(cmd);
@@ -30,11 +29,6 @@ fn opts_from_cmd(cmd: BuildCommand) -> pkg::BuildOpts {
             ir: cmd.build.print.ir(),
             reverse_order: cmd.build.print.reverse_order,
         },
-        verify_ir: cmd
-            .build
-            .verify_ir
-            .as_ref()
-            .map_or(IrCli::default(), |opts| IrCliOpt::from(opts).0),
         dump: pkg::DumpOpts {
             dump_impls: cmd.build.dump.dump_impls,
         },

--- a/forc/src/ops/forc_contract_id.rs
+++ b/forc/src/ops/forc_contract_id.rs
@@ -1,8 +1,8 @@
-use crate::cli::{shared::IrCliOpt, ContractIdCommand};
+use crate::cli::ContractIdCommand;
 use anyhow::{bail, Result};
 use forc_pkg::{self as pkg, build_with_options, DumpOpts};
 use forc_tracing::println_green;
-use sway_core::{fuel_prelude::fuel_tx, BuildTarget, IrCli};
+use sway_core::{fuel_prelude::fuel_tx, BuildTarget};
 use tracing::info;
 
 pub fn contract_id(command: ContractIdCommand) -> Result<()> {
@@ -63,10 +63,6 @@ fn build_opts_from_cmd(cmd: &ContractIdCommand) -> pkg::BuildOpts {
             ir: cmd.print.ir(),
             reverse_order: cmd.print.reverse_order,
         },
-        verify_ir: cmd
-            .verify_ir
-            .as_ref()
-            .map_or(IrCli::default(), |opts| IrCliOpt::from(opts).0),
         dump: DumpOpts::default(),
         time_phases: cmd.print.time_phases,
         profile: cmd.print.profile,

--- a/forc/src/ops/forc_predicate_root.rs
+++ b/forc/src/ops/forc_predicate_root.rs
@@ -1,7 +1,7 @@
-use crate::cli::{shared::IrCliOpt, PredicateRootCommand};
+use crate::cli::PredicateRootCommand;
 use anyhow::Result;
 use forc_pkg::{self as pkg, build_with_options, DumpOpts};
-use sway_core::{BuildTarget, IrCli};
+use sway_core::BuildTarget;
 
 pub fn predicate_root(command: PredicateRootCommand) -> Result<()> {
     let build_options = build_opts_from_cmd(command);
@@ -32,10 +32,6 @@ fn build_opts_from_cmd(cmd: PredicateRootCommand) -> pkg::BuildOpts {
             ir: cmd.print.ir(),
             reverse_order: cmd.print.reverse_order,
         },
-        verify_ir: cmd
-            .verify_ir
-            .as_ref()
-            .map_or(IrCli::default(), |opts| IrCliOpt::from(opts).0),
         dump: DumpOpts::default(),
         time_phases: cmd.print.time_phases,
         profile: cmd.print.profile,

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -237,7 +237,6 @@ pub struct BuildConfig {
     pub(crate) print_bytecode: bool,
     pub(crate) print_bytecode_spans: bool,
     pub(crate) print_ir: IrCli,
-    pub(crate) verify_ir: IrCli,
     pub(crate) include_tests: bool,
     pub(crate) optimization_level: OptLevel,
     pub(crate) backtrace: Backtrace,
@@ -289,7 +288,6 @@ impl BuildConfig {
             print_bytecode: false,
             print_bytecode_spans: false,
             print_ir: IrCli::default(),
-            verify_ir: IrCli::default(),
             include_tests: false,
             time_phases: false,
             profile: false,
@@ -340,13 +338,6 @@ impl BuildConfig {
     pub fn with_print_ir(self, a: IrCli) -> Self {
         Self {
             print_ir: a,
-            ..self
-        }
-    }
-
-    pub fn with_verify_ir(self, a: IrCli) -> Self {
-        Self {
-            verify_ir: a,
             ..self
         }
     }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -65,8 +65,8 @@ use sway_error::warning::{CollectedTraitImpl, CompileInfo, CompileWarning, Info,
 use sway_features::ExperimentalFeatures;
 use sway_ir::{
     create_o1_pass_group, register_known_passes, Context, Kind, Module, PassGroup, PassManager,
-    PrintPassesOpts, VerifyPassesOpts, ARG_DEMOTION_NAME, ARG_POINTEE_MUTABILITY_TAGGER_NAME,
-    CONST_DEMOTION_NAME, DCE_NAME, FN_DEDUP_DEBUG_PROFILE_NAME, FN_INLINE_NAME, GLOBALS_DCE_NAME,
+    PrintPassesOpts, ARG_DEMOTION_NAME, ARG_POINTEE_MUTABILITY_TAGGER_NAME, CONST_DEMOTION_NAME,
+    DCE_NAME, FN_DEDUP_DEBUG_PROFILE_NAME, FN_INLINE_NAME, GLOBALS_DCE_NAME,
     INIT_AGGR_LOWERING_NAME, MEM2REG_NAME, MEMCPYOPT_NAME, MEMCPYPROP_REVERSE_NAME,
     MISC_DEMOTION_NAME, RET_DEMOTION_NAME, SIMPLIFY_CFG_NAME, SROA_NAME,
 };
@@ -1615,13 +1615,9 @@ pub(crate) fn compile_ast_to_ir_to_asm(
 
     // Run the passes.
     let print_passes_opts: PrintPassesOpts = (&build_config.print_ir).into();
-    let verify_passes_opts: VerifyPassesOpts = (&build_config.verify_ir).into();
-    let res = if let Err(ir_error) = pass_mgr.run_with_print_verify(
-        &mut ir,
-        &pass_group,
-        &print_passes_opts,
-        &verify_passes_opts,
-    ) {
+    let res = if let Err(ir_error) =
+        pass_mgr.run_with_print_verify(&mut ir, &pass_group, &print_passes_opts)
+    {
         Err(handler.emit_err(CompileError::InternalOwned(
             ir_error.to_string(),
             span::Span::dummy(),

--- a/sway-ir/src/optimize/arg_demotion.rs
+++ b/sway-ir/src/optimize/arg_demotion.rs
@@ -219,6 +219,24 @@ fn demote_caller(
 }
 
 fn demote_block_signature(context: &mut Context, function: &Function, block: Block) -> bool {
+    // Do no demote if there is a never involved
+    if block
+        .arg_iter(context)
+        .any(|arg| arg.get_type(context).unwrap().is_never(context))
+    {
+        return false;
+    }
+
+    let preds = block.pred_iter(context).copied().collect::<Vec<Block>>();
+    for pred in preds {
+        for arg_val in pred.get_succ_params(context, &block) {
+            if arg_val.get_type(context).unwrap().is_never(context) {
+                return false;
+            }
+        }
+    }
+
+    // demote as normal now
     let candidate_args = block
         .arg_iter(context)
         .enumerate()

--- a/sway-ir/src/pass_manager.rs
+++ b/sway-ir/src/pass_manager.rs
@@ -372,21 +372,19 @@ impl PassManager {
     }
 
     /// Run the `passes` and return true if the `passes` modify the initial `ir`.
-    /// The IR states are printed and verified according to the options provided.
+    /// The IR states are printed according to the options provided and verified.
     pub fn run_with_print_verify(
         &mut self,
         ir: &mut Context,
         passes: &PassGroup,
         print_opts: &PrintPassesOpts,
-        verify_opts: &VerifyPassesOpts,
     ) -> Result<bool, IrError> {
         if print_opts.initial {
             print_initial_or_final_ir(ir, "Initial");
         }
 
-        if verify_opts.initial {
-            ir.verify()?;
-        }
+        // Verify before we start
+        ir.verify()?;
 
         let mut global_modified = false;
 
@@ -422,14 +420,9 @@ impl PassManager {
                     print_ir_after_pass(ir, self.lookup_registered_pass(pass).unwrap());
                 }
 
-                if verify_opts.passes.contains(pass) && (!verify_opts.modified_only || modified) {
-                    ir.verify()?;
-                }
+                ir.verify()?;
 
                 if force_verify {
-                    // Verify IR
-                    ir.verify()?;
-
                     // Verify pass correctly return modified
                     let ir_modified = ir_before != ir_after;
                     if modified != ir_modified {
@@ -450,10 +443,6 @@ impl PassManager {
 
         if print_opts.r#final {
             print_initial_or_final_ir(ir, "Final");
-        }
-
-        if verify_opts.r#final {
-            ir.verify()?;
         }
 
         Ok(global_modified)

--- a/sway-types/src/u256.rs
+++ b/sway-types/src/u256.rs
@@ -69,15 +69,13 @@ impl std::fmt::Display for U256 {
 
 impl std::fmt::LowerHex for U256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = self.0.to_str_radix(16);
-        write!(f, "{}{}", "0".repeat(64 - s.len()), s)
+        write!(f, "{:064x}", self.0)
     }
 }
 
 impl std::fmt::UpperHex for U256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = self.0.to_str_radix(16);
-        write!(f, "{}{}", "0".repeat(64 - s.len()), s.to_uppercase())
+        write!(f, "{:064X}", self.0)
     }
 }
 
@@ -164,4 +162,11 @@ impl std::ops::Not for &U256 {
         bytes.iter_mut().for_each(|b| *b = !*b);
         U256(BigUint::from_bytes_be(&bytes))
     }
+}
+
+#[test]
+fn to_hex_display_must_always_have_64_chars() {
+    let v = U256::from_be_bytes(&[0u8; 32]);
+    assert_eq!(format!("{v:x}").len(), 64);
+    assert_eq!(format!("{v:X}").len(), 64);
 }

--- a/sway-types/src/u256.rs
+++ b/sway-types/src/u256.rs
@@ -69,13 +69,15 @@ impl std::fmt::Display for U256 {
 
 impl std::fmt::LowerHex for U256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:x}", self.0)
+        let s = self.0.to_str_radix(16);
+        write!(f, "{}{}", "0".repeat(64 - s.len()), s)
     }
 }
 
 impl std::fmt::UpperHex for U256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:X}", self.0)
+        let s = self.0.to_str_radix(16);
+        write!(f, "{}{}", "0".repeat(64 - s.len()), s.to_uppercase())
     }
 }
 

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -290,7 +290,6 @@ pub(crate) async fn compile_to_bytes(
             ir: run_config.print_ir.clone(),
             reverse_order: false,
         },
-        verify_ir: run_config.verify_ir.clone(),
         pkg: forc_pkg::PkgOpts {
             path: Some(root.clone()),
             locked: run_config.locked,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref/stdout.snap
@@ -181,11 +181,11 @@ script {
         v180v1 = get_local __ptr { { u64 } }, args, !147
         v181v1 = const u64 0
         v182v1 = get_elem_ptr v180v1, __ptr { u64 }, v181v1, !148
-        v869v1 = get_local __ptr { u64 }, __tmp_arg
-        mem_copy_val v869v1, v182v1
-        v871v1 = call main_15(v869v1)
+        v867v1 = get_local __ptr { u64 }, __tmp_arg
+        mem_copy_val v867v1, v182v1
+        v869v1 = call main_15(v867v1)
         v185v1 = get_local __ptr u64, _result, !149
-        store v871v1 to v185v1, !149
+        store v869v1 to v185v1, !149
         v204v1 = get_local __ptr u64, _result, !150
         v205v3 = get_local __ptr __ptr u64, item_, !153
         store v204v1 to v205v3, !153

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/snapshot.toml
@@ -1,3 +1,4 @@
 cmds = [
+    "echo unwrap_84 should not show never as one of its block arguments",
     "forc build --path {root} --ir final --asm final | filter-fn {name} unwrap_84"
 ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/snapshot.toml
@@ -1,0 +1,3 @@
+cmds = [
+    "forc build --path {root} --ir final --asm final | filter-fn {name} unwrap_84"
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/stdout.snap
@@ -1,0 +1,62 @@
+---
+source: test/src/snapshot/mod.rs
+---
+> forc build --path test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage --ir final --asm final | filter-fn basic_storage unwrap_84
+
+pub fn unwrap_84(mut self: __ptr { u64, ( () | b256 ) }, mut __ret_value: __ptr b256) -> () {
+    local { u64, ( () | b256 ) } __matched_value_4
+    local u64 code_
+    local u64 other_
+
+    entry(mut self: __ptr { u64, ( () | b256 ) }, mut __ret_value: __ptr b256):
+    v7349v1 = get_local __ptr { u64, ( () | b256 ) }, __matched_value_4
+    mem_copy_val v7349v1, self
+    v7351v1 = const u64 0
+    v7352v1 = get_elem_ptr self, __ptr u64, v7351v1
+    v7353v1 = get_local __ptr u64, other_
+    v7354v1 = const u64 1
+    store v7354v1 to v7353v1
+    v7356v1 = load v7352v1
+    v7357v1 = get_local __ptr u64, other_
+    v7358v1 = load v7357v1
+    v7359v1 = cmp eq v7356v1 v7358v1
+    cbr v7359v1, block0(), block1()
+
+    block0():
+    v7361v1 = get_local __ptr { u64, ( () | b256 ) }, __matched_value_4
+    v7362v1 = const u64 1
+    v7363v1 = const u64 1
+    v7364v1 = get_elem_ptr v7361v1, __ptr b256, v7362v1, v7363v1
+    mem_copy_val __ret_value, v7364v1
+    v7366v1 = const unit ()
+    ret () v7366v1
+
+    block1():
+    v7368v1 = get_local __ptr u64, code_
+    v7369v1 = const u64 0
+    store v7369v1 to v7368v1
+    v7371v1 = get_local __ptr u64, code_
+    v7372v1 = load v7371v1
+    revert v7372v1
+}
+
+
+
+
+pshh i530432                  ; [fn init: unwrap_84]: push used high registers 40..64
+move $$locbase $sp            ; [fn init: unwrap_84]: set locals base register
+cfei i56                      ; [fn init: unwrap_84]: allocate: locals 56 byte(s), call args 0 slot(s)
+mcpi $$locbase $$arg0 i40     ; copy memory
+sw   $$locbase $one i6        ; store word
+lw   $r0 $$arg0 i0            ; load word
+lw   $r1 $$locbase i6         ; load word
+eq   $r0 $r0 $r1
+jnzf $r0 $zero i3
+sw   $$locbase $zero i5       ; store word
+lw   $r0 $$locbase i5         ; load word
+rvrt $r0
+addi $r0 $$locbase i8         ; get offset to aggregate element
+mcpi $$arg1 $r0 i32           ; copy memory
+cfsi i56                      ; [fn end: unwrap_84] free: locals 56 byte(s), call args 0 slot(s)
+poph i530432                  ; [fn end: unwrap_84]: restore used high registers 40..64
+jal  $zero $$reta i0          ; [fn end: unwrap_84] return from call

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/stdout.snap
@@ -1,6 +1,8 @@
 ---
 source: test/src/snapshot/mod.rs
 ---
+unwrap_84 should not show never as one of its block arguments
+
 > forc build --path test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage --ir final --asm final | filter-fn basic_storage unwrap_84
 
 pub fn unwrap_84(mut self: __ptr { u64, ( () | b256 ) }, mut __ret_value: __ptr b256) -> () {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/stdout.snap
@@ -11,35 +11,35 @@ pub fn unwrap_84(mut self: __ptr { u64, ( () | b256 ) }, mut __ret_value: __ptr 
     local u64 other_
 
     entry(mut self: __ptr { u64, ( () | b256 ) }, mut __ret_value: __ptr b256):
-    v7349v1 = get_local __ptr { u64, ( () | b256 ) }, __matched_value_4
-    mem_copy_val v7349v1, self
-    v7351v1 = const u64 0
-    v7352v1 = get_elem_ptr self, __ptr u64, v7351v1
-    v7353v1 = get_local __ptr u64, other_
-    v7354v1 = const u64 1
-    store v7354v1 to v7353v1
-    v7356v1 = load v7352v1
-    v7357v1 = get_local __ptr u64, other_
-    v7358v1 = load v7357v1
-    v7359v1 = cmp eq v7356v1 v7358v1
-    cbr v7359v1, block0(), block1()
+    v7334v1 = get_local __ptr { u64, ( () | b256 ) }, __matched_value_4
+    mem_copy_val v7334v1, self
+    v7336v1 = const u64 0
+    v7337v1 = get_elem_ptr self, __ptr u64, v7336v1
+    v7338v1 = get_local __ptr u64, other_
+    v7339v1 = const u64 1
+    store v7339v1 to v7338v1
+    v7341v1 = load v7337v1
+    v7342v1 = get_local __ptr u64, other_
+    v7343v1 = load v7342v1
+    v7344v1 = cmp eq v7341v1 v7343v1
+    cbr v7344v1, block0(), block1()
 
     block0():
-    v7361v1 = get_local __ptr { u64, ( () | b256 ) }, __matched_value_4
-    v7362v1 = const u64 1
-    v7363v1 = const u64 1
-    v7364v1 = get_elem_ptr v7361v1, __ptr b256, v7362v1, v7363v1
-    mem_copy_val __ret_value, v7364v1
-    v7366v1 = const unit ()
-    ret () v7366v1
+    v7346v1 = get_local __ptr { u64, ( () | b256 ) }, __matched_value_4
+    v7347v1 = const u64 1
+    v7348v1 = const u64 1
+    v7349v1 = get_elem_ptr v7346v1, __ptr b256, v7347v1, v7348v1
+    mem_copy_val __ret_value, v7349v1
+    v7351v1 = const unit ()
+    ret () v7351v1
 
     block1():
-    v7368v1 = get_local __ptr u64, code_
-    v7369v1 = const u64 0
-    store v7369v1 to v7368v1
-    v7371v1 = get_local __ptr u64, code_
-    v7372v1 = load v7371v1
-    revert v7372v1
+    v7353v1 = get_local __ptr u64, code_
+    v7354v1 = const u64 0
+    store v7354v1 to v7353v1
+    v7356v1 = get_local __ptr u64, code_
+    v7357v1 = load v7356v1
+    revert v7357v1
 }
 
 

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -84,10 +84,6 @@ struct Cli {
     #[arg(long, num_args(1..=18), value_parser = clap::builder::PossibleValuesParser::new(IrCliOpt::cli_options()))]
     print_ir: Option<Vec<String>>,
 
-    /// Verify the generated Sway IR (Intermediate Representation).
-    #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(IrCliOpt::cli_options()))]
-    verify_ir: Option<Vec<String>>,
-
     /// Print out the specified ASM (separate options with comma), if the verbose option is on
     ///
     /// This option is ignored if tests are run in parallel.
@@ -219,7 +215,6 @@ pub struct RunConfig {
     pub release: bool,
     pub update_output_files: bool,
     pub print_ir: IrCli,
-    pub verify_ir: IrCli,
     pub print_asm: PrintAsm,
     pub print_bytecode: bool,
     pub experimental: sway_features::CliFields,
@@ -263,10 +258,6 @@ async fn main() -> Result<()> {
             build_target,
             experimental: cli.experimental,
             update_output_files: cli.update_output_files,
-            verify_ir: cli
-                .verify_ir
-                .as_ref()
-                .map_or(IrCli::default(), |opts| IrCliOpt::from(opts).0),
             perf: cli.perf,
             // Always use the built-in gas costs values when running tests in parallel.
             gas_costs_values: GasCostsSource::BuiltIn.provide_gas_costs()?,
@@ -313,10 +304,6 @@ async fn main() -> Result<()> {
         update_output_files: cli.update_output_files,
         print_ir: cli
             .print_ir
-            .as_ref()
-            .map_or(IrCli::default(), |opts| IrCliOpt::from(opts).0),
-        verify_ir: cli
-            .verify_ir
             .as_ref()
             .map_or(IrCli::default(), |opts| IrCliOpt::from(opts).0),
         print_asm: cli

--- a/test/src/snapshot/mod.rs
+++ b/test/src/snapshot/mod.rs
@@ -265,9 +265,12 @@ fn run_cmds(
                             let mut inside_asm = false;
                             let mut capture_line = false;
 
-                            let compiling_project_line = format!("Compiling script {name}");
+                            let compiling_script_line = format!("Compiling script {name}");
+                            let compiling_contract_line = format!("Compiling contract {name}");
                             for line in output.lines() {
-                                if line.contains(&compiling_project_line) {
+                                if line.contains(&compiling_script_line)
+                                    || line.contains(&compiling_contract_line)
+                                {
                                     inside_ir = true;
                                 }
 


### PR DESCRIPTION
## Description

This PR removes "verify-ir" from the CLI, because we now run verify after each optimization pass. The performance impact seems to be minimal and it is well worthy the extra security it brings.

This brought to attention a problem that the pass "arg-demotion" had with blocks with "never" as arguments. A better fix will be pushed later, but for now, the pass does not generate a miscompilation anymore.

Otehr smal fixes were "filter-fn" not working with contracts, and the IR printer not correctly printings storage key address with 64 characters when they start with zero.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
