### PR TITLE
make IR snapshot fail only at the end of all comparisons

### DIFF
--- a/sway-ir/tests/cse/cse3.ir.snap
+++ b/sway-ir/tests/cse/cse3.ir.snap
@@ -10,7 +10,7 @@ script {
         v6v1 = const u64 0
         br while(v6v1, v5v1)
 
-        while(mut v3v1: u64, mut v4v1: u64):
+        while(v3v1: u64, v4v1: u64):
 -         v8v1 = cmp lt v3v1 v4v1
 +         v8v1 = cmp lt v3v1 v5v1
         cbr v8v1, while_body(), end_while()

--- a/sway-ir/tests/dce/dce_cast_ptr.ir.snap
+++ b/sway-ir/tests/dce/dce_cast_ptr.ir.snap
@@ -27,7 +27,7 @@ script {
         entry(mut arg: u64):
         br block0(arg)
 
-        block0(mut v12v1: __ptr u64):
+        block0(v12v1: __ptr u64):
         v14v1 = load v12v1
         ret u64 v14v1
     }

--- a/sway-ir/tests/dce/dce_dead_arg1.ir.snap
+++ b/sway-ir/tests/dce/dce_dead_arg1.ir.snap
@@ -12,7 +12,7 @@ script {
 -         br block0(v4v1)
 +         br block0()
 
--         block0(mut v1v1: bool):
+-         block0(v1v1: bool):
 +         block0():
         v6v1 = const bool false
 -         v7v1 = cmp eq v1v1 v6v1

--- a/sway-ir/tests/dce/dce_int_to_ptr.ir.snap
+++ b/sway-ir/tests/dce/dce_int_to_ptr.ir.snap
@@ -35,7 +35,7 @@ script {
         v20v1 = ptr_to_int v19v1 to u64
         br block2(v20v1)
 
-        block2(mut v1v1: u64):
+        block2(v1v1: u64):
         v22v1 = int_to_ptr v1v1 to __ptr u64
         v23v1 = const u64 42
         store v23v1 to v22v1

--- a/sway-ir/tests/demote_arg/demote_arg03.ir.snap
+++ b/sway-ir/tests/demote_arg/demote_arg03.ir.snap
@@ -49,9 +49,9 @@ script {
 +         store v21v1 to v31v1
 +         br block2(v31v1)
 
--         block2(mut v14v1: b256):
+-         block2(v14v1: b256):
 -         ret b256 v14v1
-+         block2(mut v27v1: __ptr b256):
++         block2(v27v1: __ptr b256):
 +         v28v1 = load v27v1
 +         ret b256 v28v1
     }

--- a/sway-ir/tests/demote_arg/demote_arg04.ir.snap
+++ b/sway-ir/tests/demote_arg/demote_arg04.ir.snap
@@ -38,26 +38,26 @@ script {
 -         cbr v16v1, block1(v9v1, v17v1, v11v1), block2(v13v1, v17v1, v15v1)
 +         cbr v16v1, block1(v30v1, v17v1, v32v1), block2(v38v1, v17v1, v40v1)
 
--         block1(mut v1v1: b256, mut v2v1: bool, mut v3v1: b256):
+-         block1(v1v1: b256, v2v1: bool, v3v1: b256):
 -         br block3(v3v1)
-+         block1(mut v26v1: __ptr b256, mut v2v1: bool, mut v28v1: __ptr b256):
++         block1(v26v1: __ptr b256, v2v1: bool, v28v1: __ptr b256):
 +         v27v1 = load v26v1
 +         v29v1 = load v28v1
 +         v44v1 = get_local __ptr b256, __tmp_block_arg3
 +         store v29v1 to v44v1
 +         br block3(v44v1)
 
--         block2(mut v4v1: b256, mut v5v1: bool, mut v6v1: b256):
+-         block2(v4v1: b256, v5v1: bool, v6v1: b256):
 -         br block3(v6v1)
-+         block2(mut v34v1: __ptr b256, mut v5v1: bool, mut v36v1: __ptr b256):
++         block2(v34v1: __ptr b256, v5v1: bool, v36v1: __ptr b256):
 +         v35v1 = load v34v1
 +         v37v1 = load v36v1
 +         v46v1 = get_local __ptr b256, __tmp_block_arg3
 +         store v37v1 to v46v1
 +         br block3(v46v1)
 
--         block3(mut v7v1: b256):
-+         block3(mut v42v1: __ptr b256):
+-         block3(v7v1: b256):
++         block3(v42v1: __ptr b256):
 +         v43v1 = load v42v1
         v21v1 = get_local __ptr b256, tmp
 -         store v7v1 to v21v1

--- a/sway-ir/tests/demote_ret/demote_ret01.ir.snap
+++ b/sway-ir/tests/demote_ret/demote_ret01.ir.snap
@@ -59,7 +59,7 @@ script {
 +         v49v1 = load v47v1
 +         br block5(v49v1)
 
-        block5(mut v10v1: b256):
+        block5(v10v1: b256):
 -         ret b256 v10v1
 +         store v10v1 to __ret_value
 +         v28v1 = const unit ()

--- a/sway-ir/tests/fn_dedup/debug/debug-dce.ir.snap
+++ b/sway-ir/tests/fn_dedup/debug/debug-dce.ir.snap
@@ -18,7 +18,7 @@ script {
         v8v1 = call foo_3(v6v1, v7v1), !8
         br block1(v8v1), !5
 
-        block1(mut v1v1: bool):
+        block1(v1v1: bool):
         ret bool v1v1
     }
 

--- a/sway-ir/tests/fn_dedup/debug/debug-nodce.ir.snap
+++ b/sway-ir/tests/fn_dedup/debug/debug-nodce.ir.snap
@@ -17,7 +17,7 @@ script {
         v8v1 = call foo_3(v6v1, v7v1), !8
         br block1(v8v1), !5
 
-        block1(mut v1v1: bool):
+        block1(v1v1: bool):
         ret bool v1v1
     }
 

--- a/sway-ir/tests/fn_dedup/release/release-dce.ir.snap
+++ b/sway-ir/tests/fn_dedup/release/release-dce.ir.snap
@@ -18,7 +18,7 @@ script {
         v8v1 = call foo_3(v6v1, v7v1), !8
         br block1(v8v1), !5
 
-        block1(mut v1v1: bool):
+        block1(v1v1: bool):
         ret bool v1v1
     }
 

--- a/sway-ir/tests/inline/bigger.ir.snap
+++ b/sway-ir/tests/inline/bigger.ir.snap
@@ -22,7 +22,7 @@ script {
         v10v1 = const u64 1
         br block2(v10v1)
 
-        block2(mut v2v1: u64):
+        block2(v2v1: u64):
         ret u64 v2v1
     }
 

--- a/sway-ir/tests/inline/by_block_and_instr_count.ir.snap
+++ b/sway-ir/tests/inline/by_block_and_instr_count.ir.snap
@@ -9,7 +9,7 @@ script {
         v2v1 = const bool true
         br block(v2v1)
 
-        block(mut v1v1: bool):
+        block(v1v1: bool):
         v4v1 = const bool false
         v5v1 = cmp eq v1v1 v4v1
         v6v1 = cmp eq v4v1 v5v1
@@ -21,7 +21,7 @@ script {
         v9v1 = const bool true
         br block(v9v1)
 
-        block(mut v8v1: bool):
+        block(v8v1: bool):
         v11v1 = const bool false
         v12v1 = cmp eq v8v1 v11v1
         v13v1 = cmp eq v11v1 v12v1

--- a/sway-ir/tests/inline/by_block_count.ir.snap
+++ b/sway-ir/tests/inline/by_block_count.ir.snap
@@ -15,7 +15,7 @@ script {
         v4v1 = const bool true
         br block(v4v1)
 
-        block(mut v3v1: bool):
+        block(v3v1: bool):
         ret bool v3v1
     }
 

--- a/sway-ir/tests/inline/by_instr_count.ir.snap
+++ b/sway-ir/tests/inline/by_instr_count.ir.snap
@@ -15,7 +15,7 @@ script {
         v4v1 = const u64 22
         br block(v4v1)
 
-        block(mut v3v1: u64):
+        block(v3v1: u64):
         ret u64 v3v1
     }
 
@@ -59,7 +59,7 @@ script {
         v32v1 = cmp eq v30v1 v31v1
         br block(v32v1)
 
-        block(mut v23v1: bool):
+        block(v23v1: bool):
         ret bool v23v1
     }
 

--- a/sway-ir/tests/inline/fiddly.ir.snap
+++ b/sway-ir/tests/inline/fiddly.ir.snap
@@ -16,7 +16,7 @@ script {
         v6v1 = const bool true
         br block2(v6v1)
 
-        block2(mut v2v1: bool):
+        block2(v2v1: bool):
         ret bool v2v1
     }
 
@@ -41,7 +41,7 @@ script {
 +         block01(mut v18v1: bool):
 +         cbr v18v1, block1(v18v1), block0(v18v1)
 + 
-        block0(mut v9v1: bool):
+        block0(v9v1: bool):
         v14v1 = const bool false
 -         v15v1 = call not(v14v1)
 -         br block1(v15v1)
@@ -59,7 +59,7 @@ script {
 +         block2(mut v23v1: bool):
 +         br block1(v23v1)
 + 
-        block1(mut v10v1: bool):
+        block1(v10v1: bool):
         ret bool v10v1
     }
 }

--- a/sway-ir/tests/mem2reg/is_prime.ir.snap
+++ b/sway-ir/tests/mem2reg/is_prime.ir.snap
@@ -92,7 +92,7 @@ script {
         v78v1 = const unit ()
         br block2(v78v1)
 
-        block2(mut v71v1: ()):
+        block2(v71v1: ()):
         v80v1 = const unit ()
         ret () v80v1
     }
@@ -129,7 +129,7 @@ script {
         v100v1 = call eq_5(n, v99v1), !64
         br block1(v100v1), !62
 
-        block1(mut v93v1: bool):
+        block1(v93v1: bool):
         cbr v93v1, block2(), block3(), !62
 
         block2():
@@ -190,8 +190,8 @@ script {
 -         br block6(v133v1)
 +         br block6(v133v1, v163v1, v166v1)
 
--         block6(mut v94v1: ()):
-+         block6(mut v94v1: (), mut v164v1: u64, mut v165v1: bool):
+-         block6(v94v1: ()):
++         block6(v94v1: (), mut v164v1: u64, mut v165v1: bool):
         v135v1 = get_local __ptr u64, i, !81
         v136v1 = get_local __ptr u64, i, !82
 -         v137v1 = load v136v1, !82
@@ -202,7 +202,7 @@ script {
 +         v139v1 = call add_7(v164v1, v138v1), !84
 +         br while(v139v1, v165v1)
 
-        block7(mut v95v1: bool):
+        block7(v95v1: bool):
         ret bool v95v1
     }
 

--- a/sway-ir/tests/mem2reg/while_loops.ir.snap
+++ b/sway-ir/tests/mem2reg/while_loops.ir.snap
@@ -110,9 +110,9 @@ script {
 -         br block5(v63v1)
 +         br block5(v63v1, v55v1, v61v1)
 
--         block5(mut v1v1: ()):
+-         block5(v1v1: ()):
 -         br while0()
-+         block5(mut v1v1: (), mut v154v1: u64, mut v156v1: u64):
++         block5(v1v1: (), mut v154v1: u64, mut v156v1: u64):
 +         br while0(v154v1, v156v1)
 
         block6():
@@ -123,7 +123,7 @@ script {
 +         v69v1 = call eq_5(v157v1, v68v1), !42
         br block7(v69v1), !29
 
-        block7(mut v2v1: bool):
+        block7(v2v1: bool):
         v71v1 = call assert_2(v2v1), !15
         v72v1 = get_local __ptr u64, counter_4, !43
 -         v73v1 = const u64 0, !44
@@ -250,7 +250,7 @@ script {
         v139v1 = const unit ()
         br block2(v139v1)
 
-        block2(mut v132v1: ()):
+        block2(v132v1: ()):
         v141v1 = const unit ()
         ret () v141v1
     }

--- a/sway-ir/tests/serialize/metadata.ir.snap
+++ b/sway-ir/tests/serialize/metadata.ir.snap
@@ -9,11 +9,11 @@ script {
         v3v1 = const bool true, !2
         cbr v3v1, block1(v3v1), block0(v3v1), !3
 
-        block0(mut v1v1: bool):
+        block0(v1v1: bool):
         v5v1 = call f(), !4
         br block1(v5v1), !3
 
-        block1(mut v2v1: bool):
+        block1(v2v1: bool):
         ret bool v2v1
     }
 

--- a/sway-ir/tests/simplify_cfg/dead_blocks.ir.snap
+++ b/sway-ir/tests/simplify_cfg/dead_blocks.ir.snap
@@ -16,12 +16,12 @@ script {
         store v7v1 to v6v1
 -         br block1(v7v1)
 - 
--         block0(mut v1v1: u64):
+-         block0(v1v1: u64):
 -         v10v1 = const u64 22
 -         store v10v1 to v6v1
 -         br block1(v10v1)
 - 
--         block1(mut v2v1: u64):
+-         block1(v2v1: u64):
         v13v1 = const u64 33
         ret u64 v13v1
     }
@@ -35,7 +35,7 @@ script {
         v19v1 = const u64 333
         br block1(v19v1)
 
-        block1(mut v16v1: u64):
+        block1(v16v1: u64):
         ret bool b
     }
 
@@ -51,7 +51,7 @@ script {
         v27v1 = const u64 333
         br block2(v27v1)
 
-        block2(mut v23v1: u64):
+        block2(v23v1: u64):
         ret bool b
     }
 
@@ -65,10 +65,10 @@ script {
 -         br block1(v35v1)
 +         br block2(v35v1)
 
--         block1(mut v31v1: u64):
+-         block1(v31v1: u64):
 -         br block2(v31v1)
 - 
-        block2(mut v32v1: u64):
+        block2(v32v1: u64):
         ret bool b
     }
 }

--- a/sway-ir/tests/simplify_cfg/merge_all_blocks.ir.snap
+++ b/sway-ir/tests/simplify_cfg/merge_all_blocks.ir.snap
@@ -11,17 +11,17 @@ script {
         v6v1 = cmp eq v4v1 v5v1
 -         br block0(v6v1)
 - 
--         block0(mut v1v1: bool):
+-         block0(v1v1: bool):
         v8v1 = const u64 22
         v9v1 = cmp eq v8v1 v5v1
 -         br block1(v9v1)
 - 
--         block1(mut v2v1: bool):
+-         block1(v2v1: bool):
         v11v1 = const u64 33
         v12v1 = cmp eq v11v1 v5v1
 -         br block2(v12v1)
 - 
--         block2(mut v3v1: bool):
+-         block2(v3v1: bool):
 -         ret bool v3v1
 +         ret bool v12v1
     }

--- a/sway-ir/tests/tests.rs
+++ b/sway-ir/tests/tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::Any,
     panic::catch_unwind,
     path::{Path, PathBuf},
 };
@@ -63,6 +64,8 @@ fn clean_output(output: &str) -> String {
 }
 
 fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
+    let mut err: Option<Box<dyn Any + Send>> = None;
+
     let source_engine = SourceEngine::default();
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let dir: PathBuf = format!("{manifest_dir}/tests/{sub_dir}").into();
@@ -98,7 +101,7 @@ fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
         let r = opt_fn(first_line, &mut ir);
         let after = ir.to_string();
 
-        fn run_insta(file: &Path, snapshot: String) {
+        fn run_insta(file: &Path, snapshot: String, r: &mut Option<Box<dyn Any + Send>>) {
             let root = file.parent().unwrap();
             let test_name = file.file_name().unwrap().to_str().unwrap();
 
@@ -109,9 +112,11 @@ fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
 
             let scope = insta.bind_to_scope();
 
-            let _ = catch_unwind(|| {
+            if let Err(err) = catch_unwind(|| {
                 insta::assert_snapshot!(test_name, snapshot);
-            });
+            }) {
+                *r = Some(err);
+            }
             drop(scope);
         }
 
@@ -153,7 +158,7 @@ fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
                 }
             }
         }
-        run_insta(&path, clean_output(&snapshot));
+        run_insta(&path, clean_output(&snapshot), &mut err);
 
         ir.verify().unwrap_or_else(|err| {
             println!("{err}");
@@ -179,6 +184,10 @@ fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
                 _ => (),
             }
         }
+    }
+
+    if let Some(err) = err {
+        panic!("Snapshot test failed: {err:?}");
     }
 }
 


### PR DESCRIPTION
## Description

Fix a problem left behind by https://github.com/FuelLabs/sway/pull/7666.

We swallow snapshot panics so we update all snapshots at once. But I forgot to raise the error at the end, which means the test harness was never failing.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
