### PR TITLE
Fix `copy_prop_reverse` cycle detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,14 +1927,14 @@ checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "duct"
-version = "0.13.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+checksum = "7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684"
 dependencies = [
  "libc",
- "once_cell",
  "os_pipe",
  "shared_child",
+ "shared_thread",
 ]
 
 [[package]]
@@ -7245,6 +7245,12 @@ dependencies = [
  "sigchld",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "shared_thread"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
 
 [[package]]
 name = "shell-words"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ devault = "0.2"
 dir_indexer = "0.0"
 dirs = "5.0"
 downcast-rs = "1.2"
-duct = { version = "1.1.1", features = ["timeout"] }
+duct = { version = "1.1", features = ["timeout"] }
 duplicate = "2.0"
 either = "1.9"
 escargot = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ devault = "0.2"
 dir_indexer = "0.0"
 dirs = "5.0"
 downcast-rs = "1.2"
-duct = "0.13"
+duct = { version = "1.1.1", features = ["timeout"] }
 duplicate = "2.0"
 either = "1.9"
 escargot = "0.5"

--- a/sway-ir/src/analysis/memory_utils.rs
+++ b/sway-ir/src/analysis/memory_utils.rs
@@ -37,7 +37,7 @@ impl Symbol {
         }
     }
 
-    pub fn _get_name(&self, context: &Context, function: Function) -> String {
+    pub fn get_name(&self, context: &Context, function: Function) -> String {
         match self {
             Symbol::Local(l) => function.lookup_local_name(context, l).unwrap().clone(),
             Symbol::Arg(ba) => format!("{}[{}]", ba.block.get_label(context), ba.idx),

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -1248,7 +1248,29 @@ fn copy_prop_reverse(
         }
     }
 
-    // Abort on cycles
+    // We currently do not optimize cycles
+    //
+    // TODO: https://github.com/FuelLabs/sway/issues/7282#issuecomment-5196527165
+    // It is not entirely true that we cannot optimize cycles.
+    // We currently bail on all cycles because `solve_transitive_copies`
+    // needs every "memcpy chain" to finish with a symbol that is never the
+    // destination of a candidate memcpy, and a cycle does not have that.
+    // But some cycles are in fact optimizable:
+    //
+    // - Self-loops: src_to_dst { x -> x }. A self-copy is a no-op and
+    // can simply be deleted.
+    //
+    // - All items have the same value: src_to_dst { a <- b; c <- a; b <- c }.
+    // To optimize this we need to be aware which value is the true source
+    // (old_b in this case).
+    //
+    // Another possible improvement, once a cycle is detected the fn returns
+    // without analyzing if there is any other possible optimizations on `src_to_dst`.
+    //
+    // This is particularly interesting because if a cycle survives the clobber test above,
+    // it means that this cycle is uniform, all involved symbols converge to one value,
+    // which means we could retain the first memcpy and replace some "uses" by this value
+    // instead of bailing.
     if let Some(node) = find_node_in_cycle(&src_to_dst) {
         if analyses.is_log_enabled {
             let cycle = Cycle::new(&src_to_dst, node);

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -1252,7 +1252,7 @@ fn copy_prop_reverse(
     if let Some(node) = find_node_in_cycle(&src_to_dst) {
         if analyses.is_log_enabled {
             let cycle = Cycle::new(&src_to_dst, node);
-            analyses.push_log(&format!(
+            analyses.push_log(format!(
                 "Cycle Detected: {:#?}\n",
                 (function, &cycle).with_context(context)
             ));
@@ -1261,20 +1261,7 @@ fn copy_prop_reverse(
         return Ok(modified);
     }
 
-    // We now know `src_to_dst` is acyclic, so we know that this
-    // fixed-point loop terminates
-    {
-        let mut changed = true;
-        while changed {
-            changed = false;
-            for (src, dst) in src_to_dst.clone().iter() {
-                if let Some(next_dst) = src_to_dst.get(dst) {
-                    src_to_dst.insert(*src, *next_dst);
-                    changed = true;
-                }
-            }
-        }
-    }
+    solve_transitive_copies(&mut src_to_dst);
 
     // Gather the get_local instructions that need to be replaced.
     let mut repl_locals = vec![];
@@ -1353,4 +1340,32 @@ fn copy_prop_reverse(
     function.remove_instructions(context, |v| to_delete.contains(&v));
 
     Ok(modified)
+}
+
+/// Solve all transitive copies. For Example:
+///
+/// Initial: { A -> B, B -> C, C -> D }
+/// Result: { A -> D, B -> D, C -> D }
+///
+/// `src_to_dst` must be acyclic
+fn solve_transitive_copies(
+    src_to_dst: &mut std::collections::HashMap<
+        Symbol,
+        Symbol,
+        std::hash::BuildHasherDefault<rustc_hash::FxHasher>,
+    >,
+) {
+    // SAFETY: it is safe to iter HashMap here because we just need
+    // solve each key once. Order is not important.
+    let sources = src_to_dst.keys().copied().collect::<Vec<_>>();
+    for src in sources {
+        let mut cur = *src_to_dst.get(&src).unwrap();
+
+        // SAFETY: `src_to_dst` is acyclic, so this terminates
+        while let Some(next) = src_to_dst.get(&cur).copied() {
+            cur = next;
+        }
+
+        src_to_dst.insert(src, cur);
+    }
 }

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -1348,13 +1348,7 @@ fn copy_prop_reverse(
 /// Result: { A -> D, B -> D, C -> D }
 ///
 /// `src_to_dst` must be acyclic
-fn solve_transitive_copies(
-    src_to_dst: &mut std::collections::HashMap<
-        Symbol,
-        Symbol,
-        std::hash::BuildHasherDefault<rustc_hash::FxHasher>,
-    >,
-) {
+fn solve_transitive_copies(src_to_dst: &mut FxHashMap<Symbol, Symbol>) {
     // SAFETY: it is safe to iter HashMap here because we just need
     // solve each key once. Order is not important.
     let sources = src_to_dst.keys().copied().collect::<Vec<_>>();

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -1,6 +1,8 @@
 //! Optimisations related to mem_copy.
 //! - replace a `store` directly from a `load` with a `mem_copy_val`.
 
+mod cycle;
+
 use indexmap::IndexMap;
 use itertools::{Either, Itertools};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -8,7 +10,9 @@ use sway_types::{FxIndexMap, FxIndexSet};
 
 use crate::{
     get_gep_symbol, get_loaded_symbols, get_referred_symbol, get_referred_symbols,
-    get_stored_symbols, memory_utils, AnalysisResults, Block, Context, EscapedSymbols,
+    get_stored_symbols,
+    memcpyopt::cycle::{find_node_in_cycle, Cycle},
+    memory_utils, AnalysisResults, Block, Context, DebugWithContext, EscapedSymbols,
     FuelVmInstruction, Function, InstOp, Instruction, InstructionInserter, IrError, LocalVar, Pass,
     PassMutability, ReferredSymbols, ScopedPass, Symbol, Type, Value, ValueDatum,
     ESCAPED_SYMBOLS_NAME,
@@ -1107,7 +1111,7 @@ pub fn create_memcpyprop_reverse_pass() -> Pass {
 /// Copy propagation of `memcpy`s, replacing source with destination.
 fn copy_prop_reverse(
     context: &mut Context,
-    _analyses: &AnalysisResults,
+    analyses: &AnalysisResults,
     function: Function,
 ) -> Result<bool, IrError> {
     let mut modified = false;
@@ -1244,27 +1248,31 @@ fn copy_prop_reverse(
         }
     }
 
-    // Take a transitive closure of src_to_dst.
+    // Abort on cycles
+    if let Some(node) = find_node_in_cycle(&src_to_dst) {
+        if analyses.is_log_enabled {
+            let cycle = Cycle::new(&src_to_dst, node);
+            analyses.push_log(&format!(
+                "Cycle Detected: {:#?}\n",
+                (function, &cycle).with_context(context)
+            ));
+        }
+
+        return Ok(modified);
+    }
+
+    // We now know `src_to_dst` is acyclic, so we know that this
+    // fixed-point loop terminates
     {
         let mut changed = true;
-        let mut cycle_detected = false;
         while changed {
             changed = false;
-            src_to_dst.clone().iter().for_each(|(src, dst)| {
+            for (src, dst) in src_to_dst.clone().iter() {
                 if let Some(next_dst) = src_to_dst.get(dst) {
-                    // Cycle detection
-                    if *next_dst == *src {
-                        cycle_detected = true;
-                        return;
-                    }
                     src_to_dst.insert(*src, *next_dst);
                     changed = true;
                 }
-            });
-        }
-        if cycle_detected {
-            // We cannot optimize in presence of cycles.
-            return Ok(modified);
+            }
         }
     }
 

--- a/sway-ir/src/optimize/memcpyopt/cycle.rs
+++ b/sway-ir/src/optimize/memcpyopt/cycle.rs
@@ -69,7 +69,7 @@ impl Cycle {
             .keys()
             .filter(|node| {
                 // check if is outside the cycle
-                if cycle_set.contains(&node) {
+                if cycle_set.contains(node) {
                     return false;
                 }
 
@@ -79,9 +79,9 @@ impl Cycle {
                 // in another cycle. This is a safe in partial functional graphs
                 // because it is an upper bound for how many steps you can take
                 // before you either hit a sink (node without outgoing edge) or find a cycle
-                std::iter::successors(Some(*node), |current| edges.get(&current))
+                std::iter::successors(Some(*node), |current| edges.get(current))
                     .take(edges.len() + 1)
-                    .any(|node| cycle_set.contains(&node))
+                    .any(|node| cycle_set.contains(node))
             })
             .copied()
             .collect::<Vec<_>>();
@@ -102,8 +102,11 @@ pub fn find_node_in_cycle(edges: &FxHashMap<Symbol, Symbol>) -> Option<Symbol> {
     // Nodes we already know are not in a cycle
     let mut not_in_cycle: FxHashSet<Symbol> = FxHashSet::default();
 
+    // SAFETY: Function promises ANY cycle, so the order here
+    // does not matter
+    #[allow(clippy::iter_over_hash_type)]
     for candidate in edges.keys() {
-        if not_in_cycle.contains(&candidate) {
+        if not_in_cycle.contains(candidate) {
             continue;
         }
 

--- a/sway-ir/src/optimize/memcpyopt/cycle.rs
+++ b/sway-ir/src/optimize/memcpyopt/cycle.rs
@@ -60,7 +60,6 @@ impl Cycle {
             }
         })
         .collect::<Vec<_>>();
-        assert!(cycle.len() > 1);
 
         // Now we check if this cycle has a tail, a set of nodes outside the cycle that
         // moving forward always reach the cycle.

--- a/sway-ir/src/optimize/memcpyopt/cycle.rs
+++ b/sway-ir/src/optimize/memcpyopt/cycle.rs
@@ -1,0 +1,138 @@
+use crate::{Context, DebugWithContext, Function, Symbol};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+#[derive(Debug)]
+pub enum Cycle {
+    /// Simple cycle. Examples: a <-> b, a -> c -> b
+    ///                                  ˆ--------/
+    Simple { nodes: Vec<Symbol> },
+    /// Has a non cyclical path until the cycle:
+    /// a -> b -> c -> d
+    ///      ^--------/
+    /// tail: [a],
+    /// cycle: [b, c, d]
+    /// Named like this just because visually resembles the Greek letter `rho` (p)
+    RhoShape {
+        tail: Vec<Symbol>,
+        cycle: Vec<Symbol>,
+    },
+}
+
+impl DebugWithContext for (Function, &Cycle) {
+    fn fmt_with_context(
+        &self,
+        formatter: &mut std::fmt::Formatter,
+        context: &Context,
+    ) -> std::fmt::Result {
+        let names = |syms: &[Symbol]| -> Vec<String> {
+            syms.iter().map(|n| n.get_name(context, self.0)).collect()
+        };
+        match self.1 {
+            Cycle::Simple { nodes } => formatter
+                .debug_struct("Cycle::Pure")
+                .field("nodes", &names(nodes))
+                .finish(),
+            Cycle::RhoShape { tail, cycle } => formatter
+                .debug_struct("Cycle::RhoShape")
+                .field("tail", &names(tail))
+                .field("cycle", &names(cycle))
+                .finish(),
+        }
+    }
+}
+
+impl Cycle {
+    /// Categorize the found cycle. `start` must be inside the cycle.
+    ///
+    /// `edges` must form a partial functional graph, a directed graph where each
+    /// node has at most one outgoing edge.
+    pub fn new(edges: &FxHashMap<Symbol, Symbol>, start: Symbol) -> Self {
+        // Starting from the `start` node, which is inside the cycle, navigate
+        // forward the graph edge.
+        // Because `start` is in the cycle and the graph is partially functional,
+        // we know that it has a forward edge and that we will eventually come back to it.
+        let cycle = std::iter::successors(Some(start), |&node| {
+            let next = edges[&node];
+            if next == start {
+                None
+            } else {
+                Some(next)
+            }
+        })
+        .collect::<Vec<_>>();
+        assert!(cycle.len() > 1);
+
+        // Now we check if this cycle has a tail, a set of nodes outside the cycle that
+        // moving forward always reach the cycle.
+        let cycle_set = cycle.iter().copied().collect::<FxHashSet<_>>();
+        let tail = edges
+            .keys()
+            .filter(|node| {
+                // check if is outside the cycle
+                if cycle_set.contains(&node) {
+                    return false;
+                }
+
+                // check if moving forward always reach the cycle.
+                //
+                // `take(edges.len() + 1)` avoids infinite looping if the node is
+                // in another cycle. This is a safe in partial functional graphs
+                // because it is an upper bound for how many steps you can take
+                // before you either hit a sink (node without outgoing edge) or find a cycle
+                std::iter::successors(Some(*node), |current| edges.get(&current))
+                    .take(edges.len() + 1)
+                    .any(|node| cycle_set.contains(&node))
+            })
+            .copied()
+            .collect::<Vec<_>>();
+
+        if tail.is_empty() {
+            Cycle::Simple { nodes: cycle }
+        } else {
+            Cycle::RhoShape { tail, cycle }
+        }
+    }
+}
+
+/// Find any cycle and return a `Symbol` inside of this cycle.
+///
+/// `edges` must form a partial functional graph, a directed graph where each
+/// node has at most one outgoing edge.
+pub fn find_node_in_cycle(edges: &FxHashMap<Symbol, Symbol>) -> Option<Symbol> {
+    // Nodes we already know are not in a cycle
+    let mut not_in_cycle: FxHashSet<Symbol> = FxHashSet::default();
+
+    for candidate in edges.keys() {
+        if not_in_cycle.contains(&candidate) {
+            continue;
+        }
+
+        let mut path = FxHashSet::default();
+        let mut candidate = *candidate;
+        loop {
+            // If we know candidate is not in a cycle,
+            // all nodes leading to it, are also not in a cycle
+            if not_in_cycle.contains(&candidate) {
+                not_in_cycle.extend(path.drain());
+                break;
+            }
+
+            // Cycle found
+            if !path.insert(candidate) {
+                return Some(candidate);
+            }
+
+            match edges.get(&candidate) {
+                // Move forward
+                Some(next) => candidate = *next,
+                // Reached a sink
+                None => {
+                    not_in_cycle.extend(path.drain());
+                    break;
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/sway-ir/src/optimize/memcpyopt/cycle.rs
+++ b/sway-ir/src/optimize/memcpyopt/cycle.rs
@@ -29,7 +29,7 @@ impl DebugWithContext for (Function, &Cycle) {
         };
         match self.1 {
             Cycle::Simple { nodes } => formatter
-                .debug_struct("Cycle::Pure")
+                .debug_struct("Cycle::Simple")
                 .field("nodes", &names(nodes))
                 .finish(),
             Cycle::RhoShape { tail, cycle } => formatter

--- a/sway-ir/src/pass_manager.rs
+++ b/sway-ir/src/pass_manager.rs
@@ -17,7 +17,9 @@ use downcast_rs::{impl_downcast, Downcast};
 use rustc_hash::FxHashMap;
 use std::{
     any::{type_name, TypeId},
+    cell::RefCell,
     collections::{hash_map, HashSet},
+    ops::DerefMut,
 };
 
 /// Result of an analysis. Specific result must be downcasted to.
@@ -94,9 +96,18 @@ pub struct AnalysisResults {
     // Hash from (AnalysisResultT, (PassScope, Scope Identity)) to an actual result.
     results: FxHashMap<(TypeId, (TypeId, slotmap::DefaultKey)), AnalysisResult>,
     name_typeid_map: FxHashMap<&'static str, TypeId>,
+    pub is_log_enabled: bool,
+    /// Amalgamated debug log from all passes
+    log_string: RefCell<String>,
 }
 
 impl AnalysisResults {
+    pub fn push_log(&self, log: impl AsRef<str>) {
+        if self.is_log_enabled {
+            self.log_string.borrow_mut().push_str(log.as_ref());
+        }
+    }
+
     /// Get the results of an analysis.
     /// Example analyses.get_analysis_result::<DomTreeAnalysis>(foo).
     pub fn get_analysis_result<T: AnalysisResultT, S: PassScope + 'static>(&self, scope: S) -> &T {
@@ -173,6 +184,7 @@ pub struct Options {
     pub print_passes: HashSet<String>,
     pub force_verify_ir: bool,
     pub rounds: usize,
+    pub log: bool,
 }
 
 impl Default for Options {
@@ -185,6 +197,7 @@ impl Default for Options {
             print_passes: HashSet::default(),
             force_verify_ir: false,
             rounds: 2,
+            log: false,
         }
     }
 }
@@ -382,6 +395,9 @@ impl PassManager {
             print_initial_or_final_ir(ir, "Initial", options.print_metadata);
         }
 
+        self.analyses.is_log_enabled = options.log;
+        self.analyses.log_string.borrow_mut().clear();
+
         // Verify before we start
         ir.verify()?;
 
@@ -450,6 +466,11 @@ impl PassManager {
     /// Get reference to a registered pass.
     pub fn lookup_registered_pass(&self, name: &str) -> Option<&Pass> {
         self.passes.get(name)
+    }
+
+    pub fn take_log(&self) -> String {
+        let mut log = self.analyses.log_string.borrow_mut();
+        std::mem::take(log.deref_mut())
     }
 
     pub fn help_text(&self) -> String {

--- a/sway-ir/tests/memcpy_prop/cycle_rho.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_rho.ir
@@ -1,0 +1,25 @@
+script {
+    fn fmt_49() -> (), !4 {
+        local { u64, bool } __struct_init_0
+        local mut { u64, bool } f__
+        local mut { u64, bool } __aggr_memcpy_0
+
+        entry():
+        v0 = get_local __ptr { u64, bool }, __struct_init_0
+        mem_clear_val v0
+        v1 = get_local __ptr { u64, bool }, f__
+        v2 = get_local __ptr { u64, bool }, __struct_init_0
+        mem_copy_val v1, v2
+        br body()
+
+        body():
+        v3 = get_local __ptr { u64, bool }, __aggr_memcpy_0
+        v4 = get_local __ptr { u64, bool }, f__
+        mem_copy_val v3, v4
+        v5 = get_local __ptr { u64, bool }, f__
+        v6 = get_local __ptr { u64, bool }, __aggr_memcpy_0
+        mem_copy_val v5, v6
+        v7 = const unit ()
+        ret () v7
+    }
+}

--- a/sway-ir/tests/memcpy_prop/cycle_rho.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_rho.ir
@@ -1,3 +1,15 @@
+// TODO: https://github.com/FuelLabs/sway/issues/7282#issuecomment-5196527165
+// This cycle is optimizable.
+//
+// `src_to_dst`: {
+//   __struct_init_0 -> f__       (block entry)
+//   f__ -> __aggr_memcpy_0       (block body)
+//   __aggr_memcpy_0 -> f__       (block body)
+// }
+//
+// Expected optimization: forward uses of `f__` and
+// `__aggr_memcpy_0` to `__struct_init_0` (the true source) and delete the three
+// `mem_copy_val`s.
 script {
     fn fmt_49() -> (), !4 {
         local { u64, bool } __struct_init_0

--- a/sway-ir/tests/memcpy_prop/cycle_rho.ir.snap
+++ b/sway-ir/tests/memcpy_prop/cycle_rho.ir.snap
@@ -1,0 +1,41 @@
+---
+source: sway-ir/tests/tests.rs
+---
+Modified: false
+
+script {
+    fn fmt_49() -> () {
+        local mut { u64, bool } __aggr_memcpy_0
+        local { u64, bool } __struct_init_0
+        local mut { u64, bool } f__
+
+        entry():
+        v1v1 = get_local __ptr { u64, bool }, __struct_init_0
+        mem_clear_val v1v1
+        v3v1 = get_local __ptr { u64, bool }, f__
+        v4v1 = get_local __ptr { u64, bool }, __struct_init_0
+        mem_copy_val v3v1, v4v1
+        br body()
+
+        body():
+        v7v1 = get_local __ptr { u64, bool }, __aggr_memcpy_0
+        v8v1 = get_local __ptr { u64, bool }, f__
+        mem_copy_val v7v1, v8v1
+        v10v1 = get_local __ptr { u64, bool }, f__
+        v11v1 = get_local __ptr { u64, bool }, __aggr_memcpy_0
+        mem_copy_val v10v1, v11v1
+        v13v1 = const unit ()
+        ret () v13v1
+    }
+}
+
+--- LOG ---
+Cycle Detected: Cycle::RhoShape {
+    tail: [
+        "__struct_init_0",
+    ],
+    cycle: [
+        "f__",
+        "__aggr_memcpy_0",
+    ],
+}

--- a/sway-ir/tests/memcpy_prop/cycle_self.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_self.ir
@@ -1,3 +1,5 @@
+// TODO: https://github.com/FuelLabs/sway/issues/7282#issuecomment-5196527165
+// This cycle is optimizable.
 script {
     pub entry fn __entry() -> u64, !3 {
         local { u64, u64 } a

--- a/sway-ir/tests/memcpy_prop/cycle_self.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_self.ir
@@ -1,0 +1,14 @@
+script {
+    pub entry fn __entry() -> u64, !3 {
+        local { u64, u64 } a
+
+        entry():
+        v0 = get_local __ptr { u64, u64 }, a
+        mem_clear_val v0
+        v1 = get_local __ptr { u64, u64 }, a
+        v2 = get_local __ptr { u64, u64 }, a
+        mem_copy_val v1, v2
+        v3 = const u64 0
+        ret u64 v3
+    }
+}

--- a/sway-ir/tests/memcpy_prop/cycle_self.ir.snap
+++ b/sway-ir/tests/memcpy_prop/cycle_self.ir.snap
@@ -1,0 +1,19 @@
+---
+source: sway-ir/tests/tests.rs
+---
+Modified: false
+
+script {
+    pub entry fn __entry() -> u64 {
+        local { u64, u64 } a
+
+        entry():
+        v1v1 = get_local __ptr { u64, u64 }, a
+        mem_clear_val v1v1
+        v3v1 = get_local __ptr { u64, u64 }, a
+        v4v1 = get_local __ptr { u64, u64 }, a
+        mem_copy_val v3v1, v4v1
+        v6v1 = const u64 0
+        ret u64 v6v1
+    }
+}

--- a/sway-ir/tests/memcpy_prop/cycle_simple_2.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_2.ir
@@ -1,3 +1,5 @@
+// TODO: https://github.com/FuelLabs/sway/issues/7282#issuecomment-5196527165
+// This cycle is optimizable.
 script {
     pub entry fn __entry() -> u64, !3 {
         local { u64, u64 } a

--- a/sway-ir/tests/memcpy_prop/cycle_simple_2.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_2.ir
@@ -1,0 +1,18 @@
+script {
+    pub entry fn __entry() -> u64, !3 {
+        local { u64, u64 } a
+        local { u64, u64 } b
+
+        entry():
+        v0 = get_local __ptr { u64, u64 }, b
+        mem_clear_val v0
+        v1 = get_local __ptr { u64, u64 }, a
+        v2 = get_local __ptr { u64, u64 }, b
+        mem_copy_val v1, v2
+        v3 = get_local __ptr { u64, u64 }, b
+        v4 = get_local __ptr { u64, u64 }, a
+        mem_copy_val v3, v4
+        v5 = const u64 0
+        ret u64 v5
+    }
+}

--- a/sway-ir/tests/memcpy_prop/cycle_simple_2.ir.snap
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_2.ir.snap
@@ -1,0 +1,31 @@
+---
+source: sway-ir/tests/tests.rs
+---
+Modified: false
+
+script {
+    pub entry fn __entry() -> u64 {
+        local { u64, u64 } a
+        local { u64, u64 } b
+
+        entry():
+        v1v1 = get_local __ptr { u64, u64 }, b
+        mem_clear_val v1v1
+        v3v1 = get_local __ptr { u64, u64 }, a
+        v4v1 = get_local __ptr { u64, u64 }, b
+        mem_copy_val v3v1, v4v1
+        v6v1 = get_local __ptr { u64, u64 }, b
+        v7v1 = get_local __ptr { u64, u64 }, a
+        mem_copy_val v6v1, v7v1
+        v9v1 = const u64 0
+        ret u64 v9v1
+    }
+}
+
+--- LOG ---
+Cycle Detected: Cycle::Pure {
+    nodes: [
+        "a",
+        "b",
+    ],
+}

--- a/sway-ir/tests/memcpy_prop/cycle_simple_2.ir.snap
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_2.ir.snap
@@ -23,7 +23,7 @@ script {
 }
 
 --- LOG ---
-Cycle Detected: Cycle::Pure {
+Cycle Detected: Cycle::Simple {
     nodes: [
         "a",
         "b",

--- a/sway-ir/tests/memcpy_prop/cycle_simple_3.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_3.ir
@@ -1,3 +1,5 @@
+// TODO: https://github.com/FuelLabs/sway/issues/7282#issuecomment-5196527165
+// This cycle is optimizable.
 script {
     pub entry fn __entry() -> u64, !3 {
         local { u64, u64 } a

--- a/sway-ir/tests/memcpy_prop/cycle_simple_3.ir
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_3.ir
@@ -1,0 +1,20 @@
+script {
+    pub entry fn __entry() -> u64, !3 {
+        local { u64, u64 } a
+        local { u64, u64 } b
+        local { u64, u64 } c
+
+        entry():
+        v0 = get_local __ptr { u64, u64 }, a
+        v1 = get_local __ptr { u64, u64 }, b
+        mem_copy_val v0, v1
+        v2 = get_local __ptr { u64, u64 }, c
+        v3 = get_local __ptr { u64, u64 }, a
+        mem_copy_val v2, v3
+        v4 = get_local __ptr { u64, u64 }, b
+        v5 = get_local __ptr { u64, u64 }, c
+        mem_copy_val v4, v5
+        v6 = const u64 0
+        ret u64 v6
+    }
+}

--- a/sway-ir/tests/memcpy_prop/cycle_simple_3.ir.snap
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_3.ir.snap
@@ -25,7 +25,7 @@ script {
 }
 
 --- LOG ---
-Cycle Detected: Cycle::Pure {
+Cycle Detected: Cycle::Simple {
     nodes: [
         "a",
         "c",

--- a/sway-ir/tests/memcpy_prop/cycle_simple_3.ir.snap
+++ b/sway-ir/tests/memcpy_prop/cycle_simple_3.ir.snap
@@ -1,0 +1,34 @@
+---
+source: sway-ir/tests/tests.rs
+---
+Modified: false
+
+script {
+    pub entry fn __entry() -> u64 {
+        local { u64, u64 } a
+        local { u64, u64 } b
+        local { u64, u64 } c
+
+        entry():
+        v1v1 = get_local __ptr { u64, u64 }, a
+        v2v1 = get_local __ptr { u64, u64 }, b
+        mem_copy_val v1v1, v2v1
+        v4v1 = get_local __ptr { u64, u64 }, c
+        v5v1 = get_local __ptr { u64, u64 }, a
+        mem_copy_val v4v1, v5v1
+        v7v1 = get_local __ptr { u64, u64 }, b
+        v8v1 = get_local __ptr { u64, u64 }, c
+        mem_copy_val v7v1, v8v1
+        v10v1 = const u64 0
+        ret u64 v10v1
+    }
+}
+
+--- LOG ---
+Cycle Detected: Cycle::Pure {
+    nodes: [
+        "a",
+        "c",
+        "b",
+    ],
+}

--- a/sway-ir/tests/tests.rs
+++ b/sway-ir/tests/tests.rs
@@ -63,7 +63,7 @@ fn clean_output(output: &str) -> String {
     result.to_string()
 }
 
-fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
+fn run_tests<F: Fn(&str, &mut Context) -> (bool, String)>(sub_dir: &str, opt_fn: F) {
     let mut err: Option<Box<dyn Any + Send>> = None;
 
     let source_engine = SourceEngine::default();
@@ -98,7 +98,7 @@ fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
         let first_line = input.split('\n').next().unwrap();
 
         let before = ir.to_string();
-        let r = opt_fn(first_line, &mut ir);
+        let (r, log) = opt_fn(first_line, &mut ir);
         let after = ir.to_string();
 
         fn run_insta(file: &Path, snapshot: String, r: &mut Option<Box<dyn Any + Send>>) {
@@ -158,6 +158,10 @@ fn run_tests<F: Fn(&str, &mut Context) -> bool>(sub_dir: &str, opt_fn: F) {
                 }
             }
         }
+        if !log.is_empty() {
+            snapshot.push_str("\n--- LOG ---\n");
+            snapshot.push_str(&log);
+        }
         run_insta(&path, clean_output(&snapshot), &mut err);
 
         ir.verify().unwrap_or_else(|err| {
@@ -195,9 +199,9 @@ fn run_passes_with_verify(
     pass_mgr: &mut PassManager,
     ir: &mut Context,
     passes: &PassGroup,
-) -> bool {
+) -> (bool, String) {
     ir.verify_ssa_dominance = true;
-    pass_mgr
+    let modified = pass_mgr
         .run(
             ir,
             passes,
@@ -208,10 +212,12 @@ fn run_passes_with_verify(
                 print_metadata: false,
                 print_passes: HashSet::default(),
                 force_verify_ir: true,
+                log: true,
                 rounds: 1, // we want to check the effect of the optimization only once
             },
         )
-        .unwrap()
+        .unwrap();
+    (modified, pass_mgr.take_log())
 }
 
 // Utility for finding test files and running IR verifier tests.
@@ -321,9 +327,9 @@ fn inline() {
             // Just inline everything, replacing all CALL instructions.
             let mut changed = false;
             for func in funcs.into_iter() {
-                changed |= opt::inline_all_function_calls(ir, &func).unwrap();
+                changed |= opt::inline_some_function_calls(ir, &func, |_, _, _| true).unwrap();
             }
-            changed
+            (changed, String::new())
         } else {
             // Get the parameters from the first line.  See the inline/README.md for details.  If
             // there aren't any found then there won't be any constraints and it'll be the
@@ -341,20 +347,23 @@ fn inline() {
                         },
                     );
 
-            funcs.into_iter().fold(false, |acc, func| {
-                let predicate = |context: &Context, function: &Function, call_site: &Value| {
-                    let attributed_inline =
-                        metadata_to_inline(context, function.get_metadata(context));
-                    match attributed_inline {
-                        Some(opt::Inline::Never) => false,
-                        Some(opt::Inline::Always) => true,
-                        None => (opt::is_small_fn(max_blocks, max_instrs, max_stack))(
-                            context, function, call_site,
-                        ),
-                    }
-                };
-                opt::inline_some_function_calls(ir, &func, predicate).unwrap() || acc
-            })
+            (
+                funcs.into_iter().fold(false, |acc, func| {
+                    let predicate = |context: &Context, function: &Function, call_site: &Value| {
+                        let attributed_inline =
+                            metadata_to_inline(context, function.get_metadata(context));
+                        match attributed_inline {
+                            Some(opt::Inline::Never) => false,
+                            Some(opt::Inline::Always) => true,
+                            None => (opt::is_small_fn(max_blocks, max_instrs, max_stack))(
+                                context, function, call_site,
+                            ),
+                        }
+                    };
+                    opt::inline_some_function_calls(ir, &func, predicate).unwrap() || acc
+                }),
+                String::new(),
+            )
         }
     })
 }
@@ -611,7 +620,7 @@ fn verify() {
 fn serialize() {
     // This isn't running a pass, it's just confirming that the IR can be loaded and printed, and
     // FileCheck can just confirm certain instructions came out OK.
-    run_tests("serialize", |_, _: &mut Context| true)
+    run_tests("serialize", |_, _: &mut Context| (true, String::new()))
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "arg_ref_mut_return_by_value"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-DB9755B7BD11CA7D"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "arg_ref_mut_return_by_value"
 
 [dependencies]
-std = { path = "../../../../../reduced_std_libs/sway-lib-std-assert" }
+std = { path = "../../../../../reduced_std_libs/sway-lib-std-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "arg_ref_mut_return_by_value"
+
+[dependencies]
+std = { path = "../../../../../reduced_std_libs/sway-lib-std-assert" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/snapshot.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/snapshot.toml
@@ -1,0 +1,16 @@
+cmds = [
+    """
+echo This test generates an indirect self copy:
+    v35v1 = get_local __ptr { u64 }, s
+    ...
+    v76v1 = load v35v1
+    br block0(v76v1)
+
+    block0(mut v71v1: { u64 }):
+    v38v1 = get_local __ptr { u64 }, s
+    store v71v1 to v38v1
+
+This cycle is detected by `copy_prop_reverse` cycle detection and abort the optimization.
+""",
+    "forc build --path {root} --release --ir inline | filter-fn {name} main_0"
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/src/main.sw
@@ -1,0 +1,18 @@
+script;
+
+struct S {
+    value: u64
+}
+
+impl S {
+    fn arg_by_ref_ret_by_value(ref mut self) -> Self {
+        self.value = 1;
+        self
+    }
+}
+
+fn main() -> u64 {
+    let mut s = S { value: 0 };
+    s = s.arg_by_ref_ret_by_value();
+    0
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value/stdout.snap
@@ -1,0 +1,51 @@
+---
+source: test/src/snapshot/mod.rs
+---
+This test generates an indirect self copy:
+    v35v1 = get_local __ptr { u64 }, s
+    ...
+    v76v1 = load v35v1
+    br block0(v76v1)
+
+    block0(mut v71v1: { u64
+}):
+    v38v1 = get_local __ptr { u64 }, s
+    store v71v1 to v38v1
+
+This cycle is
+detected by `copy_prop_reverse` cycle detection and abort the optimization.
+
+> forc build --path test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value --release --ir inline | filter-fn arg_ref_mut_return_by_value main_0
+
+entry_orig fn main_0() -> u64 {
+    local { u64 } __struct_init_0
+    local mut { u64 } s
+    local __ptr { u64 } self_
+
+    entry():
+    v15v1 = get_local __ptr { u64 }, __struct_init_0
+    v16v1 = const u64 0
+    v17v1 = get_elem_ptr v15v1, __ptr u64, v16v1
+    v18v1 = const u64 0
+    store v18v1 to v17v1
+    v20v1 = load v15v1
+    v21v1 = get_local __ptr { u64 }, s
+    store v20v1 to v21v1
+    v23v1 = get_local __ptr { u64 }, s
+    v24v1 = load v23v1
+    v25v1 = get_local __ptr __ptr { u64 }, self_
+    v26v1 = get_local __ptr __ptr { u64 }, self_
+    v27v1 = const u64 0
+    v28v1 = get_elem_ptr v23v1, __ptr u64, v27v1
+    v29v1 = const u64 1
+    store v29v1 to v28v1
+    v31v1 = get_local __ptr __ptr { u64 }, self_
+    v32v1 = load v23v1
+    br block0(v32v1)
+
+    block0(mut v14v1: { u64 }):
+    v34v1 = get_local __ptr { u64 }, s
+    store v14v1 to v34v1
+    v36v1 = const u64 0
+    ret u64 v36v1
+}

--- a/test/src/snapshot/mod.rs
+++ b/test/src/snapshot/mod.rs
@@ -20,6 +20,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Once,
+    time::Duration,
 };
 use sway_core::Engines;
 use sway_features::ExperimentalFeatures;
@@ -410,7 +411,9 @@ fn run_cmds(
                     };
 
                     let o = o.env("COLUMNS", "10").unchecked().start().unwrap();
-                    let o = o.wait().unwrap();
+                    let Some(o) = o.wait_timeout(Duration::from_secs(30)).unwrap() else {
+                        panic!("test timeout");
+                    };
                     last_output = Some(clean_output(&format!(
                         "exit status: {}\noutput:\n{}",
                         o.status.code().unwrap(),


### PR DESCRIPTION
## Description

This PR solves a bug when a valid `sway` code generates a cycle of `memcpys`. One simple example is the `e2e` test at `test/src/e2e_vm_tests/test_programs/should_pass/language/references/arg_ref_mut_return_by_value`.

The IR generated is something like:

```
v35v1 = get_local __ptr { u64 }, s, !30
...
v76v1 = load v35v1, !33
br block0(v76v1), !33

block0(mut v71v1: { u64 }):
v38v1 = get_local __ptr { u64 }, s, !41
store v71v1 to v38v1, !41
```

We end-up copying `s` into itself. 

The issue that this caused was that `copy_prop_reverse` inside the `memcpyopt` was hanging forever. 

Now, `copy_prop_reverse` cycle detection is more robust and detect any cycle, but we just bail all the optimizations as before.

To mark future improvements, I have add some optimizations I found at https://github.com/FuelLabs/sway/issues/7282#issuecomment-5196527165, and have put some TODOS around the code pointing to this issue.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
