### PR TITLE
Add additional tests for `init_aggr` instruction and its lowering

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_not_repeat.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_not_repeat.sw
@@ -132,6 +132,16 @@ pub fn no_nesting_all_zeros() {
         d: b256::zero(),
         u: (),
     });
+
+    // Additionally validate each element field-by-field against primitive
+    // literals. The aggregate-level assert above compares against a `NoNesting`
+    // that is itself created via `init_aggr`, so a bug shared between the
+    // element initialization and the expected value could otherwise be masked.
+    let mut i = 0;
+    while i < 10 {
+        assert_no_nesting_all_zeros(a[i]);
+        i += 1;
+    }
 }
 
 #[test]
@@ -221,6 +231,124 @@ pub fn no_nesting_not_all_zeros() {
         d: b256::zero(),
         u: (),
     });
+
+    // Additionally validate each element field-by-field against primitive literals.
+    let mut i = 0;
+    while i < 10 {
+        assert_no_nesting(a[i], 42, true, 42u256, b256::zero());
+        i += 1;
+    }
+}
+
+#[test]
+fn test_no_nesting_mostly_zeros() {
+    no_nesting_mostly_zeros();
+}
+
+/// A mostly-zeroed array of structs. Most elements are fully zero, and the few
+/// non-zero elements each make a *different* single primitive field non-zero, so
+/// that on top of the zero-cleared aggregate we exercise storing each nested
+/// primitive type (`u64`, `bool`, `u256`, `b256`).
+#[inline(never)]
+pub fn no_nesting_mostly_zeros() {
+    let a = [
+        // index 0: `u64` field non-zero.
+        NoNesting {
+            a: 42,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        // index 1: all zero.
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        // index 2: `bool` field non-zero.
+        NoNesting {
+            a: 0,
+            b: true,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        // index 3: all zero.
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        // index 4: `u256` field non-zero.
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 123u256,
+            d: b256::zero(),
+            u: (),
+        },
+        // index 5: all zero.
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        // index 6: `b256` field non-zero.
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: 0x00000000000000000000000000000000000000000000000000000000000000FF,
+            u: (),
+        },
+        // indices 7, 8, 9: all zero.
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+    ];
+
+    // Validate each element field-by-field against primitive literals.
+    assert_no_nesting(a[0], 42, false, 0u256, b256::zero());
+    assert_no_nesting_all_zeros(a[1]);
+    assert_no_nesting(a[2], 0, true, 0u256, b256::zero());
+    assert_no_nesting_all_zeros(a[3]);
+    assert_no_nesting(a[4], 0, false, 123u256, b256::zero());
+    assert_no_nesting_all_zeros(a[5]);
+    assert_no_nesting(
+        a[6],
+        0,
+        false,
+        0u256,
+        0x00000000000000000000000000000000000000000000000000000000000000FF,
+    );
+    assert_no_nesting_all_zeros(a[7]);
+    assert_no_nesting_all_zeros(a[8]);
+    assert_no_nesting_all_zeros(a[9]);
 }
 
 #[test]
@@ -311,6 +439,13 @@ pub fn single_field_struct_not_zero() {
         SingleFieldStruct { a: 42 },
     ];
     assert_all_elems_equal(a, SingleFieldStruct { a: 42 });
+
+    // Additionally validate each element's field against a primitive literal.
+    let mut i = 0;
+    while i < 10 {
+        assert_eq(a[i].a, 42);
+        i += 1;
+    }
 }
 
 #[test]
@@ -350,6 +485,19 @@ pub fn u64_all_zeros_array_nested_in_array() {
         [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ];
     assert_all_elems_equal(a, [0u64, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+    // Additionally validate each individual element against a primitive literal.
+    // The aggregate-level assert above compares against an array literal that is
+    // itself created via `init_aggr`.
+    let mut i = 0;
+    while i < 10 {
+        let mut j = 0;
+        while j < 10 {
+            assert_eq(a[i][j], 0u64);
+            j += 1;
+        }
+        i += 1;
+    }
 }
 
 #[test]
@@ -372,6 +520,17 @@ pub fn u64_all_42s_array_nested_in_array() {
         [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42],
     ];
     assert_all_elems_equal(a, [42u64, 42, 42, 42, 42, 42, 42, 42, 42, 42]);
+
+    // Additionally validate each individual element against a primitive literal.
+    let mut i = 0;
+    while i < 10 {
+        let mut j = 0;
+        while j < 10 {
+            assert_eq(a[i][j], 42u64);
+            j += 1;
+        }
+        i += 1;
+    }
 }
 
 #[test]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_array_repeat.sw
@@ -53,6 +53,16 @@ pub fn no_nesting_all_zeros_repeat() {
         d: b256::zero(),
         u: (),
     });
+
+    // Additionally validate each element field-by-field against primitive
+    // literals. The aggregate-level assert above compares against a `NoNesting`
+    // that is itself created via `init_aggr`, so a bug shared between the
+    // element initialization and the expected value could otherwise be masked.
+    let mut i = 0;
+    while i < 10 {
+        assert_no_nesting_all_zeros(a[i]);
+        i += 1;
+    }
 }
 
 #[test]
@@ -79,6 +89,42 @@ pub fn no_nesting_not_all_zeros_repeat() {
         d: b256::zero(),
         u: (),
     });
+
+    // Additionally validate each element field-by-field against primitive literals.
+    let mut i = 0;
+    while i < 10 {
+        assert_no_nesting(a[i], 42, true, 42u256, b256::zero());
+        i += 1;
+    }
+}
+
+#[test]
+fn test_no_nesting_mostly_zeros_repeat() {
+    no_nesting_mostly_zeros_repeat();
+}
+
+/// A repeat array of a mostly-zeroed struct. Every element is the same struct
+/// whose only non-zero field is a large `u256`, so the whole array is mostly
+/// zeroed. This exercises the interaction between the mostly-zeroed lowering
+/// (`mem_clear_val` for the whole array) and the repeat-array lowering (which
+/// still has to store the non-zero field into every element).
+#[inline(never)]
+pub fn no_nesting_mostly_zeros_repeat() {
+    let a = [
+        NoNesting {
+            a: 0,
+            b: false,
+            c: 123u256,
+            d: b256::zero(),
+            u: (),
+        }; 10
+    ];
+
+    let mut i = 0;
+    while i < 10 {
+        assert_no_nesting(a[i], 0, false, 123u256, b256::zero());
+        i += 1;
+    }
 }
 
 #[test]
@@ -145,6 +191,13 @@ pub fn single_field_struct_not_zero_repeat() {
     let a = [SingleFieldStruct { a: 42 }; 10];
 
     assert_all_elems_equal(a, SingleFieldStruct { a: 42 });
+
+    // Additionally validate each element's field against a primitive literal.
+    let mut i = 0;
+    while i < 10 {
+        assert_eq(a[i].a, 42);
+        i += 1;
+    }
 }
 
 #[test]
@@ -167,6 +220,17 @@ fn test_u64_all_zeros_array_nested_in_array_repeat() {
 pub fn u64_all_zeros_array_nested_in_array_repeat() {
     let a = [[0u64; 10]; 10];
     assert_all_elems_equal(a, [0u64; 10]);
+
+    // Additionally validate each individual element against a primitive literal.
+    let mut i = 0;
+    while i < 10 {
+        let mut j = 0;
+        while j < 10 {
+            assert_eq(a[i][j], 0u64);
+            j += 1;
+        }
+        i += 1;
+    }
 }
 
 #[test]
@@ -178,6 +242,17 @@ fn test_u64_all_42s_array_nested_in_array_repeat() {
 pub fn u64_all_42s_array_nested_in_array_repeat() {
     let a = [[42u64; 10]; 10];
     assert_all_elems_equal(a, [42u64; 10]);
+
+    // Additionally validate each individual element against a primitive literal.
+    let mut i = 0;
+    while i < 10 {
+        let mut j = 0;
+        while j < 10 {
+            assert_eq(a[i][j], 42u64);
+            j += 1;
+        }
+        i += 1;
+    }
 }
 
 #[test]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_enums.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_enums.sw
@@ -78,6 +78,17 @@ pub fn tuple_with_enum() {
     assert_eq(t.0, 0);
     assert_eq(t.1, E::Pair((1, 2u256)));
     assert_eq(t.2, 0);
+
+    // The `E::Pair` payload is a tuple built via `init_aggr`, and the expected
+    // `E::Pair((1, 2u256))` above builds it the same way. Additionally validate
+    // the payload field-by-field against primitive literals.
+    match t.1 {
+        E::Pair(p) => {
+            assert_eq(p.0, 1u64);
+            assert_eq(p.1, 2u256);
+        },
+        _ => assert(false),
+    }
 }
 
 #[test]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_misc_constellations.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_misc_constellations.sw
@@ -203,3 +203,55 @@ pub fn large_repeat_array_of_struct() {
         i += 1;
     }
 }
+
+// A struct that embeds an array and is mostly zeroed: everything is zero except a
+// single trailing scalar. Hits the mostly-zeroed lowering for a struct that
+// embeds an array (the zeroed array must not be re-initialized element by
+// element).
+#[test]
+fn test_struct_with_array_mostly_zeros() {
+    struct_with_array_mostly_zeros();
+}
+
+#[inline(never)]
+pub fn struct_with_array_mostly_zeros() {
+    let s = WithArray {
+        head: 0,
+        body: [0, 0, 0, 0],
+        tail: 7,
+    };
+
+    assert_eq(s.head, 0);
+    let mut i = 0;
+    while i < 4 {
+        assert_eq(s.body[i], 0u64);
+        i += 1;
+    }
+    assert_eq(s.tail, 7);
+}
+
+// A tuple that embeds a mostly-zeroed struct (only its `u256` field is non-zero)
+// followed by zero scalars. Exercises the mostly-zeroed lowering reaching a
+// non-zero leaf nested inside a struct nested inside a tuple.
+#[test]
+fn test_tuple_with_mostly_zero_struct() {
+    tuple_with_mostly_zero_struct();
+}
+
+#[inline(never)]
+pub fn tuple_with_mostly_zero_struct() {
+    let t = (
+        Simple {
+            a: 0,
+            b: 0,
+            c: false,
+            d: 5u256,
+        },
+        0u64,
+        0u64,
+    );
+
+    assert_simple(t.0, 0, 0, false, 5u256);
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2, 0u64);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_struct.sw
@@ -94,3 +94,76 @@ pub fn nested_all_zeros() {
     assert_no_nesting_all_zeros(s.n1);
     assert_no_nesting_all_zeros(s.n2);
 }
+
+// Mostly-zeroed struct variants. Only a single field is non-zero, so the struct
+// hits the mostly-zeroed lowering (`mem_clear_val` for the whole struct followed
+// by a `store` for the non-zero field). The `init_mostly_zeroed` module already
+// covers the `u256` and `b256` non-zero cases for `NoNesting`; here we complement
+// it with the `u64` and `bool` non-zero cases, so that storing each nested
+// primitive type on top of a zero-cleared struct is covered.
+
+#[test]
+fn test_no_nesting_mostly_zeros_u64() {
+    no_nesting_mostly_zeros_u64();
+}
+
+#[inline(never)]
+pub fn no_nesting_mostly_zeros_u64() {
+    let s = NoNesting {
+        a: 42,
+        b: false,
+        c: 0u256,
+        d: b256::zero(),
+        u: (),
+    };
+
+    assert_no_nesting(s, 42, false, 0u256, b256::zero());
+}
+
+#[test]
+fn test_no_nesting_mostly_zeros_bool() {
+    no_nesting_mostly_zeros_bool();
+}
+
+#[inline(never)]
+pub fn no_nesting_mostly_zeros_bool() {
+    let s = NoNesting {
+        a: 0,
+        b: true,
+        c: 0u256,
+        d: b256::zero(),
+        u: (),
+    };
+
+    assert_no_nesting(s, 0, true, 0u256, b256::zero());
+}
+
+// A nested struct that is mostly zeroed, with a non-zero leaf in each of the two
+// nested structs, exercising different primitive types (`bool` and `u256`).
+#[test]
+fn test_nested_mostly_zeros() {
+    nested_mostly_zeros();
+}
+
+#[inline(never)]
+pub fn nested_mostly_zeros() {
+    let s = Nested {
+        n1: NoNesting {
+            a: 0,
+            b: true,
+            c: 0u256,
+            d: b256::zero(),
+            u: (),
+        },
+        n2: NoNesting {
+            a: 0,
+            b: false,
+            c: 99u256,
+            d: b256::zero(),
+            u: (),
+        },
+    };
+
+    assert_no_nesting(s.n1, 0, true, 0u256, b256::zero());
+    assert_no_nesting(s.n2, 0, false, 99u256, b256::zero());
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_tuple.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_tuple.sw
@@ -60,6 +60,48 @@ pub fn nested_all_zeros() {
     assert_no_nesting_tuple_all_zeros(t.1);
 }
 
+// Mostly-zeroed tuples where a single element is non-zero, so the tuple hits the
+// mostly-zeroed lowering. Each test makes a *different* primitive element
+// non-zero. The `init_mostly_zeroed` module already covers the `u64` non-zero
+// case, so here we cover `bool`, `u256` and `b256`.
+
+#[test]
+fn test_mostly_zeros_bool_non_zero() {
+    mostly_zeros_bool_non_zero();
+}
+
+#[inline(never)]
+pub fn mostly_zeros_bool_non_zero() {
+    let t = (0u64, true, 0u256, b256::zero(), ());
+
+    assert_no_nesting_tuple(t, 0, true, 0u256, b256::zero());
+}
+
+#[test]
+fn test_mostly_zeros_u256_non_zero() {
+    mostly_zeros_u256_non_zero();
+}
+
+#[inline(never)]
+pub fn mostly_zeros_u256_non_zero() {
+    let t = (0u64, false, 123u256, b256::zero(), ());
+
+    assert_no_nesting_tuple(t, 0, false, 123u256, b256::zero());
+}
+
+#[test]
+fn test_mostly_zeros_b256_non_zero() {
+    mostly_zeros_b256_non_zero();
+}
+
+#[inline(never)]
+pub fn mostly_zeros_b256_non_zero() {
+    let d = 0x00000000000000000000000000000000000000000000000000000000000000FF;
+    let t = (0u64, false, 0u256, d, ());
+
+    assert_no_nesting_tuple(t, 0, false, 0u256, d);
+}
+
 #[test]
 fn test_single_element_tuple() {
     single_element_tuple();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_with_ref_mut_args.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/init_with_ref_mut_args.sw
@@ -38,6 +38,16 @@ pub fn ref_mut_args(
     assert_eq(t.3, d);
     assert_eq(t.4, e);
     assert_eq(t.5, s);
+
+    // The `t.5 == s` assert above compares two `Struct`s that are both created
+    // via `init_aggr`. Additionally validate the struct element field-by-field
+    // against the primitive literals used by the single caller of this function.
+    assert_eq(t.5.x, 100);
+    assert_eq(t.5.simple.a, 10);
+    assert_eq(t.5.simple.b, 2);
+    assert_eq(t.5.simple.c, true);
+    assert_eq(t.5.simple.d, 3u256);
+    assert_eq(t.5.b, false);
 }
 
 struct SelfCopieable {
@@ -45,29 +55,37 @@ struct SelfCopieable {
 }
 
 impl SelfCopieable {
+    // `expected` is the primitive literal `value` the caller initialized `self`
+    // with. We assert against it in addition to `self.value`, because `self` is
+    // itself created via `init_aggr` and asserting only against `self.value`
+    // would compare two identically-initialized values.
     #[inline(never)]
-    pub fn copy_me(self) {
+    pub fn copy_me(self, expected: u64) {
         let copied = (self, self);
         assert_eq(copied.0.value, self.value);
         assert_eq(copied.1.value, self.value);
+        assert_eq(copied.0.value, expected);
+        assert_eq(copied.1.value, expected);
     }
 
     #[inline(never)]
-    pub fn copy_me_ref_mut(ref mut self) {
+    pub fn copy_me_ref_mut(ref mut self, expected: u64) {
         let copied = (self, self);
         assert_eq(copied.0.value, self.value);
         assert_eq(copied.1.value, self.value);
+        assert_eq(copied.0.value, expected);
+        assert_eq(copied.1.value, expected);
     }
 }
 
 #[test]
 fn test_self_copieable_copy_me() {
     let sc = SelfCopieable { value: 123 };
-    sc.copy_me();
+    sc.copy_me(123);
 }
 
 #[test]
 fn test_self_copieable_copy_me_ref_mut() {
     let mut sc = SelfCopieable { value: 456 };
-    sc.copy_me_ref_mut();
+    sc.copy_me_ref_mut(456);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/issues.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/init_aggr/src/issues.sw
@@ -48,3 +48,360 @@ fn test_point2d_u256_tuple_try_from() {
     assert_eq(x, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256);
     assert_eq(y, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256);
 }
+
+// The tests below reproduce edge cases stumbled upon while developing the
+// mostly-zeroed aggregates lowering. They stress the size/zero-ratio analysis
+// and the recursive lowering on unusual shapes: `u8`s laid out in tuples
+// (word-aligned) vs. arrays (packed), non-zero leaves at non-leading positions,
+// single-element arrays/tuples, and deeply nested single-element aggregates like
+// `((([0], ), ), )` and `[[[[0]]]]`.
+
+// A mostly-zeroed tuple whose first element is a repeat array of `u8`, with a
+// nested all-zero tuple in the middle and many trailing zero scalars.
+#[test]
+fn test_mostly_zeroed_repeat_array_and_nested_tuple() {
+    mostly_zeroed_repeat_array_and_nested_tuple();
+}
+
+#[inline(never)]
+pub fn mostly_zeroed_repeat_array_and_nested_tuple() {
+    let t = (
+        [42u8; 8],
+        0u64,
+        (0u64, 0u64, 0u64),
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+    );
+
+    let mut i = 0;
+    while i < 8 {
+        assert_eq(t.0[i], 42u8);
+        i += 1;
+    }
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2.0, 0u64);
+    assert_eq(t.2.1, 0u64);
+    assert_eq(t.2.2, 0u64);
+    assert_eq(t.3, 0u64);
+    assert_eq(t.4, 0u64);
+    assert_eq(t.5, 0u64);
+    assert_eq(t.6, 0u64);
+    assert_eq(t.7, 0u64);
+    assert_eq(t.8, 0u64);
+    assert_eq(t.9, 0u64);
+}
+
+// Same shape, but the nested all-zero tuple comes from a local variable (a
+// runtime-zeroed aggregate initializer) rather than an inline nested `init_aggr`.
+#[test]
+fn test_mostly_zeroed_nested_tuple_from_variable() {
+    mostly_zeroed_nested_tuple_from_variable();
+}
+
+#[inline(never)]
+pub fn mostly_zeroed_nested_tuple_from_variable() {
+    let inner_tuple = (0u64, 0u64, 0u64);
+    let t = (
+        [42u8; 8],
+        0u64,
+        inner_tuple,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+    );
+
+    let mut i = 0;
+    while i < 8 {
+        assert_eq(t.0[i], 42u8);
+        i += 1;
+    }
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2.0, 0u64);
+    assert_eq(t.2.1, 0u64);
+    assert_eq(t.2.2, 0u64);
+    assert_eq(t.3, 0u64);
+    assert_eq(t.4, 0u64);
+    assert_eq(t.5, 0u64);
+    assert_eq(t.6, 0u64);
+    assert_eq(t.7, 0u64);
+    assert_eq(t.8, 0u64);
+    assert_eq(t.9, 0u64);
+}
+
+// The eight leading non-zero `u8`s are laid out as a *tuple*. In a tuple each
+// `u8` is aligned to a word, so the non-zero part is 8 * 8 bytes, giving a
+// different zero-ratio than the packed-array variant below.
+#[test]
+fn test_mostly_zeroed_leading_u8_tuple() {
+    mostly_zeroed_leading_u8_tuple();
+}
+
+#[inline(never)]
+pub fn mostly_zeroed_leading_u8_tuple() {
+    let t = (
+        (42u8, 42u8, 42u8, 42u8, 42u8, 42u8, 42u8, 42u8),
+        0u64,
+        (0u64, 0u64, 0u64),
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+    );
+
+    assert_eq(t.0.0, 42u8);
+    assert_eq(t.0.1, 42u8);
+    assert_eq(t.0.2, 42u8);
+    assert_eq(t.0.3, 42u8);
+    assert_eq(t.0.4, 42u8);
+    assert_eq(t.0.5, 42u8);
+    assert_eq(t.0.6, 42u8);
+    assert_eq(t.0.7, 42u8);
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2.0, 0u64);
+    assert_eq(t.2.1, 0u64);
+    assert_eq(t.2.2, 0u64);
+    assert_eq(t.3, 0u64);
+    assert_eq(t.4, 0u64);
+    assert_eq(t.5, 0u64);
+    assert_eq(t.6, 0u64);
+    assert_eq(t.7, 0u64);
+    assert_eq(t.8, 0u64);
+    assert_eq(t.9, 0u64);
+}
+
+// The same eight leading non-zero `u8`s, but laid out as an *array*. In an array
+// the `u8` elements are packed (1 byte each), so the counting of zero/non-zero
+// sizes differs from the tuple variant above.
+#[test]
+fn test_mostly_zeroed_leading_u8_array() {
+    mostly_zeroed_leading_u8_array();
+}
+
+#[inline(never)]
+pub fn mostly_zeroed_leading_u8_array() {
+    let t = (
+        [42u8, 42u8, 42u8, 42u8, 42u8, 42u8, 42u8, 42u8],
+        0u64,
+        (0u64, 0u64, 0u64),
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+    );
+
+    let mut i = 0;
+    while i < 8 {
+        assert_eq(t.0[i], 42u8);
+        i += 1;
+    }
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2.0, 0u64);
+    assert_eq(t.2.1, 0u64);
+    assert_eq(t.2.2, 0u64);
+    assert_eq(t.3, 0u64);
+    assert_eq(t.4, 0u64);
+    assert_eq(t.5, 0u64);
+    assert_eq(t.6, 0u64);
+    assert_eq(t.7, 0u64);
+    assert_eq(t.8, 0u64);
+    assert_eq(t.9, 0u64);
+}
+
+// A tiny tuple sitting right at the zero-ratio boundary (a zero `u8` aligned to a
+// word, plus one non-zero `u64`).
+#[test]
+fn test_half_zeroed_u8_and_u64_tuple() {
+    half_zeroed_u8_and_u64_tuple();
+}
+
+#[inline(never)]
+pub fn half_zeroed_u8_and_u64_tuple() {
+    let t = (0u8, 42u64);
+
+    assert_eq(t.0, 0u8);
+    assert_eq(t.1, 42u64);
+}
+
+// Same as above, but the zero `u8` is wrapped in a single-element array, so it is
+// counted as packed (1 byte) rather than word-aligned.
+#[test]
+fn test_half_zeroed_single_elem_u8_array_and_u64() {
+    half_zeroed_single_elem_u8_array_and_u64();
+}
+
+#[inline(never)]
+pub fn half_zeroed_single_elem_u8_array_and_u64() {
+    let t = ([0u8], 42u64);
+
+    assert_eq(t.0[0], 0u8);
+    assert_eq(t.1, 42u64);
+}
+
+// A mostly-zeroed aggregate whose non-zero leaves are *not* at the leading
+// positions: one in the middle of the array, one in the middle of the nested
+// tuple. Exercises storing non-zero values at arbitrary offsets after the
+// `mem_clear_val`.
+#[test]
+fn test_mostly_zeroed_non_zero_in_the_middle() {
+    mostly_zeroed_non_zero_in_the_middle();
+}
+
+#[inline(never)]
+pub fn mostly_zeroed_non_zero_in_the_middle() {
+    let t = (
+        [0u8, 0u8, 0u8, 0u8, 0u8, 42u8, 0u8, 0u8],
+        0u64,
+        (0u64, 42u64, 0u64),
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+        0u64,
+    );
+
+    let mut i = 0;
+    while i < 8 {
+        if i == 5 {
+            assert_eq(t.0[i], 42u8);
+        } else {
+            assert_eq(t.0[i], 0u8);
+        }
+        i += 1;
+    }
+    assert_eq(t.1, 0u64);
+    assert_eq(t.2.0, 0u64);
+    assert_eq(t.2.1, 42u64);
+    assert_eq(t.2.2, 0u64);
+    assert_eq(t.3, 0u64);
+    assert_eq(t.4, 0u64);
+    assert_eq(t.5, 0u64);
+    assert_eq(t.6, 0u64);
+    assert_eq(t.7, 0u64);
+    assert_eq(t.8, 0u64);
+    assert_eq(t.9, 0u64);
+}
+
+// A single-element array. Such arrays are treated as non-repeat by the lowering.
+#[test]
+fn test_single_element_array_zero() {
+    single_element_array_zero();
+}
+
+#[inline(never)]
+pub fn single_element_array_zero() {
+    let a = [0];
+
+    assert_eq(a[0], 0);
+}
+
+// A single-element tuple.
+#[test]
+fn test_single_element_tuple_zero() {
+    single_element_tuple_zero();
+}
+
+#[inline(never)]
+pub fn single_element_tuple_zero() {
+    let t = (0,);
+
+    assert_eq(t.0, 0);
+}
+
+// A single-element tuple whose only element is a single-element array.
+#[test]
+fn test_single_element_tuple_of_single_element_array() {
+    single_element_tuple_of_single_element_array();
+}
+
+#[inline(never)]
+pub fn single_element_tuple_of_single_element_array() {
+    let t = ([0],);
+
+    assert_eq(t.0[0], 0);
+}
+
+// Deeply nested single-element tuples ending in a single-element array:
+// `((([0], ), ), )`.
+#[test]
+fn test_deeply_nested_single_element_tuples_and_array() {
+    deeply_nested_single_element_tuples_and_array();
+}
+
+#[inline(never)]
+pub fn deeply_nested_single_element_tuples_and_array() {
+    let t = ((([0],),),);
+
+    assert_eq(t.0.0.0[0], 0);
+}
+
+// Same deeply nested shape, but with a `u256` leaf, i.e. a large scalar.
+#[test]
+fn test_deeply_nested_single_element_tuples_and_array_u256() {
+    deeply_nested_single_element_tuples_and_array_u256();
+}
+
+#[inline(never)]
+pub fn deeply_nested_single_element_tuples_and_array_u256() {
+    let t = ((([0u256],),),);
+
+    assert_eq(t.0.0.0[0], 0u256);
+}
+
+// Four levels of nested single-element arrays: `[[[[0u64]]]]`.
+#[test]
+fn test_deeply_nested_single_element_arrays() {
+    deeply_nested_single_element_arrays();
+}
+
+#[inline(never)]
+pub fn deeply_nested_single_element_arrays() {
+    let a = [[[[0u64]]]];
+
+    assert_eq(a[0][0][0][0], 0u64);
+}
+
+// Four levels of nested arrays where the innermost array has two elements:
+// `[[[[0u64, 0u64]]]]`.
+#[test]
+fn test_deeply_nested_arrays() {
+    deeply_nested_arrays();
+}
+
+#[inline(never)]
+pub fn deeply_nested_arrays() {
+    let a = [[[[0u64, 0u64]]]];
+
+    assert_eq(a[0][0][0][0], 0u64);
+    assert_eq(a[0][0][0][1], 0u64);
+}
+
+// Same as above, but with `u256` leaves.
+#[test]
+fn test_deeply_nested_arrays_u256() {
+    deeply_nested_arrays_u256();
+}
+
+#[inline(never)]
+pub fn deeply_nested_arrays_u256() {
+    let a = [[[[0u256, 0u256]]]];
+
+    assert_eq(a[0][0][0][0], 0u256);
+    assert_eq(a[0][0][0][1], 0u256);
+}


### PR DESCRIPTION
## Description

This PR extends #7677 by:
- addressing the issue of circular validation. In some of the tests, a created nested aggregate was asserted aginst an expected aggregate. A potential bug in initialization that might produce a same invalid value in the nested and expected aggregate would pass unnoticed.
- adding more tests for the mostly-zeroed aggregates optimization that is being developed in #7542.
- adding more `issues` tests. Those cover edge cases inspected while working on #7542 that were causing ICEs or sub-optimal lowerings.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.