### PR TITLE
Add comprehensive tests for `init_aggr` instruction and its lowering

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "init_aggr"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-551E051A4237E326"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "init_aggr"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_not_repeat.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_not_repeat.sw
@@ -1,0 +1,412 @@
+//! Initialization of non-repeat arrays, i.e. arrays whose elements are given
+//! individually (even if they happen to hold equal values). This tests the
+//! per-element lowering path (as opposed to the repeat-array path).
+library;
+
+use ::types::*;
+
+#[test]
+fn test_u64_all_zeros() {
+    u64_all_zeros();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros() {
+    let a = [0u64, 0, 0_0, 0, 0, 0, 0, 0u64, 0, 0];
+
+    assert_all_elems_equal(a, 0u64);
+}
+
+#[test]
+fn test_u64_all_42s() {
+    u64_all_42s();
+}
+
+#[inline(never)]
+pub fn u64_all_42s() {
+    let a = [42u64, 42, 4_2, 42, 42, 42, 42, 42u64, 42, 42];
+
+    assert_all_elems_equal(a, 42u64);
+}
+
+#[test]
+fn test_u64_mixed_values() {
+    u64_mixed_values();
+}
+
+#[inline(never)]
+pub fn u64_mixed_values() {
+    let a = [0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    let mut i = 0;
+    while i < 10 {
+        assert_eq(a[i], i);
+        i += 1;
+    }
+}
+
+#[test]
+fn test_no_nesting_all_zeros() {
+    no_nesting_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_all_zeros() {
+    let a = [
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+    ];
+
+    assert_all_elems_equal(a, NoNesting {
+        a: 0,
+        b: false,
+        c: 0u256,
+        d: b256::zero(),
+        u: (),
+    });
+}
+
+#[test]
+fn test_no_nesting_not_all_zeros() {
+    no_nesting_not_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_not_all_zeros() {
+    let a = [
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+    ];
+
+    assert_all_elems_equal(a, NoNesting {
+        a: 42,
+        b: true,
+        c: 42u256,
+        d: b256::zero(),
+        u: (),
+    });
+}
+
+#[test]
+fn test_b256_zero() {
+    b256_zero();
+}
+
+#[inline(never)]
+pub fn b256_zero() {
+    let a = [
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+        b256::zero(),
+    ];
+
+    assert_all_elems_equal(a, b256::zero());
+}
+
+#[test]
+fn test_b256_zero_literal() {
+    b256_zero_literal();
+}
+
+#[inline(never)]
+pub fn b256_zero_literal() {
+    let a: [b256; 10] = [
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+        0x0000000000000000000000000000000000000000000000000000000000000000,
+    ];
+
+    assert_all_elems_equal(a, b256::zero());
+}
+
+#[test]
+fn test_empty_array() {
+    empty_array();
+}
+
+#[inline(never)]
+pub fn empty_array() {
+    let a: [u64; 0] = [];
+    assert_eq(a.len(), 0);
+}
+
+struct SingleFieldStruct {
+    pub a: u64,
+}
+
+impl PartialEq for SingleFieldStruct {
+    fn eq(self, other: Self) -> bool {
+        self.a == other.a
+    }
+}
+impl Eq for SingleFieldStruct {}
+
+#[test]
+fn test_single_field_struct_not_zero() {
+    single_field_struct_not_zero();
+}
+
+#[inline(never)]
+pub fn single_field_struct_not_zero() {
+    let a = [
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+    ];
+    assert_all_elems_equal(a, SingleFieldStruct { a: 42 });
+}
+
+#[test]
+fn test_single_field_struct_not_zero_sroa() {
+    single_field_struct_not_zero_sroa();
+}
+
+#[inline(never)]
+pub fn single_field_struct_not_zero_sroa() {
+    let a = [
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+        SingleFieldStruct { a: 42 },
+    ];
+    assert_eq(a[1].a, 42);
+}
+
+#[test]
+fn test_u64_all_zeros_array_nested_in_array() {
+    u64_all_zeros_array_nested_in_array();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros_array_nested_in_array() {
+    let a = [
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_all_elems_equal(a, [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+}
+
+#[test]
+fn test_u64_all_42s_array_nested_in_array() {
+    u64_all_42s_array_nested_in_array();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_array_nested_in_array() {
+    let a = [
+        [42u64, 42, 42, 4_2, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 4_2, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+        [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
+    ];
+    assert_all_elems_equal(a, [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42]);
+}
+
+#[test]
+fn test_u64_all_zeros_array_nested_in_tuple() {
+    u64_all_zeros_array_nested_in_tuple();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros_array_nested_in_tuple() {
+    let a = (0u64, [0u64, 0, 0, 0, 0, 0, 0, 0, 0u64, 0], false);
+    assert_eq(a.0, 0u64);
+    assert_all_elems_equal(a.1, 0u64);
+    assert_eq(a.2, false);
+}
+
+#[test]
+fn test_u64_all_42s_array_nested_in_tuple() {
+    u64_all_42s_array_nested_in_tuple();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_array_nested_in_tuple() {
+    let a = (42u64, [42u64, 42, 42, 42, 4_2, 42, 42, 42, 42u64, 42], true);
+    assert_eq(a.0, 42u64);
+    assert_all_elems_equal(a.1, 42u64);
+    assert_eq(a.2, true);
+}
+
+fn assert_all_elems_equal<T>(array: [T; 10], val: T)
+where
+    T: PartialEq + AbiEncode,
+{
+    let mut i = 0;
+    while i < 10 {
+        assert_eq(array[i], val);
+        i += 1;
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat.sw
@@ -1,0 +1,220 @@
+//! Initialization of repeat arrays (`[value; N]`).
+//! Covers scalar and aggregate elements, zero and non-zero values,
+//! empty arrays, and arrays nested in other aggregates.
+library;
+
+use ::types::*;
+
+#[test]
+fn test_u64_all_zeros_repeat() {
+    u64_all_zeros_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros_repeat() {
+    let a = [0u64; 10];
+
+    assert_all_elems_equal(a, 0u64);
+}
+
+#[test]
+fn test_u64_all_42s_repeat() {
+    u64_all_42s_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_repeat() {
+    let a = [42u64; 10];
+
+    assert_all_elems_equal(a, 42u64);
+}
+
+#[test]
+fn test_no_nesting_all_zeros_repeat() {
+    no_nesting_all_zeros_repeat();
+}
+
+#[inline(never)]
+pub fn no_nesting_all_zeros_repeat() {
+    let a = [
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        }; 10
+    ];
+
+    assert_all_elems_equal(a, NoNesting {
+        a: 0,
+        b: false,
+        c: 0u256,
+        d: b256::zero(),
+        u: (),
+    });
+}
+
+#[test]
+fn test_no_nesting_not_all_zeros_repeat() {
+    no_nesting_not_all_zeros_repeat();
+}
+
+#[inline(never)]
+pub fn no_nesting_not_all_zeros_repeat() {
+    let a = [
+        NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        }; 10
+    ];
+
+    assert_all_elems_equal(a, NoNesting {
+        a: 42,
+        b: true,
+        c: 42u256,
+        d: b256::zero(),
+        u: (),
+    });
+}
+
+#[test]
+fn test_b256_zero_repeat() {
+    b256_zero_repeat();
+}
+
+#[inline(never)]
+pub fn b256_zero_repeat() {
+    let a = [b256::zero(); 10];
+
+    assert_all_elems_equal(a, b256::zero());
+}
+
+#[test]
+fn test_empty_array_repeat() {
+    empty_array_repeat();
+}
+
+#[inline(never)]
+pub fn empty_array_repeat() {
+    let a: [u64; 0] = [42; 0];
+
+    assert_eq(a.len(), 0);
+}
+
+#[test]
+fn test_empty_array_with_side_effect_repeat() {
+    empty_array_with_side_effect_repeat();
+}
+
+#[inline(never)]
+pub fn empty_array_with_side_effect_repeat() {
+    let mut i = 0;
+    let a: [u64; 0] = [side_effect(i); 0];
+
+    assert_eq(i, 1);
+    assert_eq(a.len(), 0);
+}
+
+fn side_effect(ref mut x: u64) -> u64 {
+    x += 1;
+    x
+}
+
+struct SingleFieldStruct {
+    pub a: u64,
+}
+
+impl PartialEq for SingleFieldStruct {
+    fn eq(self, other: Self) -> bool {
+        self.a == other.a
+    }
+}
+impl Eq for SingleFieldStruct {}
+
+#[test]
+fn test_single_field_struct_not_zero_repeat() {
+    single_field_struct_not_zero_repeat();
+}
+
+#[inline(never)]
+pub fn single_field_struct_not_zero_repeat() {
+    let a = [SingleFieldStruct { a: 42 }; 10];
+
+    assert_all_elems_equal(a, SingleFieldStruct { a: 42 });
+}
+
+#[test]
+fn test_single_field_struct_not_zero_sroa_repeat() {
+    single_field_struct_not_zero_sroa_repeat();
+}
+
+#[inline(never)]
+pub fn single_field_struct_not_zero_sroa_repeat() {
+    let a = [SingleFieldStruct { a: 42 }; 10];
+    assert_eq(a[1].a, 42);
+}
+
+#[test]
+fn test_u64_all_zeros_array_nested_in_array_repeat() {
+    u64_all_zeros_array_nested_in_array_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros_array_nested_in_array_repeat() {
+    let a = [[0u64; 10]; 10];
+    assert_all_elems_equal(a, [0u64; 10]);
+}
+
+#[test]
+fn test_u64_all_42s_array_nested_in_array_repeat() {
+    u64_all_42s_array_nested_in_array_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_array_nested_in_array_repeat() {
+    let a = [[42u64; 10]; 10];
+    assert_all_elems_equal(a, [42u64; 10]);
+}
+
+#[test]
+fn test_u64_all_zeros_array_nested_in_tuple_repeat() {
+    u64_all_zeros_array_nested_in_tuple_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros_array_nested_in_tuple_repeat() {
+    let a = (0u64, [0u64; 10], false);
+
+    assert_eq(a.0, 0u64);
+    assert_all_elems_equal(a.1, 0u64);
+    assert_eq(a.2, false);
+}
+
+#[test]
+fn test_u64_all_42s_array_nested_in_tuple_repeat() {
+    u64_all_42s_array_nested_in_tuple_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_array_nested_in_tuple_repeat() {
+    let a = (42u64, [42u64; 10], true);
+
+    assert_eq(a.0, 42u64);
+    assert_all_elems_equal(a.1, 42u64);
+    assert_eq(a.2, true);
+}
+
+fn assert_all_elems_equal<T>(array: [T; 10], val: T)
+where
+    T: PartialEq + AbiEncode,
+{
+    let mut i = 0;
+    while i < 10 {
+        assert_eq(array[i], val);
+        i += 1;
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat_split_block_insert_loop.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat_split_block_insert_loop.sw
@@ -1,0 +1,73 @@
+//! Large repeat arrays (length > 5) are lowered into an initialization loop.
+//! These tests test that path, including several such loops within a
+//! single function (multiple block splits in one function body).
+library;
+
+use ::types::*;
+
+#[test]
+fn test_u64_all_42s_repeat() {
+    u64_all_42s_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_repeat() {
+    let a = [42u64; 10];
+
+    assert_all_elems_equal(a, 42u64);
+}
+
+#[test]
+fn test_u64_all_42s_repeat_several_times() {
+    u64_all_42s_repeat_several_times();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_repeat_several_times() {
+    let a = [42u64; 10];
+    assert_all_elems_equal(a, 42u64);
+
+    let a = [333u64; 10];
+    assert_all_elems_equal(a, 333u64);
+
+    let a = [444u64; 10];
+    assert_all_elems_equal(a, 444u64);
+}
+
+#[test]
+fn test_boundary_small_vs_loop() {
+    boundary_small_vs_loop();
+}
+
+/// The lowering initializes small repeat arrays (length <= 5) with individual
+/// stores, and larger ones (length > 5) with a loop. This test covers both
+/// sides of that boundary.
+#[inline(never)]
+pub fn boundary_small_vs_loop() {
+    let small = [7u64; 5];
+
+    let mut i = 0;
+    while i < 5 {
+        assert_eq(small[i], 7u64);
+        i += 1;
+    }
+
+    let large = [7u64; 6];
+
+    let mut i = 0;
+    while i < 6 {
+        assert_eq(large[i], 7u64);
+        i += 1;
+    }
+}
+
+fn assert_all_elems_equal<T>(array: [T; 10], val: T)
+where
+    T: PartialEq + AbiEncode,
+{
+    let mut i = 0;
+    while i < 10 {
+        assert_eq(array[i], val);
+        i += 1;
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat_sroa.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat_sroa.sw
@@ -1,0 +1,54 @@
+//! Initialization of repeat arrays where only a single element is later
+//! accessed. This exercises the interaction between the `init_aggr` lowering
+//! and SROA. Covers both the "large" (loop-lowered) and "small" repeat arrays.
+library;
+
+use ::types::*;
+
+#[test]
+fn test_u64_all_zeros_repeat() {
+    u64_all_zeros_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros_repeat() {
+    let a = [0u64; 10];
+
+    assert_eq(a[0], 0u64);
+}
+
+#[test]
+fn test_u64_all_zeros_small_array_repeat() {
+    u64_all_zeros_small_array_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_zeros_small_array_repeat() {
+    let a = [0u64; 4];
+
+    assert_eq(a[0], 0u64);
+}
+
+#[test]
+fn test_u64_all_42s_repeat() {
+    u64_all_42s_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_repeat() {
+    let a = [42u64; 10];
+
+    assert_eq(a[0], 42u64);
+}
+
+#[test]
+fn test_u64_all_42s_small_array_repeat() {
+    u64_all_42s_small_array_repeat();
+}
+
+#[inline(never)]
+pub fn u64_all_42s_small_array_repeat() {
+    let a = [42u64; 4];
+
+    assert_eq(a[0], 42u64);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_empty_aggregates.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_empty_aggregates.sw
@@ -1,0 +1,56 @@
+//! Initialization of empty / zero-sized aggregates.
+library;
+
+use ::types::*;
+
+#[test]
+fn test_empty_struct() {
+    empty_struct();
+}
+
+#[inline(never)]
+pub fn empty_struct() {
+    let s = EmptyStruct {};
+    assert_eq(s, EmptyStruct {});
+}
+
+#[test]
+fn test_empty_struct_container() {
+    empty_struct_container();
+}
+
+#[inline(never)]
+pub fn empty_struct_container() {
+    let s = EmptyStructContainer { e: EmptyStruct {} };
+    assert_eq(s, EmptyStructContainer { e: EmptyStruct {} });
+}
+
+#[test]
+fn test_empty_struct_container_with_side_effect() {
+    empty_struct_container_with_side_effect();
+}
+
+#[inline(never)]
+pub fn empty_struct_container_with_side_effect() {
+    let s = EmptyStructContainer {
+        e: return_empty_struct(),
+    };
+    assert_eq(s, EmptyStructContainer { e: EmptyStruct {} });
+}
+
+#[test]
+fn test_empty_tuple_like_aggregates() {
+    empty_tuple_like_aggregates();
+}
+
+#[inline(never)]
+pub fn empty_tuple_like_aggregates() {
+    // A tuple of unit and empty struct values is zero-sized.
+    let t = ((), EmptyStruct {}, ());
+    assert_eq(t.0, ());
+    assert_eq(t.1, EmptyStruct {});
+    assert_eq(t.2, ());
+
+    let a: [u64; 0] = [];
+    assert_eq(a.len(), 0);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_enums.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_enums.sw
@@ -1,0 +1,146 @@
+//! Initialization of aggregates that contain enums. Enums are themselves not
+//! initialized via `init_aggr`, but they can appear as fields/elements of
+//! structs, tuples, and arrays that are. The lowering must treat an enum field
+//! as an opaque value (for zero analysis it is a non-`init_aggr` leaf).
+library;
+
+use ::types::*;
+
+enum E {
+    Unit: (),
+    Num: u64,
+    Pair: (u64, u256),
+}
+
+impl PartialEq for E {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (E::Unit, E::Unit) => true,
+            (E::Num(a), E::Num(b)) => a == b,
+            (E::Pair(a), E::Pair(b)) => a.0 == b.0 && a.1 == b.1,
+            _ => false,
+        }
+    }
+}
+impl Eq for E {}
+
+struct HasEnum {
+    tag: u64,
+    e: E,
+    trailing: u64,
+}
+
+#[test]
+fn test_struct_with_enum_unit() {
+    struct_with_enum_unit();
+}
+
+#[inline(never)]
+pub fn struct_with_enum_unit() {
+    let s = HasEnum {
+        tag: 0,
+        e: E::Unit,
+        trailing: 0,
+    };
+
+    assert_eq(s.tag, 0);
+    assert_eq(s.e, E::Unit);
+    assert_eq(s.trailing, 0);
+}
+
+#[test]
+fn test_struct_with_enum_num() {
+    struct_with_enum_num();
+}
+
+#[inline(never)]
+pub fn struct_with_enum_num() {
+    let s = HasEnum {
+        tag: 7,
+        e: E::Num(42),
+        trailing: 9,
+    };
+
+    assert_eq(s.tag, 7);
+    assert_eq(s.e, E::Num(42));
+    assert_eq(s.trailing, 9);
+}
+
+#[test]
+fn test_tuple_with_enum() {
+    tuple_with_enum();
+}
+
+#[inline(never)]
+pub fn tuple_with_enum() {
+    let t = (0u64, E::Pair((1, 2u256)), 0u64);
+
+    assert_eq(t.0, 0);
+    assert_eq(t.1, E::Pair((1, 2u256)));
+    assert_eq(t.2, 0);
+}
+
+#[test]
+fn test_array_of_enums() {
+    array_of_enums();
+}
+
+#[inline(never)]
+pub fn array_of_enums() {
+    let a = [E::Num(1), E::Num(2), E::Num(3)];
+
+    assert(a[0] == E::Num(1));
+    assert(a[1] == E::Num(2));
+    assert(a[2] == E::Num(3));
+}
+
+#[test]
+fn test_array_of_enums_repeat() {
+    array_of_enums_repeat();
+}
+
+#[inline(never)]
+pub fn array_of_enums_repeat() {
+    let a = [E::Num(5); 10];
+
+    let mut i = 0;
+    while i < 10 {
+        assert(a[i] == E::Num(5));
+        i += 1;
+    }
+}
+
+#[test]
+fn test_option_in_struct() {
+    option_in_struct();
+}
+
+// Test a mostly-zeroed struct that holds `Option`.
+#[inline(never)]
+pub fn option_in_struct() {
+    let s = HasEnumOption {
+        a: 0,
+        opt: Some(42u64),
+        b: 0,
+    };
+
+    assert_eq(s.a, 0);
+    assert_eq(s.opt.unwrap(), 42);
+    assert_eq(s.b, 0);
+
+    let s = HasEnumOption {
+        a: 0,
+        opt: None,
+        b: 0,
+    };
+
+    assert_eq(s.a, 0);
+    assert(s.opt.is_none());
+    assert_eq(s.b, 0);
+}
+
+struct HasEnumOption {
+    a: u64,
+    opt: Option<u64>,
+    b: u64,
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_misc_constellations.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_misc_constellations.sw
@@ -1,0 +1,205 @@
+//! Additional aggregate-initialization constellations that combine structs,
+//! tuples and arrays in various nestings. These stress the recursive lowering
+//! (structs of arrays, arrays of structs, tuples of arrays of structs, etc.).
+library;
+
+use ::types::*;
+
+struct WithArray {
+    head: u64,
+    body: [u64; 4],
+    tail: u64,
+}
+
+impl PartialEq for WithArray {
+    fn eq(self, other: Self) -> bool {
+        let mut i = 0;
+        let mut body_eq = true;
+        while i < 4 {
+            if self.body[i] != other.body[i] {
+                body_eq = false;
+            }
+            i += 1;
+        }
+        self.head == other.head && body_eq && self.tail == other.tail
+    }
+}
+impl Eq for WithArray {}
+
+// Struct containing an array field.
+#[test]
+fn test_struct_with_array() {
+    struct_with_array();
+}
+
+#[inline(never)]
+pub fn struct_with_array() {
+    let s = WithArray {
+        head: 1,
+        body: [2, 3, 4, 5],
+        tail: 6,
+    };
+
+    assert_eq(s.head, 1);
+    assert_eq(s.body[0], 2);
+    assert_eq(s.body[1], 3);
+    assert_eq(s.body[2], 4);
+    assert_eq(s.body[3], 5);
+    assert_eq(s.tail, 6);
+}
+
+// Struct containing a repeat array field.
+#[test]
+fn test_struct_with_repeat_array() {
+    struct_with_repeat_array();
+}
+
+#[inline(never)]
+pub fn struct_with_repeat_array() {
+    let s = WithArray {
+        head: 1,
+        body: [9; 4],
+        tail: 2,
+    };
+
+    assert_eq(s.head, 1);
+    let mut i = 0;
+    while i < 4 {
+        assert_eq(s.body[i], 9);
+        i += 1;
+    }
+    assert_eq(s.tail, 2);
+}
+
+// Array of tuples.
+#[test]
+fn test_array_of_tuples() {
+    array_of_tuples();
+}
+
+#[inline(never)]
+pub fn array_of_tuples() {
+    let a = [(1u64, true), (2u64, false), (3u64, true)];
+
+    assert_eq(a[0].0, 1);
+    assert_eq(a[0].1, true);
+    assert_eq(a[1].0, 2);
+    assert_eq(a[1].1, false);
+    assert_eq(a[2].0, 3);
+    assert_eq(a[2].1, true);
+}
+
+// Array of structs (non-repeat, distinct values).
+#[test]
+fn test_array_of_structs_distinct() {
+    array_of_structs_distinct();
+}
+
+#[inline(never)]
+pub fn array_of_structs_distinct() {
+    let a = [
+        NoNesting {
+            a: 1,
+            b: true,
+            c: 1u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 2,
+            b: false,
+            c: 2u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 3,
+            b: true,
+            c: 3u256,
+            d: b256::zero(),
+            u: (),
+        },
+    ];
+
+    assert_no_nesting(a[0], 1, true, 1u256, b256::zero());
+    assert_no_nesting(a[1], 2, false, 2u256, b256::zero());
+    assert_no_nesting(a[2], 3, true, 3u256, b256::zero());
+}
+
+// Tuple of an array of structs.
+#[test]
+fn test_tuple_of_array_of_structs() {
+    tuple_of_array_of_structs();
+}
+
+#[inline(never)]
+pub fn tuple_of_array_of_structs() {
+    let t = (
+        100u64,
+        [create_some_simple(1), create_some_simple(2)],
+        true,
+    );
+
+    assert_eq(t.0, 100);
+    assert_simple(t.1[0], 1, 2, true, 3u256);
+    assert_simple(t.1[1], 2, 2, true, 3u256);
+    assert_eq(t.2, true);
+}
+
+// Struct nested in a struct nested in a struct, with a mix of values.
+#[test]
+fn test_deep_struct_nesting() {
+    deep_struct_nesting();
+}
+
+#[inline(never)]
+pub fn deep_struct_nesting() {
+    let s = Struct {
+        x: 10,
+        simple: Simple {
+            a: 1,
+            b: 2,
+            c: true,
+            d: 3u256,
+        },
+        b: false,
+    };
+
+    assert_eq(s.x, 10);
+    assert_simple(s.simple, 1, 2, true, 3u256);
+    assert_eq(s.b, false);
+}
+
+// Array of u256 (large scalars), non-repeat.
+#[test]
+fn test_array_of_u256() {
+    array_of_u256();
+}
+
+#[inline(never)]
+pub fn array_of_u256() {
+    let a = [1u256, 2u256, 3u256, 0u256];
+
+    assert_eq(a[0], 1u256);
+    assert_eq(a[1], 2u256);
+    assert_eq(a[2], 3u256);
+    assert_eq(a[3], 0u256);
+}
+
+// A large repeat array of a struct element (triggers the loop path for a
+// non-scalar repeated value).
+#[test]
+fn test_large_repeat_array_of_struct() {
+    large_repeat_array_of_struct();
+}
+
+#[inline(never)]
+pub fn large_repeat_array_of_struct() {
+    let a = [create_some_simple(7); 8];
+
+    let mut i = 0;
+    while i < 8 {
+        assert_simple(a[i], 7, 2, true, 3u256);
+        i += 1;
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_mostly_zeroed.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_mostly_zeroed.sw
@@ -1,0 +1,289 @@
+//! Initialization of "mostly zeroed" aggregates, i.e. aggregates where a large
+//! fraction of the bytes are zero-initialized. The optimization lowers such
+//! aggregates to a single `mem_clear_val` for the whole aggregate followed by
+//! `store`s for only the non-zero fields.
+//!
+//! These tests cover:
+//! - the common `(non_zero, 0, 0, 0, ...)` shapes for tuples, arrays and structs,
+//! - nesting (arrays in arrays, tuples in tuples, structs in structs),
+//! - values around the "is it mostly zeroed?" ratio threshold,
+//! - fully zeroed aggregates (100% zero), and
+//! - aggregates that are *not* mostly zeroed (below the threshold), which must
+//!   still be initialized correctly by the default lowering.
+library;
+
+use ::types::*;
+
+// A tuple with a single non-zero leading element followed by zeros.
+#[test]
+fn test_tuple_leading_non_zero() {
+    tuple_leading_non_zero();
+}
+
+#[inline(never)]
+pub fn tuple_leading_non_zero() {
+    let t = (42u64, 0u64, 0u64, 0u64);
+
+    assert_eq(t.0, 42u64);
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2, 0u64);
+    assert_eq(t.3, 0u64);
+}
+
+// A tuple with a single non-zero trailing element preceded by zeros. This is
+// the classic `(0, 0, 0, some_variable)` case.
+#[test]
+fn test_tuple_trailing_non_zero() {
+    tuple_trailing_non_zero();
+}
+
+#[inline(never)]
+pub fn tuple_trailing_non_zero() {
+    let x = opaque_u64(7);
+    let t = (0u64, 0u64, 0u64, x);
+
+    assert_eq(t.0, 0u64);
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2, 0u64);
+    assert_eq(t.3, 7u64);
+}
+
+// An array with a single non-zero leading element.
+#[test]
+fn test_array_leading_non_zero() {
+    array_leading_non_zero();
+}
+
+#[inline(never)]
+pub fn array_leading_non_zero() {
+    let a = [42u64, 0, 0, 0];
+
+    assert_eq(a[0], 42u64);
+    assert_eq(a[1], 0u64);
+    assert_eq(a[2], 0u64);
+    assert_eq(a[3], 0u64);
+}
+
+// Nested arrays where the outer array is mostly zeroed: one non-zero inner
+// array followed by all-zero inner arrays.
+#[test]
+fn test_nested_arrays_mostly_zeroed() {
+    nested_arrays_mostly_zeroed();
+}
+
+#[inline(never)]
+pub fn nested_arrays_mostly_zeroed() {
+    let a = [[42u64; 10], [0u64; 10], [0u64; 10], [0u64; 10]];
+
+    let mut i = 0;
+    while i < 10 {
+        assert_eq(a[0][i], 42u64);
+        assert_eq(a[1][i], 0u64);
+        assert_eq(a[2][i], 0u64);
+        assert_eq(a[3][i], 0u64);
+        i += 1;
+    }
+}
+
+// A tuple whose first element is a non-zero array, followed by many zero
+// scalars. The non-zero array is a small fraction of the whole aggregate.
+#[test]
+fn test_tuple_array_then_many_zeros() {
+    tuple_array_then_many_zeros();
+}
+
+#[inline(never)]
+pub fn tuple_array_then_many_zeros() {
+    let t = (
+        [42u8; 8],
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+    );
+
+    let mut i = 0;
+    while i < 8 {
+        assert_eq(t.0[i], 42u8);
+        i += 1;
+    }
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2, 0u64);
+    assert_eq(t.3, 0u64);
+    assert_eq(t.4, 0u64);
+    assert_eq(t.5, 0u64);
+    assert_eq(t.6, 0u64);
+    assert_eq(t.7, 0u64);
+    assert_eq(t.8, 0u64);
+    assert_eq(t.9, 0u64);
+    assert_eq(t.10, 0u64);
+    assert_eq(t.11, 0u64);
+}
+
+// A deeply nested mostly-zeroed tuple: an array, then a zero scalar, then a
+// nested all-zero tuple, then more zero scalars.
+#[test]
+fn test_deeply_nested_mostly_zeroed() {
+    deeply_nested_mostly_zeroed();
+}
+
+#[inline(never)]
+pub fn deeply_nested_mostly_zeroed() {
+    let t = (
+        [42u8; 8],
+        0u64,
+        (0u64, 0u64, 0u64),
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+    );
+
+    let mut i = 0;
+    while i < 8 {
+        assert_eq(t.0[i], 42u8);
+        i += 1;
+    }
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2.0, 0u64);
+    assert_eq(t.2.1, 0u64);
+    assert_eq(t.2.2, 0u64);
+    assert_eq(t.3, 0u64);
+    assert_eq(t.4, 0u64);
+    assert_eq(t.5, 0u64);
+    assert_eq(t.6, 0u64);
+    assert_eq(t.7, 0u64);
+    assert_eq(t.8, 0u64);
+    assert_eq(t.9, 0u64);
+}
+
+// A struct that is mostly zeroed but has one large non-zero field.
+#[test]
+fn test_struct_mostly_zeroed_large_non_zero() {
+    struct_mostly_zeroed_large_non_zero();
+}
+
+#[inline(never)]
+pub fn struct_mostly_zeroed_large_non_zero() {
+    let s = NoNesting {
+        a: 0,
+        b: false,
+        c: 123u256,
+        d: b256::zero(),
+        u: (),
+    };
+
+    assert_no_nesting(s, 0, false, 123u256, b256::zero());
+}
+
+// A struct that is mostly zeroed but with a non-zero `b256` field.
+#[test]
+fn test_struct_mostly_zeroed_non_zero_b256() {
+    struct_mostly_zeroed_non_zero_b256();
+}
+
+#[inline(never)]
+pub fn struct_mostly_zeroed_non_zero_b256() {
+    let d = 0x00000000000000000000000000000000000000000000000000000000000000FF;
+    let s = NoNesting {
+        a: 0,
+        b: false,
+        c: 0u256,
+        d,
+        u: (),
+    };
+
+    assert_no_nesting(s, 0, false, 0u256, d);
+}
+
+// Nested struct where only a single leaf field is non-zero.
+#[test]
+fn test_nested_struct_single_non_zero_leaf() {
+    nested_struct_single_non_zero_leaf();
+}
+
+#[inline(never)]
+pub fn nested_struct_single_non_zero_leaf() {
+    let s = Nested {
+        n1: NoNesting::default(),
+        n2: NoNesting {
+            a: 5,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+    };
+
+    assert_no_nesting_all_zeros(s.n1);
+    assert_no_nesting(s.n2, 5, false, 0u256, b256::zero());
+}
+
+// A fully zeroed aggregate (100% zero). Should lower to just a `mem_clear_val`.
+#[test]
+fn test_fully_zeroed() {
+    fully_zeroed();
+}
+
+#[inline(never)]
+pub fn fully_zeroed() {
+    let t = (0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+    assert_eq(t.0, 0u64);
+    assert_eq(t.7, 0u64);
+
+    let a = [0u64, 0, 0, 0];
+    assert_eq(a[0], 0u64);
+    assert_eq(a[3], 0u64);
+
+    let s = NoNesting::default();
+    assert_no_nesting_all_zeros(s);
+}
+
+// A tuple that is NOT mostly zeroed (well below the threshold). This must still
+// be initialized correctly by the default lowering.
+#[test]
+fn test_not_mostly_zeroed() {
+    not_mostly_zeroed();
+}
+
+#[inline(never)]
+pub fn not_mostly_zeroed() {
+    let t = (1u64, 2u64, 3u64, 0u64);
+
+    assert_eq(t.0, 1u64);
+    assert_eq(t.1, 2u64);
+    assert_eq(t.2, 3u64);
+    assert_eq(t.3, 0u64);
+}
+
+// A tuple sitting right around the "half zeroed" mark.
+#[test]
+fn test_half_zeroed() {
+    half_zeroed();
+}
+
+#[inline(never)]
+pub fn half_zeroed() {
+    let t = (1u64, 0u64, 2u64, 0u64);
+
+    assert_eq(t.0, 1u64);
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2, 2u64);
+    assert_eq(t.3, 0u64);
+}
+
+#[inline(never)]
+fn opaque_u64(x: u64) -> u64 {
+    asm() {}; // To forbid const-eval.
+    x
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_single_store.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_single_store.sw
@@ -1,0 +1,145 @@
+//! Initialization of aggregates that reduce to a single stored value, e.g.
+//! single-field structs and chains of single-field wrapper structs. These are
+//! interesting because the lowering should avoid unnecessary temporaries and
+//! `memcpy`s (especially for large scalars like `u256`), and cooperate with SROA.
+library;
+
+use ::types::*;
+
+struct SingleField<T> {
+    field: T,
+}
+
+impl<T> PartialEq for SingleField<T>
+where
+    T: PartialEq,
+{
+    fn eq(self, other: Self) -> bool {
+        self.field == other.field
+    }
+}
+impl<T> Eq for SingleField<T>
+where
+    T: PartialEq,
+{}
+
+struct InnerWrapper<T> {
+    value: SingleField<T>,
+}
+
+struct OuterWrapper<T> {
+    inner: InnerWrapper<T>,
+}
+
+#[test]
+fn test_single_field_u8_zero() {
+    single_field_u8_zero();
+}
+
+#[inline(never)]
+pub fn single_field_u8_zero() {
+    let t = SingleField { field: 0u8 };
+    assert_eq(t.field, 0u8);
+}
+
+#[test]
+fn test_single_field_u256_zero() {
+    single_field_u256_zero();
+}
+
+#[inline(never)]
+pub fn single_field_u256_zero() {
+    let t = SingleField { field: 0u256 };
+    assert_eq(t.field, 0u256);
+}
+
+#[test]
+fn test_single_field_u256_non_zero() {
+    single_field_u256_non_zero();
+}
+
+#[inline(never)]
+pub fn single_field_u256_non_zero() {
+    let t = SingleField { field: 42u256 };
+    assert_eq(t.field, 42u256);
+}
+
+#[test]
+fn test_single_field_sroa() {
+    single_field_sroa();
+}
+
+#[inline(never)]
+pub fn single_field_sroa() {
+    let t = SingleField { field: 0u256 };
+    assert_eq(t.field, 0u256);
+
+    let t = SingleField { field: 42u256 };
+    assert_eq(t.field, 42u256);
+}
+
+#[test]
+fn test_nested_wrappers_zero() {
+    nested_wrappers_zero();
+}
+
+#[inline(never)]
+pub fn nested_wrappers_zero() {
+    let t = OuterWrapper {
+        inner: InnerWrapper {
+            value: SingleField { field: 0u256 },
+        },
+    };
+    assert_eq(t.inner.value.field, 0u256);
+}
+
+#[test]
+fn test_nested_wrappers_non_zero() {
+    nested_wrappers_non_zero();
+}
+
+#[inline(never)]
+pub fn nested_wrappers_non_zero() {
+    let t = OuterWrapper {
+        inner: InnerWrapper {
+            value: SingleField { field: 42u256 },
+        },
+    };
+    assert_eq(t.inner.value.field, 42u256);
+}
+
+#[test]
+fn test_nested_wrappers_sroa() {
+    nested_wrappers_sroa();
+}
+
+#[inline(never)]
+pub fn nested_wrappers_sroa() {
+    let t = OuterWrapper {
+        inner: InnerWrapper {
+            value: SingleField { field: 0u256 },
+        },
+    };
+    assert_eq(t.inner.value.field, 0u256);
+
+    let t = OuterWrapper {
+        inner: InnerWrapper {
+            value: SingleField { field: 42u256 },
+        },
+    };
+    assert_eq(t.inner.value.field, 42u256);
+}
+
+#[test]
+fn test_single_element_tuple_u8() {
+    single_element_tuple_u8();
+}
+
+#[inline(never)]
+pub fn single_element_tuple_u8() {
+    let t = (0u8,);
+    assert_eq(t.0, 0u8);
+
+    let t = (42u8,);
+    assert_eq(t.0, 42u8);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct.sw
@@ -1,0 +1,96 @@
+//! Initialization of structs, with and without nesting, all-zeros and not-all-zeros.
+library;
+
+use ::types::*;
+
+#[test]
+fn test_no_nesting_not_all_zeros() {
+    no_nesting_not_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_not_all_zeros() {
+    let s = NoNesting {
+        a: 42,
+        b: true,
+        c: 42u256,
+        d: b256::zero(),
+        u: (),
+    };
+
+    assert_no_nesting(s, 42, true, 42u256, b256::zero());
+}
+
+#[test]
+fn test_no_nesting_all_zeros() {
+    no_nesting_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_all_zeros() {
+    let s = NoNesting {
+        a: 0,
+        b: false,
+        c: 0u256,
+        d: b256::zero(),
+        u: (),
+    };
+
+    assert_no_nesting_all_zeros(s);
+}
+
+#[test]
+fn test_nested_not_all_zeros() {
+    nested_not_all_zeros();
+}
+
+#[inline(never)]
+pub fn nested_not_all_zeros() {
+    let s = Nested {
+        n1: NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        n2: NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+    };
+
+    assert_no_nesting_all_zeros(s.n1);
+    assert_no_nesting(s.n2, 42, true, 42u256, b256::zero());
+}
+
+#[test]
+fn test_nested_all_zeros() {
+    nested_all_zeros();
+}
+
+#[inline(never)]
+pub fn nested_all_zeros() {
+    let s = Nested {
+        n1: NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        n2: NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+    };
+
+    assert_no_nesting_all_zeros(s.n1);
+    assert_no_nesting_all_zeros(s.n2);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct_from_branching.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct_from_branching.sw
@@ -1,0 +1,331 @@
+//! Initialization of aggregates whose fields (or whole values) come from
+//! branching expressions (`if`/`else`, `else if` chains) and from function
+//! calls. This tests `init_aggr`s whose initializers are computed in
+//! predecessor blocks and merged, as well as nested `init_aggr`s inside `if`s.
+library;
+
+use ::types::*;
+
+#[inline(never)]
+fn get_no_nesting_all_zeros() -> NoNesting {
+    NoNesting {
+        a: 0,
+        b: false,
+        c: 0u256,
+        d: b256::zero(),
+        u: (),
+    }
+}
+
+#[test]
+fn test_from_if_true() {
+    from_if(true);
+}
+
+#[test]
+fn test_from_if_false() {
+    from_if(false);
+}
+
+#[inline(never)]
+pub fn from_if(value: bool) {
+    let no_nesting = if value {
+        NoNesting {
+            a: 111,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        }
+    } else {
+        NoNesting {
+            a: 222,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        }
+    };
+
+    assert_no_nesting(
+        no_nesting,
+        if value {
+            111
+        } else {
+            222
+        },
+        if value {
+            false
+        } else {
+            true
+        },
+        if value {
+            0u256
+        } else {
+            42u256
+        },
+        b256::zero(),
+    );
+
+    let no_nesting = if value {
+        NoNesting {
+            a: 333,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        }
+    } else {
+        get_no_nesting_all_zeros()
+    };
+
+    if value {
+        assert_no_nesting(no_nesting, 333, false, 0u256, b256::zero());
+    } else {
+        assert_no_nesting_all_zeros(no_nesting);
+    }
+
+    let s = Nested {
+        n1: if value {
+            NoNesting {
+                a: 999,
+                b: false,
+                c: 444u256,
+                d: b256::zero(),
+                u: (),
+            }
+        } else {
+            NoNesting {
+                a: 999,
+                b: true,
+                c: 555u256,
+                d: b256::zero(),
+                u: (),
+            }
+        },
+        n2: NoNesting {
+            a: 999,
+            b: false,
+            c: 666u256,
+            d: b256::zero(),
+            u: (),
+        },
+    };
+
+    if value {
+        assert_no_nesting(s.n1, 999, false, 444u256, b256::zero());
+    } else {
+        assert_no_nesting(s.n1, 999, true, 555u256, b256::zero());
+    }
+    assert_no_nesting(s.n2, 999, false, 666u256, b256::zero());
+}
+
+#[test]
+fn test_from_if_isolated_true() {
+    from_if_isolated(true);
+}
+
+#[test]
+fn test_from_if_isolated_false() {
+    from_if_isolated(false);
+}
+
+#[inline(never)]
+pub fn from_if_isolated(value: bool) {
+    let s = Nested {
+        n1: if value {
+            NoNesting {
+                a: 999,
+                b: false,
+                c: 444u256,
+                d: b256::zero(),
+                u: (),
+            }
+        } else {
+            NoNesting {
+                a: 999,
+                b: true,
+                c: 555u256,
+                d: b256::zero(),
+                u: (),
+            }
+        },
+        n2: NoNesting::default(),
+    };
+
+    if value {
+        assert_no_nesting(s.n1, 999, false, 444u256, b256::zero());
+    } else {
+        assert_no_nesting(s.n1, 999, true, 555u256, b256::zero());
+    }
+    assert_no_nesting_all_zeros(s.n2);
+}
+
+#[test]
+fn test_from_if_struct_true() {
+    from_if_struct(true);
+}
+
+#[test]
+fn test_from_if_struct_false() {
+    from_if_struct(false);
+}
+
+#[inline(never)]
+pub fn from_if_struct(value: bool) {
+    let s = Struct {
+        x: 1111,
+        simple: if value {
+            Simple {
+                a: 111,
+                b: 22222,
+                c: true,
+                d: 33333u256,
+            }
+        } else {
+            create_some_simple(42)
+        },
+        b: true,
+    };
+
+    if value {
+        assert_simple(s.simple, 111, 22222, true, 33333u256);
+    } else {
+        assert_simple(s.simple, 42, 2, true, 3u256);
+    }
+}
+
+#[test]
+fn test_from_if_struct_only_inits_true() {
+    from_if_struct_only_inits(true);
+}
+
+#[test]
+fn test_from_if_struct_only_inits_false() {
+    from_if_struct_only_inits(false);
+}
+
+#[inline(never)]
+pub fn from_if_struct_only_inits(value: bool) {
+    let s = Struct {
+        x: 1111,
+        simple: if value {
+            Simple {
+                a: 111,
+                b: 22222,
+                c: true,
+                d: 33333u256,
+            }
+        } else {
+            Simple {
+                a: 222,
+                b: 33333,
+                c: true,
+                d: 44444u256,
+            }
+        },
+        b: true,
+    };
+
+    if value {
+        assert_simple(s.simple, 111, 22222, true, 33333u256);
+    } else {
+        assert_simple(s.simple, 222, 33333, true, 44444u256);
+    }
+}
+
+#[test]
+fn test_from_multiple_if_else_struct_value_1() {
+    from_multiple_if_else_struct(1);
+}
+
+#[test]
+fn test_from_multiple_if_else_struct_value_2() {
+    from_multiple_if_else_struct(2);
+}
+
+#[test]
+fn test_from_multiple_if_else_struct_value_42() {
+    from_multiple_if_else_struct(42);
+}
+
+#[inline(never)]
+pub fn from_multiple_if_else_struct(value: u64) {
+    let s = Struct {
+        x: 1111,
+        simple: if value == 1 {
+            Simple {
+                a: 111,
+                b: 22222,
+                c: true,
+                d: 33333u256,
+            }
+        } else if value == 2 {
+            create_some_simple(1)
+        } else {
+            create_some_simple(42)
+        },
+        b: true,
+    };
+
+    if value == 1 {
+        assert_simple(s.simple, 111, 22222, true, 33333u256);
+    } else if value == 2 {
+        assert_simple(s.simple, 1, 2, true, 3u256);
+    } else {
+        assert_simple(s.simple, 42, 2, true, 3u256);
+    }
+}
+
+#[test]
+fn test_from_multiple_if_else_struct_only_inits_value_1() {
+    from_multiple_if_else_struct_only_inits(1);
+}
+
+#[test]
+fn test_from_multiple_if_else_struct_only_inits_value_2() {
+    from_multiple_if_else_struct_only_inits(2);
+}
+
+#[test]
+fn test_from_multiple_if_else_struct_only_inits_value_42() {
+    from_multiple_if_else_struct_only_inits(42);
+}
+
+#[inline(never)]
+pub fn from_multiple_if_else_struct_only_inits(value: u64) {
+    let s = Struct {
+        x: 1111,
+        simple: if value == 1 {
+            Simple {
+                a: 111,
+                b: 22222,
+                c: true,
+                d: 33333u256,
+            }
+        } else if value == 2 {
+            Simple {
+                a: 222,
+                b: 33333,
+                c: true,
+                d: 44444u256,
+            }
+        } else {
+            Simple {
+                a: 255,
+                b: 44444,
+                c: true,
+                d: 55555u256,
+            }
+        },
+        b: true,
+    };
+
+    if value == 1 {
+        assert_simple(s.simple, 111, 22222, true, 33333u256);
+    } else if value == 2 {
+        assert_simple(s.simple, 222, 33333, true, 44444u256);
+    } else {
+        assert_simple(s.simple, 255, 44444, true, 55555u256);
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct_sroa.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct_sroa.sw
@@ -1,0 +1,99 @@
+//! Initialization of structs where only a single field is later accessed.
+//! This exercises the interaction between `init_aggr` lowering and SROA,
+//! which can eliminate the aggregate entirely once its fields are
+//! lowered to individual stores.
+library;
+
+use ::types::*;
+
+#[test]
+fn test_no_nesting_not_all_zeros() {
+    no_nesting_not_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_not_all_zeros() {
+    let s = NoNesting {
+        a: 42,
+        b: true,
+        c: 42u256,
+        d: b256::zero(),
+        u: (),
+    };
+
+    assert_eq(s.c, 42u256);
+}
+
+#[test]
+fn test_no_nesting_all_zeros() {
+    no_nesting_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_all_zeros() {
+    let s = NoNesting {
+        a: 0,
+        b: false,
+        c: 0u256,
+        d: b256::zero(),
+        u: (),
+    };
+
+    assert_eq(s.c, 0u256);
+}
+
+#[test]
+fn test_nested_not_all_zeros() {
+    nested_not_all_zeros();
+}
+
+#[inline(never)]
+pub fn nested_not_all_zeros() {
+    let s = Nested {
+        n1: NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        n2: NoNesting {
+            a: 42,
+            b: true,
+            c: 42u256,
+            d: b256::zero(),
+            u: (),
+        },
+    };
+
+    assert_eq(s.n1.c, 0u256);
+    assert_eq(s.n2.c, 42u256);
+}
+
+#[test]
+fn test_nested_all_zeros() {
+    nested_all_zeros();
+}
+
+#[inline(never)]
+pub fn nested_all_zeros() {
+    let s = Nested {
+        n1: NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        n2: NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+    };
+
+    assert_eq(s.n1.c, 0u256);
+    assert_eq(s.n2.c, 0u256);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct_with_str.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct_with_str.sw
@@ -1,0 +1,48 @@
+//! Initialization of structs containing string arrays (`str[N]`) and string
+//! slices (`str`). These fields are non-scalar and must be correctly copied
+//! by the `init_aggr` lowering.
+library;
+
+use ::types::*;
+
+struct StructWithStr {
+    f_u64: u64,
+    f_str_arr: str[5],
+    f_str: str,
+}
+
+#[test]
+fn test_all_empty() {
+    all_empty();
+}
+
+#[inline(never)]
+pub fn all_empty() {
+    let s = StructWithStr {
+        f_u64: 0,
+        f_str_arr: __to_str_array("     "),
+        f_str: " ",
+    };
+
+    assert_eq(s.f_u64, 0);
+    assert_eq(s.f_str_arr, __to_str_array("     "));
+    assert_eq(s.f_str, " ");
+}
+
+#[test]
+fn test_non_empty() {
+    non_empty();
+}
+
+#[inline(never)]
+pub fn non_empty() {
+    let s = StructWithStr {
+        f_u64: 42,
+        f_str_arr: __to_str_array("hello"),
+        f_str: "world",
+    };
+
+    assert_eq(s.f_u64, 42);
+    assert_eq(s.f_str_arr, __to_str_array("hello"));
+    assert_eq(s.f_str, "world");
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_tuple.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_tuple.sw
@@ -1,0 +1,75 @@
+//! Initialization of tuples, with and without nesting, all-zeros and
+//! not-all-zeros. Tuples are lowered as structs by the `init_aggr` lowering.
+library;
+
+use ::types::*;
+
+#[test]
+fn test_no_nesting_not_all_zeros() {
+    no_nesting_not_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_not_all_zeros() {
+    let t = (42u64, true, 42u256, b256::zero(), ());
+
+    assert_no_nesting_tuple(t, 42, true, 42u256, b256::zero());
+}
+
+#[test]
+fn test_no_nesting_all_zeros() {
+    no_nesting_all_zeros();
+}
+
+#[inline(never)]
+pub fn no_nesting_all_zeros() {
+    let t = (0u64, false, 0u256, b256::zero(), ());
+
+    assert_no_nesting_tuple_all_zeros(t);
+}
+
+#[test]
+fn test_nested_not_all_zeros() {
+    nested_not_all_zeros();
+}
+
+#[inline(never)]
+pub fn nested_not_all_zeros() {
+    let t = (
+        (0u64, false, 0u256, b256::zero(), ()),
+        (42u64, true, 42u256, b256::zero(), ()),
+    );
+
+    assert_no_nesting_tuple_all_zeros(t.0);
+    assert_no_nesting_tuple(t.1, 42, true, 42u256, b256::zero());
+}
+
+#[test]
+fn test_nested_all_zeros() {
+    nested_all_zeros();
+}
+
+#[inline(never)]
+pub fn nested_all_zeros() {
+    let t = (
+        (0u64, false, 0u256, b256::zero(), ()),
+        (0u64, false, 0u256, b256::zero(), ()),
+    );
+
+    assert_no_nesting_tuple_all_zeros(t.0);
+    assert_no_nesting_tuple_all_zeros(t.1);
+}
+
+#[test]
+fn test_single_element_tuple() {
+    single_element_tuple();
+}
+
+#[inline(never)]
+pub fn single_element_tuple() {
+    let t = (42u64,);
+    assert_eq(t.0, 42u64);
+
+    let z = (0u64,);
+    assert_eq(z.0, 0u64);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_with_ref_mut_args.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_with_ref_mut_args.sw
@@ -1,0 +1,73 @@
+//! Initialization of aggregates whose initializers are `ref mut` function
+//! arguments, and initialization from `self`. These tests `init_aggr`s
+//! whose initializer values are pointers to memory that must be correctly
+//! loaded/copied.
+library;
+
+use ::types::*;
+
+#[test]
+fn test_ref_mut_args() {
+    let mut a: u64 = 42;
+    let mut b: bool = true;
+    let mut c: u256 = 42u256;
+    let mut d: b256 = b256::zero();
+    let mut e: () = ();
+    let mut s: Struct = Struct {
+        x: 100,
+        simple: create_some_simple(10),
+        b: false,
+    };
+    ref_mut_args(a, b, c, d, e, s);
+}
+
+#[inline(never)]
+pub fn ref_mut_args(
+    ref mut a: u64,
+    ref mut b: bool,
+    ref mut c: u256,
+    ref mut d: b256,
+    ref mut e: (),
+    ref mut s: Struct,
+) {
+    let t = (a, b, c, d, e, s);
+
+    assert_eq(t.0, a);
+    assert_eq(t.1, b);
+    assert_eq(t.2, c);
+    assert_eq(t.3, d);
+    assert_eq(t.4, e);
+    assert_eq(t.5, s);
+}
+
+struct SelfCopieable {
+    value: u64,
+}
+
+impl SelfCopieable {
+    #[inline(never)]
+    pub fn copy_me(self) {
+        let copied = (self, self);
+        assert_eq(copied.0.value, self.value);
+        assert_eq(copied.1.value, self.value);
+    }
+
+    #[inline(never)]
+    pub fn copy_me_ref_mut(ref mut self) {
+        let copied = (self, self);
+        assert_eq(copied.0.value, self.value);
+        assert_eq(copied.1.value, self.value);
+    }
+}
+
+#[test]
+fn test_self_copieable_copy_me() {
+    let sc = SelfCopieable { value: 123 };
+    sc.copy_me();
+}
+
+#[test]
+fn test_self_copieable_copy_me_ref_mut() {
+    let mut sc = SelfCopieable { value: 456 };
+    sc.copy_me_ref_mut();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/issues.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/issues.sw
@@ -1,0 +1,50 @@
+//! Regression tests for issues found while developing the `init_aggr`
+//! optimization. These reproduce const-evaluation and lowering bugs around
+//! initialization of tuples containing large scalars (`u256`) built from
+//! runtime values, including through `std::crypto::point2d`.
+library;
+
+use ::types::*;
+use std::crypto::point2d::*;
+
+// Reproduces a const-eval issue where a tuple of `u256`s was initialized from
+// values copied out of a `Point2D` (i.e. from runtime pointers), wrapped in an
+// `Option`.
+#[test]
+fn test_const_eval_issue_extracted() {
+    // Use `zero()` (not `new()`): `zero()` produces valid 32-byte zero buffers,
+    // whereas `new()` produces empty `Bytes` and copying from them reads out of
+    // bounds. The initialization pattern being exercised (a tuple of `u256`s
+    // built from runtime pointer copies, wrapped in an `Option`) is the same.
+    let point = Point2D::zero();
+
+    let mut value_x = 0x0000000000000000000000000000000000000000000000000000000000000000_u256;
+    let mut value_y = 0x0000000000000000000000000000000000000000000000000000000000000000_u256;
+    let ptr_x = __addr_of(value_x);
+    let ptr_y = __addr_of(value_y);
+
+    point.x().ptr().copy_to::<u256>(ptr_x, 1);
+    point.y().ptr().copy_to::<u256>(ptr_y, 1);
+
+    let x = Some((value_x, value_y));
+
+    assert_eq(x.unwrap().0, value_x);
+    assert_eq(x.unwrap().1, value_y);
+    assert_eq(x.unwrap().0, 0u256);
+    assert_eq(x.unwrap().1, 0u256);
+}
+
+// Reproduces an issue where a `(u256, u256)` tuple produced by `TryFrom` for a
+// `Point2D` was incorrectly initialized.
+#[test]
+fn test_point2d_u256_tuple_try_from() {
+    let max = Point2D::from((
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256,
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256,
+    ));
+
+    let (x, y) = <(u256, u256) as TryFrom<Point2D>>::try_from(max).unwrap();
+
+    assert_eq(x, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256);
+    assert_eq(y, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/main.sw
@@ -1,0 +1,33 @@
+library;
+
+pub mod types;
+
+mod init_struct;
+mod init_struct_sroa;
+mod init_struct_from_branching;
+mod init_struct_with_str;
+
+mod init_array_repeat;
+mod init_array_repeat_sroa;
+mod init_array_not_repeat;
+mod init_array_repeat_split_block_insert_loop;
+
+mod init_tuple;
+
+mod init_with_ref_mut_args;
+
+mod init_mostly_zeroed;
+
+mod init_empty_aggregates;
+
+// Aggregates reducing to a single stored value (single-field/wrapper structs).
+mod init_single_store;
+
+// Aggregates containing enums.
+mod init_enums;
+
+// Additional mixed nesting constellations.
+mod init_misc_constellations;
+
+// Regression tests for issues found while developing the optimization.
+mod issues;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/types.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/types.sw
@@ -1,0 +1,152 @@
+//! Shared types and helper functions used across the `init_aggr` test modules.
+library;
+
+pub struct EmptyStruct {}
+
+impl PartialEq for EmptyStruct {
+    fn eq(self, other: Self) -> bool {
+        true
+    }
+}
+impl Eq for EmptyStruct {}
+
+pub struct EmptyStructContainer {
+    pub e: EmptyStruct,
+}
+
+impl PartialEq for EmptyStructContainer {
+    fn eq(self, other: Self) -> bool {
+        self.e == other.e
+    }
+}
+impl Eq for EmptyStructContainer {}
+
+
+#[inline(never)]
+pub fn return_empty_struct() -> EmptyStruct {
+    asm() {}; // To forbid const-eval.
+    EmptyStruct {}
+}
+
+/// A struct with no nested aggregates. Covers a mix of small and large scalar
+/// fields, as well as a zero-sized `()` field.
+pub struct NoNesting {
+    pub a: u64,
+    pub b: bool,
+    pub c: u256,
+    pub d: b256,
+    pub u: (),
+}
+
+impl NoNesting {
+    pub fn default() -> Self {
+        Self {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        }
+    }
+}
+
+impl PartialEq for NoNesting {
+    fn eq(self, other: Self) -> bool {
+        self.a == other.a && self.b == other.b && self.c == other.c && self.d == other.d && self.u == other.u
+    }
+}
+impl Eq for NoNesting {}
+
+/// A struct that nests two `NoNesting` structs. Covers nested `init_aggr`s.
+pub struct Nested {
+    pub n1: NoNesting,
+    pub n2: NoNesting,
+}
+
+pub struct Simple {
+    pub a: u8,
+    pub b: u64,
+    pub c: bool,
+    pub d: u256,
+}
+
+#[inline(never)]
+pub fn create_some_simple(a: u8) -> Simple {
+    Simple {
+        a,
+        b: 2,
+        c: true,
+        d: 3u256,
+    }
+}
+
+pub struct Struct {
+    pub x: u64,
+    pub simple: Simple,
+    pub b: bool,
+}
+
+impl PartialEq for Struct {
+    fn eq(self, other: Self) -> bool {
+        self.x == other.x && self.simple.a == other.simple.a && self.simple.b == other.simple.b && self.simple.c == other.simple.c && self.simple.d == other.simple.d && self.b == other.b
+    }
+}
+impl Eq for Struct {}
+
+#[inline(never)]
+pub fn assert_no_nesting_all_zeros(s: NoNesting) {
+    assert_eq(s.a, 0);
+    assert_eq(s.b, false);
+    assert_eq(s.c, 0u256);
+    assert_eq(s.d, b256::zero());
+    assert_eq(s.u, ());
+}
+
+#[inline(never)]
+pub fn assert_no_nesting(s: NoNesting, a: u64, b: bool, c: u256, d: b256) {
+    assert_eq(s.a, a);
+    assert_eq(s.b, b);
+    assert_eq(s.c, c);
+    assert_eq(s.d, d);
+    assert_eq(s.u, ());
+}
+
+#[inline(never)]
+pub fn assert_simple_all_zeros(s: Simple) {
+    assert_eq(s.a, 0);
+    assert_eq(s.b, 0);
+    assert_eq(s.c, false);
+    assert_eq(s.d, 0u256);
+}
+
+#[inline(never)]
+pub fn assert_simple(s: Simple, a: u8, b: u64, c: bool, d: u256) {
+    assert_eq(s.a, a);
+    assert_eq(s.b, b);
+    assert_eq(s.c, c);
+    assert_eq(s.d, d);
+}
+
+#[inline(never)]
+pub fn assert_no_nesting_tuple_all_zeros(t: (u64, bool, u256, b256, ())) {
+    assert_eq(t.0, 0);
+    assert_eq(t.1, false);
+    assert_eq(t.2, 0u256);
+    assert_eq(t.3, b256::zero());
+    assert_eq(t.4, ());
+}
+
+#[inline(never)]
+pub fn assert_no_nesting_tuple(
+    t: (u64, bool, u256, b256, ()),
+    a: u64,
+    b: bool,
+    c: u256,
+    d: b256,
+) {
+    assert_eq(t.0, a);
+    assert_eq(t.1, b);
+    assert_eq(t.2, c);
+    assert_eq(t.3, d);
+    assert_eq(t.4, ());
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/test.toml
@@ -1,0 +1,1 @@
+category = "unit_tests_pass"

--- a/test/src/ir_generation/tests/init_aggr_array_repeat_loop.sw
+++ b/test/src/ir_generation/tests/init_aggr_array_repeat_loop.sw
@@ -1,0 +1,43 @@
+script;
+
+// Large repeat arrays (length > 5) are lowered into an initialization loop.
+fn main() -> u64 {
+    let a = [7u64; 10];
+    a[1]
+}
+
+// ::check-ir::
+
+// check: local [u64; 10] __array_init_0
+
+// check: $(ptr_array_init=$VAL) = get_local __ptr [u64; 10], __array_init_0
+// check: $(c_7=$VAL) = const u64 7
+// check: init_aggr $ptr_array_init [$c_7 x 10]
+
+// ::check-ir-optimized::
+// pass: lower-init-aggr
+
+// The entry block branches into the loop with index 0.
+// check: $(ptr_array_init=$VAL) = get_local __ptr [u64; 10], __array_init_0
+// check: $(idx_init=$VAL) = const u64 0
+// check: br array_init_loop($idx_init)
+
+// The loop block: store the repeated value into `array[index]`.
+// check: array_init_loop(mut $(index=$VAL): u64):
+// check: $(ptr_elem=$VAL) = get_elem_ptr $ptr_array_init, __ptr u64, $index
+// check: $(c_7=$VAL) = const u64 7
+// check: store $c_7 to $ptr_elem
+
+// Increment the index and compare against the length.
+// check: $(c_1=$VAL) = const u64 1
+// check: $(index_inc=$VAL) = add $index, $c_1
+// check: $(c_len=$VAL) = const u64 10
+// check: $(continue=$VAL) = cmp lt $index_inc $c_len
+// check: cbr $continue, array_init_loop($index_inc), array_init_loop_exit()
+
+// The exit block loads the fully initialized array.
+// check: array_init_loop_exit():
+// check: load $ptr_array_init
+
+// There must be no `init_aggr` left after lowering.
+// not: init_aggr

--- a/test/src/ir_generation/tests/init_aggr_array_repeat_loop_in_struct.sw
+++ b/test/src/ir_generation/tests/init_aggr_array_repeat_loop_in_struct.sw
@@ -1,0 +1,59 @@
+script;
+
+// A large repeat array (length > 5) nested inside a struct. The array is
+// lowered into an initialization loop, but unlike the top-level case, the loop
+// operates on a pointer computed with a `get_elem_ptr` into the struct (the
+// non-empty GEP-indices branch of the lowering). The remaining scalar field is
+// stored in the loop's exit block.
+
+struct S {
+    head: u64,
+    body: [u64; 10],
+}
+
+fn main() -> u64 {
+    let s = S {
+        head: 3,
+        body: [7u64; 10],
+    };
+    s.body[1]
+}
+
+// ::check-ir::
+
+// check: local { u64, [u64; 10] } __struct_init_0
+
+// check: $(ptr_struct_init=$VAL) = get_local __ptr { u64, [u64; 10] }, __struct_init_0
+// check: init_aggr
+
+// ::check-ir-optimized::
+// pass: lower-init-aggr
+
+// check: $(ptr_struct_init=$VAL) = get_local __ptr { u64, [u64; 10] }, __struct_init_0
+
+// The pointer to the nested array field is computed with a GEP into the struct.
+// check: get_elem_ptr $ptr_struct_init, __ptr [u64; 10]
+
+// The array is initialized with a loop.
+// check: br array_init_loop($VAL)
+
+// check: array_init_loop(mut $(index=$VAL): u64):
+// check: $(ptr_elem=$VAL) = get_elem_ptr $(body_ptr=$VAL), __ptr u64, $index
+// check: $(c_7=$VAL) = const u64 7
+// check: store $c_7 to $ptr_elem
+// check: $(c_1=$VAL) = const u64 1
+// check: $(index_inc=$VAL) = add $index, $c_1
+// check: $(c_len=$VAL) = const u64 10
+// check: $(continue=$VAL) = cmp lt $index_inc $c_len
+// check: cbr $continue, array_init_loop($index_inc), array_init_loop_exit()
+
+// The scalar `head` field (index 0) is stored in the exit block.
+// check: array_init_loop_exit():
+// check: $(c_head_idx=$VAL) = const u64 0
+// check: $(ptr_head=$VAL) = get_elem_ptr $ptr_struct_init, __ptr u64, $c_head_idx
+// check: $(c_3=$VAL) = const u64 3
+// check: store $c_3 to $ptr_head
+// check: load $ptr_struct_init
+
+// There must be no `init_aggr` left after lowering.
+// not: init_aggr

--- a/test/src/ir_generation/tests/init_aggr_array_repeat_small.sw
+++ b/test/src/ir_generation/tests/init_aggr_array_repeat_small.sw
@@ -1,0 +1,47 @@
+script;
+
+// Small repeat arrays (length <= 5) are lowered into individual `store`s of the
+// repeated value into each element. The repeated value is emitted once and
+// reused for every element.
+
+fn main() -> u64 {
+    let a = [7u64; 3];
+    a[1]
+}
+
+// ::check-ir::
+
+// check: local [u64; 3] __array_init_0
+// check: local [u64; 3] a
+
+// check: $(ptr_array_init=$VAL) = get_local __ptr [u64; 3], __array_init_0
+// check: $(c_7=$VAL) = const u64 7
+// check: $(ptr_init_aggr=$VAL) = init_aggr $ptr_array_init [$c_7 x 3]
+// check: $(loaded_init_aggr=$VAL) = load $ptr_init_aggr
+// check: $(ptr_a=$VAL) = get_local __ptr [u64; 3], a
+// check: store $loaded_init_aggr to $ptr_a
+
+// ::check-ir-optimized::
+// pass: lower-init-aggr
+
+// check: $(ptr_array_init=$VAL) = get_local __ptr [u64; 3], __array_init_0
+
+// The repeated value is stored into every element individually. The repeated
+// value constant is emitted once and reused for all stores.
+// check: $(idx_0=$VAL) = const u64 0
+// check: $(ptr_array_0=$VAL) = get_elem_ptr $ptr_array_init, __ptr u64, $idx_0
+// check: $(c_7=$VAL) = const u64 7
+// check: store $c_7 to $ptr_array_0
+// check: $(idx_1=$VAL) = const u64 1
+// check: $(ptr_array_1=$VAL) = get_elem_ptr $ptr_array_init, __ptr u64, $idx_1
+// check: store $c_7 to $ptr_array_1
+// check: $(idx_2=$VAL) = const u64 2
+// check: $(ptr_array_2=$VAL) = get_elem_ptr $ptr_array_init, __ptr u64, $idx_2
+// check: store $c_7 to $ptr_array_2
+
+// check: $(load_array_init=$VAL) = load $ptr_array_init
+// check: $(ptr_a=$VAL) = get_local __ptr [u64; 3], a
+// check: store $load_array_init to $ptr_a
+
+// There must be no `init_aggr` left after lowering.
+// not: init_aggr

--- a/test/src/ir_generation/tests/init_aggr_array_repeat_struct.sw
+++ b/test/src/ir_generation/tests/init_aggr_array_repeat_struct.sw
@@ -1,0 +1,60 @@
+script;
+
+// A repeat array whose repeated element is itself an aggregate (a nested
+// `init_aggr`). The nested aggregate is first initialized into its own
+// temporary, then loaded once, and that loaded value is stored into every
+// element of the array. The nested `init_aggr` is thus completely removed.
+
+struct Record {
+    a: u64,
+    b: u64,
+}
+
+fn main() -> u64 {
+    let a = [Record { a: 1, b: 2 }; 3];
+    a[1].a
+}
+
+// ::check-ir::
+
+// check: local [{ u64, u64 }; 3] __array_init_0
+// check: local { u64, u64 } __struct_init_0
+
+// The nested struct `init_aggr` provides the repeated value for the array `init_aggr`.
+// check: $(ptr_struct_init=$VAL) = get_local __ptr { u64, u64 }, __struct_init_0
+// check: $(nested_init_aggr=$VAL) = init_aggr $ptr_struct_init
+// check: $(nested_load=$VAL) = load $nested_init_aggr
+// check: init_aggr $(arr_ptr=$VAL) [$nested_load x 3]
+
+// ::check-ir-optimized::
+// pass: lower-init-aggr
+
+// check: $(ptr_array_init=$VAL) = get_local __ptr [{ u64, u64 }; 3], __array_init_0
+// check: $(ptr_struct_init=$VAL) = get_local __ptr { u64, u64 }, __struct_init_0
+
+// The nested struct is initialized into its own temporary.
+// check: $(c_0a=$VAL) = const u64 0
+// check: $(ptr_field_a=$VAL) = get_elem_ptr $ptr_struct_init, __ptr u64, $c_0a
+// check: $(c_1=$VAL) = const u64 1
+// check: store $c_1 to $ptr_field_a
+// check: $(c_1b=$VAL) = const u64 1
+// check: $(ptr_field_b=$VAL) = get_elem_ptr $ptr_struct_init, __ptr u64, $c_1b
+// check: $(c_2=$VAL) = const u64 2
+// check: store $c_2 to $ptr_field_b
+
+// The nested aggregate is loaded once and stored into every array element.
+// check: $(repeated=$VAL) = load $ptr_struct_init
+// check: $(idx_0=$VAL) = const u64 0
+// check: $(ptr_elem_0=$VAL) = get_elem_ptr $ptr_array_init, __ptr { u64, u64 }, $idx_0
+// check: store $repeated to $ptr_elem_0
+// check: $(idx_1=$VAL) = const u64 1
+// check: $(ptr_elem_1=$VAL) = get_elem_ptr $ptr_array_init, __ptr { u64, u64 }, $idx_1
+// check: store $repeated to $ptr_elem_1
+// check: $(idx_2=$VAL) = const u64 2
+// check: $(ptr_elem_2=$VAL) = get_elem_ptr $ptr_array_init, __ptr { u64, u64 }, $idx_2
+// check: store $repeated to $ptr_elem_2
+
+// check: load $ptr_array_init
+
+// There must be no `init_aggr` left after lowering.
+// not: init_aggr


### PR DESCRIPTION
## Description

This PR adds comprehensive test suite for aggregates initialization. Most of these tests are ported from tryouts and examples used while developing #7530. They also cover cases of initializing mostly-zeroed aggregates that we want to further improve in #7542.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.