### PR TITLE
Refactor `DeclEngine` for robustness and semantic consistency

### DIFF
--- a/justfile
+++ b/justfile
@@ -187,6 +187,14 @@ build-highlightjs:
 generate-sway-lib-std:
     cd ./sway-lib-std && ./generate.sh
 
+alias tfmt := test-forc-fmt-check-panic
+# test `forc fmt` for panicking
 [group('test')]
 test-forc-fmt-check-panic:
     cd ./scripts/formatter && ./forc-fmt-check-panic.sh
+
+alias t := run-tests
+# run the full local test suite (pass `--lsp` to also run the sway-lsp tests)
+[group('test')]
+run-tests *args:
+    bash ./scripts/test/run-tests.sh {{args}}

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+
+# Orchestrate the local test suite for the Sway compiler.
+#
+# Usage: ./scripts/test/run-tests.sh [--lsp]
+#
+#   --lsp   Additionally run the (slow) `sway-lsp` tests.
+#
+# The script runs, in order:
+#   1. All tests:                cargo r -r -p test
+#   2. E2E tests (release):      cargo r -r -p test -- --release -ke2e
+#                                (fuel-core is started/stopped automatically)
+#   3. SDK harness tests:        build the contracts, then run the tests
+#   4. In-language tests:        debug and release
+#   5. sway-ir unit tests:       cargo test -p sway-ir
+#   6. sway-lsp tests:           cargo test -p sway-lsp   (only with --lsp)
+#
+# It fails fast: the first failing step aborts the run and the remaining steps
+# are skipped. A per-step and total timing breakdown is printed at the end, and
+# an OS notification (Linux: notify-send, macOS: terminal-notifier/osascript) is
+# sent when the run finishes or fails.
+#
+# Works on Linux and macOS (bash 3.2+).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+RUN_LSP=false
+for arg in "$@"; do
+    case "$arg" in
+        --lsp)
+            RUN_LSP=true
+            ;;
+        -h|--help)
+            # Print the leading comment block (skipping the shebang line).
+            awk 'NR==1{next} /^#/{started=1; sub(/^# ?/,""); print; next} started{exit}' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument: $arg" >&2
+            echo "Usage: $0 [--lsp]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Timing / bookkeeping
+# ---------------------------------------------------------------------------
+OVERALL_START=$SECONDS
+FINISHED_OK=false
+CURRENT_STEP=""
+FUEL_CORE_PID=""
+
+STEP_NAMES=()
+STEP_DURS=()
+STEP_STATUS=()
+
+fmt_dur() {
+    local s=$1
+    printf '%dh %02dm %02ds' $(( s / 3600 )) $(( (s % 3600) / 60 )) $(( s % 60 ))
+}
+
+# ---------------------------------------------------------------------------
+# OS notification (best-effort; never fails the run)
+# ---------------------------------------------------------------------------
+notify() {
+    local title="$1"
+    local message="$2"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        if command -v terminal-notifier >/dev/null 2>&1; then
+            terminal-notifier -title "$title" -message "$message" >/dev/null 2>&1 || true
+        else
+            osascript -e "display notification \"${message//\"/\\\"}\" with title \"${title//\"/\\\"}\"" >/dev/null 2>&1 || true
+        fi
+    else
+        if command -v notify-send >/dev/null 2>&1; then
+            notify-send "$title" "$message" >/dev/null 2>&1 || true
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# fuel-core lifecycle (used by the E2E step)
+# ---------------------------------------------------------------------------
+stop_fuel_core() {
+    if [[ -n "$FUEL_CORE_PID" ]] && kill -0 "$FUEL_CORE_PID" 2>/dev/null; then
+        echo "Stopping fuel-core (pid $FUEL_CORE_PID)..."
+        kill "$FUEL_CORE_PID" 2>/dev/null || true
+        wait "$FUEL_CORE_PID" 2>/dev/null || true
+    fi
+    FUEL_CORE_PID=""
+}
+
+wait_for_fuel_core() {
+    # fuel-core's GraphQL service listens on 127.0.0.1:4000 by default.
+    local port=4000
+    local tries=120 # up to ~60s
+    local i
+    for (( i = 0; i < tries; i++ )); do
+        if ! kill -0 "$FUEL_CORE_PID" 2>/dev/null; then
+            echo "Error: fuel-core exited before becoming ready." >&2
+            return 1
+        fi
+        if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+            exec 3>&- 3<&- 2>/dev/null || true
+            return 0
+        fi
+        sleep 0.5
+    done
+    echo "Error: timed out waiting for fuel-core to listen on port $port." >&2
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Reporting on exit (breakdown + notification)
+# ---------------------------------------------------------------------------
+print_breakdown() {
+    local total=$(( SECONDS - OVERALL_START ))
+    echo ""
+    echo "=================================================================="
+    echo "Test run breakdown"
+    echo "=================================================================="
+    if [[ ${#STEP_NAMES[@]} -gt 0 ]]; then
+        local i
+        for i in "${!STEP_NAMES[@]}"; do
+            printf '  %-30s %-6s %s\n' "${STEP_NAMES[$i]}" "${STEP_STATUS[$i]}" "$(fmt_dur "${STEP_DURS[$i]}")"
+        done
+    else
+        echo "  (no steps were run)"
+    fi
+    echo "------------------------------------------------------------------"
+    printf '  %-30s %-6s %s\n' "TOTAL" "" "$(fmt_dur "$total")"
+    echo "=================================================================="
+}
+
+finish() {
+    local rc=$?
+    stop_fuel_core
+    print_breakdown
+    if [[ "$FINISHED_OK" == true ]]; then
+        notify "Sway tests: PASSED" "All test steps completed in $(fmt_dur $(( SECONDS - OVERALL_START )))."
+    else
+        notify "Sway tests: FAILED" "Failed at step: ${CURRENT_STEP:-unknown}."
+    fi
+}
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# ---------------------------------------------------------------------------
+# Step runner
+# ---------------------------------------------------------------------------
+# Usage: run_step "Human readable name" command args...
+# The command can be an external program or a shell function.
+run_step() {
+    local name="$1"
+    shift
+    CURRENT_STEP="$name"
+
+    echo ""
+    echo "=================================================================="
+    echo ">> $name"
+    echo "=================================================================="
+
+    local start=$SECONDS
+    "$@"
+    local rc=$?
+    local dur=$(( SECONDS - start ))
+
+    STEP_NAMES+=("$name")
+    STEP_DURS+=("$dur")
+
+    if [[ $rc -ne 0 ]]; then
+        STEP_STATUS+=("FAIL")
+        echo ""
+        echo "!! Step failed: $name (exit code $rc). Aborting." >&2
+        exit "$rc"
+    fi
+
+    STEP_STATUS+=("PASS")
+    echo "-- Done: $name ($(fmt_dur "$dur"))"
+}
+
+# ---------------------------------------------------------------------------
+# Composite steps
+# ---------------------------------------------------------------------------
+step_e2e_release() {
+    if ! command -v fuel-core >/dev/null 2>&1; then
+        echo "Error: \`fuel-core\` not found on PATH. Install it to run the E2E tests." >&2
+        return 1
+    fi
+
+    local fuel_core_log
+    fuel_core_log="$(mktemp)"
+
+    echo "Starting fuel-core (logs: $fuel_core_log)..."
+    fuel-core run --debug --db-type=in-memory >"$fuel_core_log" 2>&1 &
+    FUEL_CORE_PID=$!
+
+    if ! wait_for_fuel_core; then
+        echo "---- fuel-core log ----" >&2
+        cat "$fuel_core_log" >&2 || true
+        stop_fuel_core
+        rm -f "$fuel_core_log"
+        return 1
+    fi
+    echo "fuel-core is ready (pid $FUEL_CORE_PID)."
+
+    cargo r -r -p test -- --release -ke2e
+    local rc=$?
+
+    stop_fuel_core
+    rm -f "$fuel_core_log"
+    return $rc
+}
+
+step_sdk_harness() {
+    cargo run --locked --release -p forc -- build --locked \
+        --path ./test/src/sdk-harness \
+        --output-directory ./test/src/sdk-harness/out \
+        && cargo test --locked --release \
+            --manifest-path ./test/src/sdk-harness/Cargo.toml \
+            -- --skip can_get_predicate_address --nocapture
+}
+
+# ---------------------------------------------------------------------------
+# Run everything
+# ---------------------------------------------------------------------------
+run_step "All tests"                 cargo r -r -p test
+run_step "E2E tests (release)"       step_e2e_release
+run_step "SDK harness tests"         step_sdk_harness
+run_step "In-language tests"         ./test/src/in_language_tests/run_in_language_tests.sh
+run_step "In-language tests (release)" ./test/src/in_language_tests/run_in_language_tests.sh --release
+run_step "sway-ir unit tests"        cargo test -p sway-ir
+
+if [[ "$RUN_LSP" == true ]]; then
+    run_step "sway-lsp tests"        cargo test -p sway-lsp
+fi
+
+FINISHED_OK=true
+echo ""
+echo "All test steps passed."
+exit 0

--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -122,7 +122,7 @@ where
         let inner = self.inner.read();
         f(inner.items[index]
             .as_ref()
-            .expect("invalid slab index for ConcurrentSlab::get"))
+            .expect("invalid slab index for ConcurrentSlab::map"))
     }
 
     pub fn retain(&self, predicate: impl Fn(&usize, &mut Arc<T>) -> bool) {

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -63,8 +63,6 @@ pub struct DeclEngine {
         RwLock<HashMap<DeclId<TyConstGenericDecl>, ParsedDeclId<ConstGenericDeclaration>>>,
     configurable_parsed_decl_id_map:
         RwLock<HashMap<DeclId<TyConfigurableDecl>, ParsedDeclId<ConfigurableDeclaration>>>,
-    const_generics_parsed_decl_id_map:
-        RwLock<HashMap<DeclId<TyConstGenericDecl>, ParsedDeclId<ConstGenericDeclaration>>>,
     enum_parsed_decl_id_map: RwLock<HashMap<DeclId<TyEnumDecl>, ParsedDeclId<EnumDeclaration>>>,
     type_alias_parsed_decl_id_map:
         RwLock<HashMap<DeclId<TyTypeAliasDecl>, ParsedDeclId<TypeAliasDeclaration>>>,
@@ -113,9 +111,6 @@ impl Clone for DeclEngine {
             configurable_parsed_decl_id_map: RwLock::new(
                 self.configurable_parsed_decl_id_map.read().clone(),
             ),
-            const_generics_parsed_decl_id_map: RwLock::new(
-                self.const_generics_parsed_decl_id_map.read().clone(),
-            ),
             enum_parsed_decl_id_map: RwLock::new(self.enum_parsed_decl_id_map.read().clone()),
             type_alias_parsed_decl_id_map: RwLock::new(
                 self.type_alias_parsed_decl_id_map.read().clone(),
@@ -148,22 +143,27 @@ pub trait DeclEngineInsert<T>
 where
     T: Named + Spanned + TyDeclParsedType,
 {
-    fn insert(
-        &self,
-        decl: T,
-        parsed_decl_id: Option<&ParsedDeclId<T::ParsedType>>,
-    ) -> DeclRef<DeclId<T>>;
-}
+    /// Inserts a typed declaration `decl` that corresponds to the parsed declaration
+    /// `parsed_decl_it` into the [DeclEngine] for the first time.
+    ///
+    /// This method is meant to be called **only during the initial type checking**,
+    /// when the typed declaration is created for the first time.
+    fn insert(&self, decl: T, parsed_decl_id: ParsedDeclId<T::ParsedType>) -> DeclRef<DeclId<T>>;
 
-pub trait DeclEngineInsertArc<T>
-where
-    T: Named + Spanned + TyDeclParsedType,
-{
-    fn insert_arc(
-        &self,
-        decl: Arc<T>,
-        parsed_decl_id: Option<&ParsedDeclId<T::ParsedType>>,
-    ) -> DeclRef<DeclId<T>>;
+    /// Inserts a typed declaration `modified_decl` that represents a modified version of
+    /// an `original_decl`. E.g., during monomorphization, we get an original typed declaration
+    /// from the [DeclEngine], modify it, and insert the `modified_decl` into the [DeclEngine].
+    ///
+    /// The `modified_decl` will have the same corresponding parsed declaration as the `original_decl`.
+    ///
+    /// Panics if the `original_decl` does not exist in the [DeclEngine]
+    /// or if it doesn't have its corresponding parsed declaration.
+    ///
+    /// The only typed declarations that legitimately have no corresponding parsed
+    /// declaration are the trait-interface dummy functions inserted via
+    /// [DeclEngine::insert_dummy_func]. For those, [DeclEngineInsert] is implemented
+    /// manually (see the implementation for [ty::TyFunctionDecl]).
+    fn insert_modified(&self, modified_decl: T, original_decl: DeclId<T>) -> DeclRef<DeclId<T>>;
 }
 
 pub trait DeclEngineReplace<T> {
@@ -219,43 +219,67 @@ macro_rules! decl_engine_insert {
             fn insert(
                 &self,
                 decl: $decl,
-                parsed_decl_id: Option<&ParsedDeclId<<$decl as TyDeclParsedType>::ParsedType>>,
+                parsed_decl_id: ParsedDeclId<<$decl as TyDeclParsedType>::ParsedType>,
             ) -> DeclRef<DeclId<$decl>> {
                 let span = decl.span();
                 let decl_name = decl.name().clone();
                 let decl_id = DeclId::new(self.$slab.insert(decl));
-                if let Some(parsed_decl_id) = parsed_decl_id {
-                    self.$parsed_slab
-                        .write()
-                        .insert(decl_id, parsed_decl_id.clone());
-                }
+                self.$parsed_slab.write().insert(decl_id, parsed_decl_id);
                 DeclRef::new(decl_name, decl_id, span)
             }
-        }
-        impl DeclEngineInsertArc<$decl> for DeclEngine {
-            fn insert_arc(
+
+            fn insert_modified(
                 &self,
-                decl: Arc<$decl>,
-                parsed_decl_id: Option<&ParsedDeclId<<$decl as TyDeclParsedType>::ParsedType>>,
+                modified_decl: $decl,
+                original_decl: DeclId<$decl>,
             ) -> DeclRef<DeclId<$decl>> {
-                let span = decl.span();
-                let decl_name = decl.name().clone();
-                let decl_id = DeclId::new(self.$slab.insert_arc(decl));
-                if let Some(parsed_decl_id) = parsed_decl_id {
-                    self.$parsed_slab
-                        .write()
-                        .insert(decl_id, parsed_decl_id.clone());
-                }
-                DeclRef::new(decl_name, decl_id, span)
+                self.insert(
+                    modified_decl,
+                    self.get_parsed_decl_id(&original_decl)
+                        .expect("`original_decl` must have a corresponding parsed declaration"),
+                )
             }
         }
     };
 }
-decl_engine_insert!(
-    function_slab,
-    function_parsed_decl_id_map,
-    ty::TyFunctionDecl
-);
+
+/// [ty::TyFunctionDecl] is intentionally not implemented via the `decl_engine_insert!`
+/// macro. Unlike all other typed declarations, functions have one legitimate case of not
+/// having a corresponding parsed declaration: the trait-interface dummy functions inserted
+/// via [DeclEngine::insert_dummy_func]. `insert_modified` must therefore tolerate a missing
+/// parsed declaration, but **only for such dummy functions**.
+impl DeclEngineInsert<ty::TyFunctionDecl> for DeclEngine {
+    fn insert(
+        &self,
+        decl: ty::TyFunctionDecl,
+        parsed_decl_id: ParsedDeclId<<ty::TyFunctionDecl as TyDeclParsedType>::ParsedType>,
+    ) -> DeclRef<DeclId<ty::TyFunctionDecl>> {
+        let span = decl.span();
+        let decl_name = decl.name().clone();
+        let decl_id = DeclId::new(self.function_slab.insert(decl));
+        self.function_parsed_decl_id_map
+            .write()
+            .insert(decl_id, parsed_decl_id);
+        DeclRef::new(decl_name, decl_id, span)
+    }
+
+    fn insert_modified(
+        &self,
+        modified_decl: ty::TyFunctionDecl,
+        original_decl: DeclId<ty::TyFunctionDecl>,
+    ) -> DeclRef<DeclId<ty::TyFunctionDecl>> {
+        match self.get_parsed_decl_id(&original_decl) {
+            // The `modified_decl` inherits the parsed declaration of the
+            // `original_decl` it was cloned and modified from.
+            Some(parsed_decl_id) => self.insert(modified_decl, parsed_decl_id),
+            // The only functions that legitimately lack a parsed declaration are the
+            // trait-interface dummy functions. If the `original_decl` had no parsed
+            // declaration and was not a dummy function, that is a bug.
+            None => self.insert_dummy_func(modified_decl),
+        }
+    }
+}
+
 decl_engine_insert!(trait_slab, trait_parsed_decl_id_map, ty::TyTraitDecl);
 decl_engine_insert!(trait_fn_slab, trait_fn_parsed_decl_id_map, ty::TyTraitFn);
 decl_engine_insert!(
@@ -283,7 +307,7 @@ decl_engine_insert!(
 );
 decl_engine_insert!(
     const_generics_slab,
-    const_generics_parsed_decl_id_map,
+    const_generic_parsed_decl_id_map,
     ty::TyConstGenericDecl
 );
 decl_engine_insert!(enum_slab, enum_parsed_decl_id_map, ty::TyEnumDecl);
@@ -605,6 +629,38 @@ impl DeclEngine {
             .entry(index)
             .and_modify(|e| e.push(parent.clone()))
             .or_insert_with(|| vec![parent]);
+    }
+
+    /// Inserts a trait-interface **dummy function** into the [DeclEngine].
+    ///
+    /// This is a bit of a maverick compared to the regular [DeclEngineInsert::insert].
+    /// It deliberately inserts a [ty::TyFunctionDecl] **without an associated parsed
+    /// declaration**.
+    ///
+    /// Dummy functions are placeholders created from trait interface methods
+    /// (see [ty::TyTraitFn::to_dummy_func]). They allow the trait's
+    /// provided methods to refer to interface methods before an actual implementation
+    /// exists. Their parsed origin is a [TraitFn] (i.e., a parsed trait function), not a
+    /// [FunctionDeclaration], so there is no [FunctionDeclaration] to associate them with.
+    ///
+    /// This is the only semantically valid case of a [ty::TyFunctionDecl] having no
+    /// corresponding parsed declaration. Everything else must go through
+    /// [DeclEngineInsert::insert] or [DeclEngineInsert::insert_modified], which guarantee
+    /// (and, for `insert_modified`, assert) the presence of a parsed declaration.
+    ///
+    /// Panics if the `decl` is not a trait-interface dummy function.
+    pub fn insert_dummy_func(
+        &self,
+        decl: ty::TyFunctionDecl,
+    ) -> DeclRef<DeclId<ty::TyFunctionDecl>> {
+        assert!(
+            decl.is_trait_method_dummy,
+            "`insert_dummy_func` must only be called with trait-interface dummy functions"
+        );
+        let span = decl.span();
+        let decl_name = decl.name().clone();
+        let decl_id = DeclId::new(self.function_slab.insert(decl));
+        DeclRef::new(decl_name, decl_id, span)
     }
 
     /// Friendly helper method for calling the `get` method from the

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -255,9 +255,7 @@ impl SubstTypes for DeclId<TyConstantDecl> {
         let decl_engine = ctx.engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
         if decl.subst(ctx).has_changes() {
-            *self = *decl_engine
-                .insert(decl, decl_engine.get_parsed_decl_id(self).as_ref())
-                .id();
+            *self = *decl_engine.insert_modified(decl, *self).id();
             HasChanges::Yes
         } else {
             HasChanges::No
@@ -277,7 +275,7 @@ where
         let decl_engine = ctx.engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
         if decl.subst(ctx).has_changes() {
-            Some(decl_engine.insert(decl, decl_engine.get_parsed_decl_id(self).as_ref()))
+            Some(decl_engine.insert_modified(decl, *self))
         } else {
             None
         }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -110,7 +110,7 @@ where
         {
             let mut decl = (*decl_engine.get(&self.id)).clone();
             if decl.subst(ctx).has_changes() {
-                Some(decl_engine.insert(decl, decl_engine.get_parsed_decl_id(&self.id).as_ref()))
+                Some(decl_engine.insert_modified(decl, self.id))
             } else {
                 None
             }
@@ -150,7 +150,7 @@ where
         if decl.subst(ctx).has_changes() {
             Some(
                 decl_engine
-                    .insert(decl, decl_engine.get_parsed_decl_id(&self.id).as_ref())
+                    .insert_modified(decl, self.id)
                     .with_parent(decl_engine, self.id.into()),
             )
         } else {

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -161,16 +161,12 @@ impl MaterializeConstGenerics for TyAstNode {
                 let decl = engines.de().get(&constant_decl.decl_id);
 
                 let mut decl = TyConstantDecl::clone(&*decl);
-                let mut has_changes =
-                    decl.materialize_const_generics(engines, handler, name, value)?;
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let r = engines.de().insert(decl, None); // TODO: Add `parsed_decl_id`.
-                *constant_decl = ConstantDecl { decl_id: *r.id() };
-
-                // TODO: Deliberately using `mut has_changes` above and changing it here.
-                //       This will be changed when we inspect returned `HasChanges` and
-                //       remove additional not needed `DeclEngine::insert` calls.
-                has_changes |= HasChanges::Yes;
+                if has_changes.has_changes() {
+                    let r = engines.de().insert_modified(decl, constant_decl.decl_id);
+                    *constant_decl = ConstantDecl { decl_id: *r.id() };
+                }
 
                 Ok(has_changes)
             }

--- a/sway-core/src/language/ty/declaration/configurable.rs
+++ b/sway-core/src/language/ty/declaration/configurable.rs
@@ -25,7 +25,7 @@ pub struct TyConfigurableDecl {
     pub return_type: TypeId,
     pub type_ascription: GenericTypeArgument,
     pub span: Span,
-    // Only encoding v1 has a decode_fn
+    /// `Some` iff encoding is v1, otherwise `None`.
     pub decode_fn: Option<DeclRef<DeclId<TyFunctionDecl>>>,
 }
 

--- a/sway-core/src/language/ty/declaration/const_generic.rs
+++ b/sway-core/src/language/ty/declaration/const_generic.rs
@@ -57,8 +57,7 @@ impl MaterializeConstGenerics for TyConstGenericDecl {
         name: &str,
         value: &TyExpression,
     ) -> Result<HasChanges, ErrorEmitted> {
-        let mut has_changes = HasChanges::No;
-        if self.call_path.suffix.as_str() == name {
+        let has_changes = if self.call_path.suffix.as_str() == name {
             match self.value.as_ref() {
                 // If the const generic already has value,
                 // it must be the same as the `value`.
@@ -75,13 +74,17 @@ impl MaterializeConstGenerics for TyConstGenericDecl {
                                 .unwrap(),
                         "{v:?} {value:?}",
                     );
+                    HasChanges::No
                 }
                 None => {
                     self.value = Some(value.clone());
-                    has_changes = HasChanges::Yes;
+                    HasChanges::Yes
                 }
             }
-        }
+        } else {
+            HasChanges::No
+        };
+
         Ok(has_changes)
     }
 }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -69,8 +69,7 @@ impl ReplaceDecls for ConstantDecl {
         let mut decl = TyConstantDecl::clone(&*ctx.engines.de().get(&self.decl_id));
         let has_changes = decl.replace_decls(decl_mapping, handler, ctx)?;
         if has_changes.has_changes() {
-            let parsed_decl_id = ctx.engines.de().get_parsed_decl_id(&self.decl_id);
-            let new_ref = ctx.engines.de().insert(decl, parsed_decl_id.as_ref());
+            let new_ref = ctx.engines.de().insert_modified(decl, self.decl_id);
             self.decl_id.replace_id(*new_ref.id());
         }
         Ok(has_changes)

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -441,10 +441,7 @@ impl DeclRefFunction {
             let decl_ref = if has_changes.has_changes() {
                 engines
                     .de()
-                    .insert(
-                        method.clone(),
-                        engines.de().get_parsed_decl_id(self.id()).as_ref(),
-                    )
+                    .insert_modified(method.clone(), *self.id())
                     .with_parent(decl_engine, self.id().into())
             } else {
                 self.clone()

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -451,7 +451,7 @@ impl MaterializeConstGenerics for TyExpression {
             } => {
                 let mut has_changes = HasChanges::No;
 
-                // Materialize non dummy fns
+                // Materialize a non-dummy function.
                 let fn_decl = engines.de().get(fn_ref.id());
                 if !fn_decl.is_trait_method_dummy {
                     let mut type_subst_map = TypeSubstMap::new();
@@ -469,7 +469,7 @@ impl MaterializeConstGenerics for TyExpression {
                         })
                         .has_changes()
                     {
-                        *fn_ref = engines.de().insert(new_decl, None);
+                        *fn_ref = engines.de().insert_modified(new_decl, *fn_ref.id());
                         has_changes = HasChanges::Yes;
                     }
                 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -5,10 +5,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
     ast_elements::type_parameter::GenericTypeParameter,
-    decl_engine::{
-        parsed_id::ParsedDeclId, DeclEngineGetParsedDeclId, DeclEngineInsert, DeclEngineInsertArc,
-        DeclId,
-    },
+    decl_engine::{parsed_id::ParsedDeclId, DeclEngineInsert, DeclId},
     language::ty::{TyAbiDecl, TyFunctionDecl},
     namespace::{IsExtendingExistingImpl, IsImplInterfaceSurface, IsImplSelf},
     semantic_analysis::{
@@ -133,8 +130,8 @@ impl ty::TyAbiDecl {
                     let decl_name = match item {
                         TraitItem::TraitFn(decl_id) => {
                             let method = &*engines.pe().get_trait_fn(decl_id);
-                            // check that a super-trait does not define a method
-                            // with the same name as the current interface method
+                            // Check that a super-trait does not define a method
+                            // with the same name as the current interface method.
                             error_on_shadowing_superabi_method(&method.name, ctx);
                             let method = ty::TyTraitFn::type_check(handler, ctx.by_ref(), method)?;
                             for param in &method.parameters {
@@ -150,7 +147,7 @@ impl ty::TyAbiDecl {
                             let method_name = method.name.clone();
 
                             new_interface_surface.push(ty::TyTraitInterfaceItem::TraitFn(
-                                ctx.engines.de().insert(method, Some(decl_id)),
+                                ctx.engines.de().insert(method, *decl_id),
                             ));
 
                             method_name
@@ -162,7 +159,7 @@ impl ty::TyAbiDecl {
 
                             let const_name = const_decl.call_path.suffix.clone();
 
-                            let decl_ref = ctx.engines.de().insert(const_decl, Some(decl_id));
+                            let decl_ref = ctx.engines.de().insert(const_decl, *decl_id);
                             new_interface_surface
                                 .push(ty::TyTraitInterfaceItem::Constant(decl_ref));
 
@@ -177,7 +174,7 @@ impl ty::TyAbiDecl {
                                 ty::TyTraitType::type_check(handler, ctx.by_ref(), type_decl)?;
 
                             let type_name = type_decl.name.clone();
-                            let decl_ref = ctx.engines().de().insert(type_decl, Some(decl_id));
+                            let decl_ref = ctx.engines().de().insert(type_decl, *decl_id);
                             new_interface_surface.push(ty::TyTraitInterfaceItem::Type(decl_ref));
 
                             type_name
@@ -220,9 +217,7 @@ impl ty::TyAbiDecl {
                             name: (&method.name).into(),
                         });
                     }
-                    new_items.push(TyTraitItem::Fn(
-                        ctx.engines.de().insert(method, Some(method_id)),
-                    ));
+                    new_items.push(TyTraitItem::Fn(ctx.engines.de().insert(method, *method_id)));
                 }
 
                 // Compared to regular traits, we do not insert recursively methods of ABI supertraits
@@ -319,13 +314,10 @@ impl ty::TyAbiDecl {
                         }
                         all_items.push(TyImplItem::Fn(
                             decl_engine
-                                .insert(
-                                    method.to_dummy_func(
-                                        AbiMode::ImplAbiFn(self.name.clone(), Some(self_decl_id)),
-                                        Some(type_id),
-                                    ),
-                                    None,
-                                )
+                                .insert_dummy_func(method.to_dummy_func(
+                                    AbiMode::ImplAbiFn(self.name.clone(), Some(self_decl_id)),
+                                    Some(type_id),
+                                ))
                                 .with_parent(ctx.engines.de(), (*decl_ref.id()).into()),
                         ));
                     }
@@ -378,42 +370,26 @@ impl ty::TyAbiDecl {
                                 }
                             }
                         }
-                        all_items.push(TyImplItem::Fn(
-                            decl_engine
-                                .insert_arc(
-                                    method,
-                                    decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                                )
-                                .with_parent(ctx.engines.de(), (*decl_ref.id()).into()),
-                        ));
+                        all_items.push(TyImplItem::Fn(decl_ref.clone()));
                     }
                     ty::TyTraitItem::Constant(decl_ref) => {
-                        let const_decl = decl_engine.get_constant(decl_ref);
-                        let const_name = const_decl.name().clone();
-                        let const_has_value = const_decl.value.is_some();
-                        let decl_id = decl_engine.insert_arc(
-                            const_decl,
-                            decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                        );
-                        all_items.push(TyImplItem::Constant(decl_id.clone()));
+                        all_items.push(TyImplItem::Constant(decl_ref.clone()));
 
                         // If this non-interface item has a value, then we want to overwrite the
                         // the previously inserted constant symbol from the interface surface.
+                        let const_decl = decl_engine.get_constant(decl_ref);
+                        let const_has_value = const_decl.value.is_some();
                         if const_has_value {
                             const_symbols.insert(
-                                const_name,
+                                const_decl.name().clone(),
                                 ty::TyDecl::ConstantDecl(ty::ConstantDecl {
-                                    decl_id: *decl_id.id(),
+                                    decl_id: *decl_ref.id(),
                                 }),
                             );
                         }
                     }
                     ty::TyTraitItem::Type(decl_ref) => {
-                        let type_decl = decl_engine.get_type(decl_ref);
-                        all_items.push(TyImplItem::Type(decl_engine.insert_arc(
-                            type_decl,
-                            decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                        )));
+                        all_items.push(TyImplItem::Type(decl_ref.clone()));
                     }
                 }
             }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
@@ -10,9 +10,7 @@ use symbol_collection_context::SymbolCollectionContext;
 
 use crate::{
     ast_elements::{type_argument::GenericTypeArgument, type_parameter::GenericTypeParameter},
-    decl_engine::{
-        parsed_id::ParsedDeclId, DeclEngineGetParsedDeclId, DeclEngineInsert, ReplaceDecls,
-    },
+    decl_engine::{parsed_id::ParsedDeclId, DeclEngineInsert, ReplaceDecls},
     language::{
         parsed::*,
         ty::{self, TyConfigurableDecl, TyExpression},
@@ -155,10 +153,7 @@ impl ty::TyConfigurableDecl {
             {
                 engines
                     .de()
-                    .insert(
-                        decode_fn_decl,
-                        engines.de().get_parsed_decl_id(&decode_fn_id).as_ref(),
-                    )
+                    .insert_modified(decode_fn_decl, decode_fn_id)
                     .with_parent(engines.de(), decode_fn_id.into())
             } else {
                 decode_fn_ref

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -112,8 +112,7 @@ impl TyDecl {
                     Err(err) => return Ok(ty::TyDecl::ErrorRecovery(decl.span.clone(), err)),
                 };
                 let name = const_decl.name().clone();
-                let typed_const_decl: ty::TyDecl =
-                    decl_engine.insert(const_decl, Some(decl_id)).into();
+                let typed_const_decl: ty::TyDecl = decl_engine.insert(const_decl, *decl_id).into();
                 ctx.insert_symbol(handler, name, typed_const_decl.clone())?;
                 typed_const_decl
             }
@@ -123,7 +122,7 @@ impl TyDecl {
                     match ty::TyConfigurableDecl::type_check(handler, ctx.by_ref(), decl) {
                         Ok(config_decl) => {
                             config_decl.forbid_const_generics(handler, engines)?;
-                            ty::TyDecl::from(decl_engine.insert(config_decl, Some(decl_id)))
+                            ty::TyDecl::from(decl_engine.insert(config_decl, *decl_id))
                         }
                         Err(err) => ty::TyDecl::ErrorRecovery(decl.span.clone(), err),
                     };
@@ -137,8 +136,7 @@ impl TyDecl {
                     Err(err) => return Ok(ty::TyDecl::ErrorRecovery(decl.span.clone(), err)),
                 };
                 let name = type_decl.name().clone();
-                let typed_type_decl: ty::TyDecl =
-                    decl_engine.insert(type_decl, Some(decl_id)).into();
+                let typed_type_decl: ty::TyDecl = decl_engine.insert(type_decl, *decl_id).into();
                 ctx.insert_symbol(handler, name, typed_type_decl.clone())?;
                 typed_type_decl
             }
@@ -149,8 +147,7 @@ impl TyDecl {
                     Err(err) => return Ok(ty::TyDecl::ErrorRecovery(decl.span.clone(), err)),
                 };
                 let name = enum_decl.call_path.suffix.clone();
-                let typed_enum_decl: ty::TyDecl =
-                    decl_engine.insert(enum_decl, Some(decl_id)).into();
+                let typed_enum_decl: ty::TyDecl = decl_engine.insert(enum_decl, *decl_id).into();
                 ctx.insert_symbol(handler, name, typed_enum_decl.clone())?;
                 typed_enum_decl
             }
@@ -173,7 +170,7 @@ impl TyDecl {
                 };
 
                 let name = fn_decl.name.clone();
-                let decl: ty::TyDecl = decl_engine.insert(fn_decl, Some(decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(fn_decl, *decl_id).into();
                 let _ = ctx.insert_symbol(handler, name, decl.clone());
                 decl
             }
@@ -207,7 +204,7 @@ impl TyDecl {
                             });
                 }
 
-                let decl: ty::TyDecl = decl_engine.insert(trait_decl.clone(), Some(decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(trait_decl.clone(), *decl_id).into();
 
                 trait_decl
                     .items
@@ -332,7 +329,7 @@ impl TyDecl {
                     IsImplInterfaceSurface::No,
                 )?;
                 let impl_trait_decl: ty::TyDecl =
-                    decl_engine.insert(impl_trait.clone(), Some(decl_id)).into();
+                    decl_engine.insert(impl_trait.clone(), *decl_id).into();
                 impl_trait.items.iter_mut().for_each(|item| {
                     item.replace_implementing_type(engines, impl_trait_decl.clone());
                 });
@@ -348,7 +345,7 @@ impl TyDecl {
                         }
                     };
                 let name = decl.call_path.suffix.clone();
-                let decl: ty::TyDecl = decl_engine.insert(decl, Some(decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(decl, *decl_id).into();
                 ctx.insert_symbol(handler, name, decl.clone())?;
                 decl
             }
@@ -382,7 +379,7 @@ impl TyDecl {
                             });
                 }
 
-                let decl: ty::TyDecl = decl_engine.insert(abi_decl.clone(), Some(decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(abi_decl.clone(), *decl_id).into();
                 abi_decl
                     .items
                     .iter_mut()
@@ -495,7 +492,7 @@ impl TyDecl {
                     storage_keyword: storage_keyword.clone(),
                 };
 
-                let decl_ref = decl_engine.insert(decl, Some(decl_id));
+                let decl_ref = decl_engine.insert(decl, *decl_id);
 
                 // insert the storage declaration into the symbols
                 // if there already was one, return an error that duplicate storage
@@ -535,7 +532,7 @@ impl TyDecl {
                     span,
                 };
 
-                let decl: ty::TyDecl = decl_engine.insert(decl, Some(decl_id)).into();
+                let decl: ty::TyDecl = decl_engine.insert(decl, *decl_id).into();
 
                 ctx.insert_symbol(handler, name, decl.clone())?;
                 decl

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -41,7 +41,7 @@ impl ty::TyFunctionDecl {
                 .type_parameters
                 .iter()
                 .filter_map(|x| x.as_const_parameter())
-                .filter_map(|x| x.id.as_ref());
+                .map(|x| &x.parsed_decl_id);
 
             for const_generic_parameter in const_generic_parameters {
                 let const_generic_decl = engines.pe().get(const_generic_parameter);
@@ -120,7 +120,7 @@ impl ty::TyFunctionDecl {
             })
         }
 
-        // create a namespace for the function
+        // Create a namespace for the function.
         ctx.by_ref()
             .with_const_shadowing_mode(ConstShadowingMode::Sequential)
             .disallow_functions()
@@ -139,9 +139,7 @@ impl ty::TyFunctionDecl {
                     .iter()
                     .filter_map(|x| x.as_const_parameter());
                 for const_generic in const_generic_parameters {
-                    let Some(id) = const_generic.id.as_ref() else {
-                        continue;
-                    };
+                    let id = &const_generic.parsed_decl_id;
                     let const_generic_decl = ctx.engines.pe().get(id);
 
                     let decl_ref = ctx.engines.de().insert(
@@ -158,7 +156,7 @@ impl ty::TyFunctionDecl {
                                 .as_ref()
                                 .map(|x| x.to_ty_expression(ctx.engines)),
                         },
-                        Some(id),
+                        *id,
                     );
 
                     if let Some(old) = already_declared

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -63,7 +63,7 @@ impl TyImplSelfOrTrait {
                     .impl_type_parameters
                     .iter()
                     .filter_map(|x| x.as_const_parameter())
-                    .filter_map(|x| x.id.as_ref());
+                    .map(|x| &x.parsed_decl_id);
 
                 for const_generic_parameter in const_generic_parameters {
                     let const_generic_decl = engines.pe().get(const_generic_parameter);
@@ -166,7 +166,7 @@ impl TyImplSelfOrTrait {
                 let const_generic_parameters = impl_type_parameters
                     .iter()
                     .filter_map(|x| x.as_const_parameter())
-                    .filter_map(|x| x.id.as_ref());
+                    .map(|x| &x.parsed_decl_id);
                 for const_generic_decl_id in const_generic_parameters {
                     let const_generic_decl = engines.pe().get(const_generic_decl_id);
 
@@ -181,7 +181,7 @@ impl TyImplSelfOrTrait {
                             return_type: const_generic_decl.ty,
                             value: None,
                         },
-                        Some(const_generic_decl_id),
+                        *const_generic_decl_id,
                     );
 
                     ctx.insert_symbol(
@@ -457,7 +457,7 @@ impl TyImplSelfOrTrait {
                 let const_generic_parameters = impl_type_parameters
                     .iter()
                     .filter_map(|x| x.as_const_parameter())
-                    .filter_map(|x| x.id.as_ref());
+                    .map(|x| &x.parsed_decl_id);
                 for const_generic_decl_id in const_generic_parameters {
                     let const_generic_decl = engines.pe().get(const_generic_decl_id);
 
@@ -472,7 +472,7 @@ impl TyImplSelfOrTrait {
                             return_type: const_generic_decl.ty,
                             value: None,
                         },
-                        Some(const_generic_decl_id),
+                        *const_generic_decl_id,
                     );
 
                     ctx.insert_symbol(
@@ -634,8 +634,7 @@ impl TyImplSelfOrTrait {
                                 ) else {
                                     continue;
                                 };
-                                new_items
-                                    .push(TyImplItem::Fn(decl_engine.insert(fn_decl, Some(id))));
+                                new_items.push(TyImplItem::Fn(decl_engine.insert(fn_decl, *id)));
                             }
                             ImplItem::Constant(decl_id) => {
                                 let const_decl = &*engines.pe().get_constant(decl_id);
@@ -647,7 +646,7 @@ impl TyImplSelfOrTrait {
                                     Ok(res) => res,
                                     Err(_) => continue,
                                 };
-                                let decl_ref = decl_engine.insert(const_decl, Some(decl_id));
+                                let decl_ref = decl_engine.insert(const_decl, *decl_id);
 
                                 ctx.insert_symbol(
                                     handler,
@@ -669,7 +668,7 @@ impl TyImplSelfOrTrait {
                                     Ok(res) => res,
                                     Err(_) => continue,
                                 };
-                                let decl_ref = decl_engine.insert(type_decl, Some(decl_id));
+                                let decl_ref = decl_engine.insert(type_decl, *decl_id);
                                 new_items.push(TyImplItem::Type(decl_ref));
                             }
                         }
@@ -737,7 +736,7 @@ impl TyImplSelfOrTrait {
                     }
 
                     let impl_trait_decl = decl_engine
-                        .insert(impl_trait.clone(), Some(parsed_decl_id))
+                        .insert(impl_trait.clone(), *parsed_decl_id)
                         .into();
 
                     // First lets perform an analysis pass.
@@ -1045,7 +1044,7 @@ fn type_check_trait_implementation(
                 type_checklist.remove(&type_decl_name);
 
                 // Add this type to the "impld decls".
-                let decl_ref = decl_engine.insert(type_decl, Some(decl_id));
+                let decl_ref = decl_engine.insert(type_decl, *decl_id);
                 impld_item_refs.insert(
                     (type_decl_name.clone(), implementing_for),
                     TyTraitItem::Type(decl_ref),
@@ -1115,7 +1114,7 @@ fn type_check_trait_implementation(
                 constant_checklist.remove(&name);
 
                 // Add this constant to the "impld decls".
-                let decl_ref = decl_engine.insert(const_decl, Some(decl_id));
+                let decl_ref = decl_engine.insert(const_decl, *decl_id);
                 impld_item_refs.insert(
                     (name.clone(), implementing_for),
                     TyTraitItem::Constant(decl_ref.clone()),
@@ -1165,7 +1164,7 @@ fn type_check_trait_implementation(
                 method_checklist.remove(&name);
 
                 // Add this method to the "impld items".
-                let decl_ref = decl_engine.insert(impl_method, Some(impl_method_id));
+                let decl_ref = decl_engine.insert(impl_method, *impl_method_id);
                 impld_item_refs.insert((name, implementing_for), TyTraitItem::Fn(decl_ref));
             }
             ImplItem::Constant(_decl_id) => {}
@@ -1187,12 +1186,7 @@ fn type_check_trait_implementation(
 
             let mut const_decl = (*decl_engine.get_constant(interface_decl_ref)).clone();
             let decl_ref = if const_decl.subst(&ctx.subst_ctx(handler)).has_changes() {
-                decl_engine.insert(
-                    const_decl,
-                    decl_engine
-                        .get_parsed_decl_id(interface_decl_ref.id())
-                        .as_ref(),
-                )
+                decl_engine.insert_modified(const_decl, *interface_decl_ref.id())
             } else {
                 interface_decl_ref.clone()
             };
@@ -1294,10 +1288,7 @@ fn type_check_trait_implementation(
 
                 let decl_ref = if has_changes.has_changes() {
                     decl_engine
-                        .insert(
-                            method,
-                            decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                        )
+                        .insert_modified(method, *decl_ref.id())
                         .with_parent(decl_engine, (*decl_ref.id()).into())
                 } else {
                     decl_ref.clone()
@@ -1318,10 +1309,7 @@ fn type_check_trait_implementation(
                 };
 
                 let decl_ref = if has_changes.has_changes() {
-                    decl_engine.insert(
-                        const_decl,
-                        decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                    )
+                    decl_engine.insert_modified(const_decl, *decl_ref.id())
                 } else {
                     decl_ref.clone()
                 };
@@ -1338,10 +1326,7 @@ fn type_check_trait_implementation(
                 ));
 
                 let decl_ref = if has_changes.has_changes() {
-                    decl_engine.insert(
-                        type_decl.clone(),
-                        decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                    )
+                    decl_engine.insert_modified(type_decl.clone(), *decl_ref.id())
                 } else {
                     decl_ref.clone()
                 };

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -141,7 +141,7 @@ impl TyTraitDecl {
 
                             let type_decl_name = type_decl.name.clone();
 
-                            let decl_ref = decl_engine.insert(type_decl, Some(&decl_id));
+                            let decl_ref = decl_engine.insert(type_decl, decl_id);
                             dummy_interface_surface.push(ty::TyImplItem::Type(decl_ref.clone()));
                             new_interface_surface.push(ty::TyTraitInterfaceItem::Type(decl_ref));
 
@@ -181,12 +181,11 @@ impl TyTraitDecl {
                         TraitItem::TraitFn(decl_id) => {
                             let method = engines.pe().get_trait_fn(decl_id);
                             let method = ty::TyTraitFn::type_check(handler, ctx.by_ref(), &method)?;
-                            let decl_ref = decl_engine.insert(method.clone(), Some(decl_id));
+                            let decl_ref = decl_engine.insert(method.clone(), *decl_id);
                             dummy_interface_surface.push(ty::TyImplItem::Fn(
                                 decl_engine
-                                    .insert(
+                                    .insert_dummy_func(
                                         method.to_dummy_func(AbiMode::NonAbi, Some(self_type)),
-                                        None,
                                     )
                                     .with_parent(decl_engine, (*decl_ref.id()).into()),
                             ));
@@ -197,8 +196,7 @@ impl TyTraitDecl {
                             let const_decl = &*engines.pe().get_constant(decl_id);
                             let const_decl =
                                 ty::TyConstantDecl::type_check(handler, ctx.by_ref(), const_decl)?;
-                            let decl_ref =
-                                ctx.engines.de().insert(const_decl.clone(), Some(decl_id));
+                            let decl_ref = ctx.engines.de().insert(const_decl.clone(), *decl_id);
                             new_interface_surface
                                 .push(ty::TyTraitInterfaceItem::Constant(decl_ref.clone()));
 
@@ -258,7 +256,7 @@ impl TyTraitDecl {
                     )
                     .unwrap_or_else(|_| ty::TyFunctionDecl::error(&method));
                     new_items.push(ty::TyTraitItem::Fn(
-                        decl_engine.insert(method, Some(method_decl_id)),
+                        decl_engine.insert(method, *method_decl_id),
                     ));
                 }
 
@@ -424,10 +422,7 @@ impl TyTraitDecl {
                         .has_changes()
                     {
                         decl_engine
-                            .insert(
-                                method,
-                                decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                            )
+                            .insert_modified(method, *decl_ref.id())
                             .with_parent(decl_engine, (*decl_ref.id()).into())
                     } else {
                         decl_ref.clone()
@@ -446,10 +441,7 @@ impl TyTraitDecl {
                         ))
                         .has_changes()
                     {
-                        decl_engine.insert(
-                            const_decl,
-                            decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                        )
+                        decl_engine.insert_modified(const_decl, *decl_ref.id())
                     } else {
                         decl_ref.clone()
                     };
@@ -467,8 +459,7 @@ impl TyTraitDecl {
                         ))
                         .has_changes()
                     {
-                        decl_engine
-                            .insert(t, decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref())
+                        decl_engine.insert_modified(t, *decl_ref.id())
                     } else {
                         decl_ref.clone()
                     };
@@ -527,7 +518,7 @@ impl TyTraitDecl {
                     ));
                     all_items.push(TyImplItem::Fn(
                         decl_engine
-                            .insert(method.to_dummy_func(AbiMode::NonAbi, Some(type_id)), None)
+                            .insert_dummy_func(method.to_dummy_func(AbiMode::NonAbi, Some(type_id)))
                             .with_parent(ctx.engines.de(), (*decl_ref.id()).into()),
                     ));
                 }
@@ -562,10 +553,7 @@ impl TyTraitDecl {
                     {
                         ctx.engines
                             .de()
-                            .insert(
-                                method,
-                                decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                            )
+                            .insert_modified(method, *decl_ref.id())
                             .with_parent(decl_engine, (*decl_ref.id()).into())
                     } else {
                         decl_ref.clone()
@@ -585,10 +573,7 @@ impl TyTraitDecl {
                     let const_has_value = const_decl.value.is_some();
 
                     let decl_id = if has_changes.has_changes() {
-                        decl_engine.insert(
-                            const_decl,
-                            decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                        )
+                        decl_engine.insert_modified(const_decl, *decl_ref.id())
                     } else {
                         decl_ref.clone()
                     };
@@ -616,10 +601,7 @@ impl TyTraitDecl {
                     ));
 
                     let decl_ref = if has_changes.has_changes() {
-                        decl_engine.insert(
-                            type_decl,
-                            decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                        )
+                        decl_engine.insert_modified(type_decl, *decl_ref.id())
                     } else {
                         decl_ref.clone()
                     };

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -9,7 +9,7 @@ use sway_error::{
 use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
-    decl_engine::{DeclEngineGetParsedDeclId, DeclEngineInsert, DeclRef},
+    decl_engine::{DeclEngineInsert, DeclRef},
     language::{
         parsed::*,
         ty::{self, StructAccessInfo, TyDecl, TyScrutinee, TyStructDecl, TyStructField},
@@ -423,10 +423,7 @@ fn type_check_struct(
     })?;
 
     let struct_ref = if has_changes.has_changes() {
-        decl_engine.insert(
-            struct_decl,
-            decl_engine.get_parsed_decl_id(&struct_id).as_ref(),
-        )
+        decl_engine.insert_modified(struct_decl, struct_id)
     } else {
         DeclRef::new(struct_decl.name().clone(), struct_id, struct_decl.span())
     };
@@ -539,7 +536,7 @@ fn type_check_enum(
     let typed_value = ty::TyScrutinee::type_check(handler, ctx, value)?;
 
     let enum_ref = if has_changes.has_changes() {
-        decl_engine.insert(enum_decl, decl_engine.get_parsed_decl_id(&enum_id).as_ref())
+        decl_engine.insert_modified(enum_decl, enum_id)
     } else {
         DeclRef::new(enum_decl.name().clone(), enum_id, enum_decl.span())
     };

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1311,12 +1311,8 @@ impl ty::TyExpression {
 
         // Update the `access_type` to be the type of the monomorphized struct after inserting it
         // into the type engine.
-        let storage_key_struct_decl_ref = decl_engine.insert(
-            storage_key_struct_decl,
-            decl_engine
-                .get_parsed_decl_id(&storage_key_struct_decl_id)
-                .as_ref(),
-        );
+        let storage_key_struct_decl_ref =
+            decl_engine.insert_modified(storage_key_struct_decl, storage_key_struct_decl_id);
         access_type = type_engine.insert_struct(engines, *storage_key_struct_decl_ref.id());
 
         Ok(ty::TyExpression {
@@ -1964,32 +1960,18 @@ impl ty::TyExpression {
                     let method = decl_engine.get_trait_fn(decl_ref);
                     abi_items.push(TyImplItem::Fn(
                         decl_engine
-                            .insert(
-                                method.to_dummy_func(
-                                    AbiMode::ImplAbiFn(
-                                        abi_name.suffix.clone(),
-                                        Some(*abi_ref.id()),
-                                    ),
-                                    Some(return_type),
-                                ),
-                                None,
-                            )
+                            .insert_dummy_func(method.to_dummy_func(
+                                AbiMode::ImplAbiFn(abi_name.suffix.clone(), Some(*abi_ref.id())),
+                                Some(return_type),
+                            ))
                             .with_parent(decl_engine, (*decl_ref.id()).into()),
                     ));
                 }
                 ty::TyTraitInterfaceItem::Constant(decl_ref) => {
-                    let const_decl = decl_engine.get_constant(decl_ref);
-                    abi_items.push(TyImplItem::Constant(decl_engine.insert_arc(
-                        const_decl,
-                        decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                    )));
+                    abi_items.push(TyImplItem::Constant(decl_ref.clone()));
                 }
                 ty::TyTraitInterfaceItem::Type(decl_ref) => {
-                    let type_decl = decl_engine.get_type(decl_ref);
-                    abi_items.push(TyImplItem::Type(decl_engine.insert_arc(
-                        type_decl,
-                        decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-                    )));
+                    abi_items.push(TyImplItem::Type(decl_ref.clone()));
                 }
             }
         }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -1,7 +1,5 @@
 use crate::{
-    decl_engine::{
-        engine::DeclEngineGetParsedDeclId, DeclEngineInsert, DeclRefFunction, ReplaceDecls,
-    },
+    decl_engine::{DeclEngineInsert, DeclRefFunction, ReplaceDecls},
     language::{
         ty::{self, TyFunctionDecl, TyFunctionSig},
         *,
@@ -113,12 +111,7 @@ pub(crate) fn instantiate_function_application(
                 let method_sig = TyFunctionSig::from_fn_decl(&new_function_decl);
 
                 let new_decl_ref = decl_engine
-                    .insert(
-                        new_function_decl,
-                        decl_engine
-                            .get_parsed_decl_id(function_decl_ref.id())
-                            .as_ref(),
-                    )
+                    .insert_modified(new_function_decl, *function_decl_ref.id())
                     .with_parent(decl_engine, (*function_decl_ref.id()).into());
                 (
                     method_sig,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -1,6 +1,6 @@
 use crate::{
     decl_engine::{
-        engine::{DeclEngineGet, DeclEngineGetParsedDeclId, DeclEngineReplace},
+        engine::{DeclEngineGet, DeclEngineReplace},
         DeclEngineInsert, DeclRefFunction, ReplaceDecls, UpdateConstantExpression,
     },
     language::{
@@ -1056,10 +1056,7 @@ pub(crate) fn monomorphize_method(
     //       For details see: https://github.com/FuelLabs/sway/issues/7658
     let decl_ref = if has_changes.has_changes() {
         decl_engine
-            .insert(
-                func_decl,
-                decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref(),
-            )
+            .insert_modified(func_decl, *decl_ref.id())
             .with_parent(decl_engine, (*decl_ref.id()).into())
     } else {
         decl_ref

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -1009,7 +1009,7 @@ impl TraitMap {
                         .has_changes()
                     {
                         decl_engine
-                            .insert(decl, decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref())
+                            .insert_modified(decl, *decl_ref.id())
                             .with_parent(decl_engine, decl_ref.id().into())
                     } else {
                         decl_ref.clone()
@@ -1029,8 +1029,7 @@ impl TraitMap {
                         ))
                         .has_changes()
                     {
-                        decl_engine
-                            .insert(decl, decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref())
+                        decl_engine.insert_modified(decl, *decl_ref.id())
                     } else {
                         decl_ref.clone()
                     };
@@ -1049,8 +1048,7 @@ impl TraitMap {
                         ))
                         .has_changes()
                     {
-                        decl_engine
-                            .insert(decl, decl_engine.get_parsed_decl_id(decl_ref.id()).as_ref())
+                        decl_engine.insert_modified(decl, *decl_ref.id())
                     } else {
                         decl_ref.clone()
                     };

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -588,7 +588,7 @@ pub fn item_fn_to_function_declaration(
     let kind = override_kind.unwrap_or(kind);
     let implementing_type = context.implementing_type.clone();
 
-    let mut generic_parameters = generic_params_opt_to_type_parameters_with_parent(
+    let generic_parameters = generic_params_opt_to_type_parameters_with_parent(
         context,
         handler,
         engines,
@@ -597,19 +597,6 @@ pub fn item_fn_to_function_declaration(
         item_fn.fn_signature.where_clause_opt.clone(),
         parent_where_clause_opt,
     )?;
-
-    for p in generic_parameters.iter_mut() {
-        match p {
-            TypeParameter::Type(_) => {}
-            TypeParameter::Const(p) => {
-                p.id = Some(engines.pe().insert(ConstGenericDeclaration {
-                    name: p.name.clone(),
-                    ty: p.ty,
-                    span: p.span.clone(),
-                }));
-            }
-        }
-    }
 
     let fn_decl = FunctionDeclaration {
         purity: attributes.purity(),
@@ -851,26 +838,13 @@ pub fn item_impl_to_impl_declaration(
         .filter_map_ok(|item| item)
         .collect::<Result<_, _>>()?;
 
-    let mut impl_type_parameters = generic_params_opt_to_type_parameters(
+    let impl_type_parameters = generic_params_opt_to_type_parameters(
         context,
         handler,
         engines,
         item_impl.generic_params_opt,
         item_impl.where_clause_opt,
     )?;
-
-    for p in impl_type_parameters.iter_mut() {
-        match p {
-            TypeParameter::Type(_) => {}
-            TypeParameter::Const(p) => {
-                p.id = Some(engines.pe().insert(ConstGenericDeclaration {
-                    name: p.name.clone(),
-                    ty: p.ty,
-                    span: p.span.clone(),
-                }));
-            }
-        }
-    }
 
     match item_impl.trait_opt {
         Some((path_type, _)) => {
@@ -1605,14 +1579,23 @@ fn generic_params_opt_to_type_parameters_with_parent(
                         is_from_parent,
                     })
                 }
-                GenericParam::Const { ident, .. } => TypeParameter::Const(ConstGenericParameter {
-                    span: ident.span().clone(),
-                    name: ident,
-                    ty: type_engine.id_of_u64(),
-                    is_from_parent,
-                    id: None,
-                    expr: None,
-                }),
+                GenericParam::Const { ident, .. } => {
+                    let ty = type_engine.id_of_u64();
+                    let span = ident.span().clone();
+                    let parsed_decl_id = engines.pe().insert(ConstGenericDeclaration {
+                        name: ident.clone(),
+                        ty,
+                        span: span.clone(),
+                    });
+                    TypeParameter::Const(ConstGenericParameter {
+                        span,
+                        name: ident,
+                        ty,
+                        is_from_parent,
+                        parsed_decl_id,
+                        expr: None,
+                    })
+                }
             })
             .collect(),
         None => vec![],

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -1,9 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    decl_engine::{
-        parsed_id::ParsedDeclId, DeclEngineGetParsedDeclId, DeclEngineInsert, DeclId, DeclRef,
-    },
+    decl_engine::{parsed_id::ParsedDeclId, DeclEngineInsert, DeclId, DeclRef},
     engine_threading::{EqWithEngines, PartialEqWithEngines, PartialEqWithEnginesContext},
     language::{
         parsed::{FunctionDeclaration, StructDeclaration},
@@ -335,10 +333,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
 
                 let new_fn_ref = if has_changes.has_changes() {
                     decl_engine
-                        .insert(
-                            new_copy,
-                            decl_engine.get_parsed_decl_id(fn_ref.id()).as_ref(),
-                        )
+                        .insert_modified(new_copy, *fn_ref.id())
                         .with_parent(ctx.engines.de(), fn_ref.id().into())
                 } else {
                     fn_ref
@@ -419,12 +414,7 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
         let span = new_copy.span();
         let decl_name = new_copy.name().clone();
         let new_struct_id = if has_changes.has_changes() {
-            *decl_engine
-                .insert(
-                    new_copy,
-                    decl_engine.get_parsed_decl_id(&struct_id).as_ref(),
-                )
-                .id()
+            *decl_engine.insert_modified(new_copy, struct_id).id()
         } else {
             struct_id
         };
@@ -482,9 +472,7 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         let span = new_copy.span();
         let decl_name = new_copy.name().clone();
         let new_enum_id = if has_changes.has_changes() {
-            *decl_engine
-                .insert(new_copy, decl_engine.get_parsed_decl_id(&enum_id).as_ref())
-                .id()
+            *decl_engine.insert_modified(new_copy, enum_id).id()
         } else {
             enum_id
         };

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -303,41 +303,39 @@ impl MaterializeConstGenerics for GenericArgument {
         name: &str,
         value: &crate::language::ty::TyExpression,
     ) -> Result<HasChanges, sway_error::handler::ErrorEmitted> {
-        let mut has_changes = HasChanges::No;
-        match self {
+        let has_changes = match self {
             GenericArgument::Type(arg) => {
-                has_changes |= arg.materialize_const_generics(engines, handler, name, value)?;
+                arg.materialize_const_generics(engines, handler, name, value)?
             }
             GenericArgument::Const(arg) => {
-                arg.expr = match arg.expr.clone() {
-                    ConstGenericExpr::AmbiguousVariableExpression { ident, mut decl } => {
-                        if let Some(decl) = decl.as_mut() {
-                            has_changes |=
-                                decl.materialize_const_generics(engines, handler, name, value)?;
-                        }
-
-                        if ident.as_str() == name {
-                            has_changes = HasChanges::Yes;
-                            ConstGenericExpr::Literal {
-                                val: value
-                                    .extract_literal_value()
-                                    .unwrap()
-                                    .cast_value_to_u64()
-                                    .unwrap() as usize,
-                                span: value.span.clone(),
-                            }
-                        } else {
-                            // If the `decl` got changed, `has_changes` already reflects that.
-                            // Otherwise, this newly created `ConstGenericExpr` is same as
-                            // the original `arg.expr` and there is no need for setting the
-                            // `has_changes` to `Yes`.
-                            ConstGenericExpr::AmbiguousVariableExpression { ident, decl }
-                        }
+                if let ConstGenericExpr::AmbiguousVariableExpression { ident, decl } = &mut arg.expr
+                {
+                    let mut has_changes = HasChanges::No;
+                    if let Some(decl) = decl.as_mut() {
+                        has_changes |=
+                            decl.materialize_const_generics(engines, handler, name, value)?;
                     }
-                    expr => expr,
-                };
+
+                    if ident.as_str() == name {
+                        arg.expr = ConstGenericExpr::Literal {
+                            val: value
+                                .extract_literal_value()
+                                .unwrap()
+                                .cast_value_to_u64()
+                                .unwrap() as usize,
+                            span: value.span.clone(),
+                        };
+
+                        has_changes = HasChanges::Yes;
+                    }
+
+                    has_changes
+                } else {
+                    HasChanges::No
+                }
             }
-        }
+        };
+
         Ok(has_changes)
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -86,7 +86,7 @@ impl TypeParameter {
             TypeParameter::Const(ConstGenericParameter {
                 is_from_parent,
                 name,
-                id,
+                parsed_decl_id,
                 span,
                 ty,
                 expr,
@@ -102,7 +102,7 @@ impl TypeParameter {
                         return_type: *ty,
                         value: expr.as_ref().map(|x| x.to_ty_expression(ctx.engines)),
                     },
-                    id.as_ref(),
+                    *parsed_decl_id,
                 );
                 (
                     is_from_parent,
@@ -986,34 +986,30 @@ impl MaterializeConstGenerics for ConstGenericExprTyDecl {
     ) -> Result<HasChanges, sway_error::handler::ErrorEmitted> {
         match self {
             ConstGenericExprTyDecl::ConstGenericDecl(decl) => {
-                let mut decl = TyConstGenericDecl::clone(&*engines.de().get(&decl.decl_id));
-                let mut has_changes =
-                    decl.materialize_const_generics(engines, handler, name, value)?;
+                let decl_id = &decl.decl_id;
+                let mut decl = TyConstGenericDecl::clone(&*engines.de().get(decl_id));
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let decl_ref = engines.de().insert(decl, None); // TODO improve parsed_decl_id
-                *self = ConstGenericExprTyDecl::ConstGenericDecl(ConstGenericDecl {
-                    decl_id: *decl_ref.id(),
-                });
-
-                // TODO: Deliberately using `mut has_changes` above and changing it here.
-                //       This will be changed when we inspect returned `HasChanges` and
-                //       remove additional not needed `DeclEngine::insert` calls.
-                has_changes |= HasChanges::Yes;
+                if has_changes.has_changes() {
+                    let decl_ref = engines.de().insert_modified(decl, *decl_id);
+                    *self = ConstGenericExprTyDecl::ConstGenericDecl(ConstGenericDecl {
+                        decl_id: *decl_ref.id(),
+                    });
+                }
 
                 Ok(has_changes)
             }
             ConstGenericExprTyDecl::ConstantDecl(decl) => {
-                let mut decl = TyConstantDecl::clone(&*engines.de().get(&decl.decl_id));
-                let mut has_changes =
-                    decl.materialize_const_generics(engines, handler, name, value)?;
+                let decl_id = &decl.decl_id;
+                let mut decl = TyConstantDecl::clone(&*engines.de().get(decl_id));
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let decl_ref = engines.de().insert(decl, None); // TODO improve parsed_decl_id
-                *self = ConstGenericExprTyDecl::ConstantDecl(ConstantDecl {
-                    decl_id: *decl_ref.id(),
-                });
-
-                // TODO: See above.
-                has_changes |= HasChanges::Yes;
+                if has_changes.has_changes() {
+                    let decl_ref = engines.de().insert_modified(decl, *decl_id);
+                    *self = ConstGenericExprTyDecl::ConstantDecl(ConstantDecl {
+                        decl_id: *decl_ref.id(),
+                    });
+                }
 
                 Ok(has_changes)
             }
@@ -1247,23 +1243,25 @@ pub struct ConstGenericParameter {
     pub ty: TypeId,
     pub is_from_parent: bool,
     pub span: Span,
-    pub id: Option<ParsedDeclId<ConstGenericDeclaration>>,
+    pub parsed_decl_id: ParsedDeclId<ConstGenericDeclaration>,
     pub expr: Option<ConstGenericExpr>,
 }
 
 impl HashWithEngines for ConstGenericParameter {
     fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
         let ConstGenericParameter {
-            name, ty, id, expr, ..
+            name,
+            ty,
+            parsed_decl_id: id,
+            expr,
+            ..
         } = self;
         let type_engine = engines.te();
         type_engine.get(*ty).hash(state, engines);
         name.hash(state);
-        if let Some(id) = id.as_ref() {
-            let decl = engines.pe().get(id);
-            decl.name.hash(state);
-            decl.ty.hash(state);
-        }
+        let decl = engines.pe().get(id);
+        decl.name.hash(state);
+        decl.ty.hash(state);
         match &expr {
             Some(expr) => {
                 expr.hash(state);

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -8,9 +8,7 @@ use sway_error::{
 use sway_types::{BaseIdent, Named, Span, Spanned};
 
 use crate::{
-    decl_engine::{
-        DeclEngineGet, DeclEngineGetParsedDecl, DeclEngineInsert, MaterializeConstGenerics,
-    },
+    decl_engine::{DeclEngineGet, DeclEngineInsert, MaterializeConstGenerics},
     engine_threading::{DebugWithEngines, DisplayWithEngines, Engines, WithEngines},
     language::{
         ty::{StructDecl, TyDecl, TyStructDecl},
@@ -132,14 +130,13 @@ impl MaterializeConstGenerics for TypeId {
         name: &str,
         value: &crate::language::ty::TyExpression,
     ) -> Result<HasChanges, ErrorEmitted> {
-        let mut has_changes = HasChanges::No;
-        match &*engines.te().get(*self) {
+        let has_changes = match &*engines.te().get(*self) {
             TypeInfo::Array(
                 element_type,
                 Length(ConstGenericExpr::AmbiguousVariableExpression { ident, decl }),
             ) => {
                 let mut elem_type = element_type.clone();
-                has_changes |=
+                let mut has_changes =
                     elem_type.materialize_const_generics(engines, handler, name, value)?;
 
                 if ident.as_str() == name {
@@ -155,6 +152,9 @@ impl MaterializeConstGenerics for TypeId {
                         }
                     };
 
+                    // We are always replacing `Length` with a `ConstGenericExpr::Literal`,
+                    // regardless if `elem_type` had changes or not. Therefore, `self` is
+                    // always changed and `has_changes` is always `Yes`.
                     *self = engines.te().insert_array(
                         engines,
                         elem_type,
@@ -171,47 +171,45 @@ impl MaterializeConstGenerics for TypeId {
                             decl.materialize_const_generics(engines, handler, name, value)?;
                     }
 
-                    *self = engines.te().insert_array(
-                        engines,
-                        elem_type,
-                        Length(ConstGenericExpr::AmbiguousVariableExpression {
-                            ident: ident.clone(),
-                            decl,
-                        }),
-                    );
-                    has_changes = HasChanges::Yes;
+                    // In this case, we are replacing `self` only if `elem_type` or
+                    // `decl` had changes.
+                    if has_changes.has_changes() {
+                        *self = engines.te().insert_array(
+                            engines,
+                            elem_type,
+                            Length(ConstGenericExpr::AmbiguousVariableExpression {
+                                ident: ident.clone(),
+                                decl,
+                            }),
+                        );
+                    }
                 }
+                has_changes
             }
             TypeInfo::Enum(id) => {
                 let decl = engines.de().get(id);
                 let mut decl = (*decl).clone();
-                has_changes |= decl.materialize_const_generics(engines, handler, name, value)?;
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let parsed_decl = engines
-                    .de()
-                    .get_parsed_decl(id)
-                    .unwrap()
-                    .to_enum_decl(handler, engines)
-                    .ok();
-                let decl_ref = engines.de().insert(decl, parsed_decl.as_ref());
+                if has_changes.has_changes() {
+                    let decl_ref = engines.de().insert_modified(decl, *id);
 
-                *self = engines.te().insert_enum(engines, *decl_ref.id());
-                has_changes = HasChanges::Yes;
+                    *self = engines.te().insert_enum(engines, *decl_ref.id());
+                }
+
+                has_changes
             }
             TypeInfo::Struct(id) => {
                 let mut decl = TyStructDecl::clone(&engines.de().get(id));
-                has_changes |= decl.materialize_const_generics(engines, handler, name, value)?;
+                let has_changes = decl.materialize_const_generics(engines, handler, name, value)?;
 
-                let parsed_decl = engines
-                    .de()
-                    .get_parsed_decl(id)
-                    .unwrap()
-                    .to_struct_decl(handler, engines)
-                    .ok();
-                let decl_ref = engines.de().insert(decl, parsed_decl.as_ref());
+                if has_changes.has_changes() {
+                    let decl_ref = engines.de().insert_modified(decl, *id);
 
-                *self = engines.te().insert_struct(engines, *decl_ref.id());
-                has_changes = HasChanges::Yes;
+                    *self = engines.te().insert_struct(engines, *decl_ref.id());
+                }
+
+                has_changes
             }
             TypeInfo::StringArray(Length(ConstGenericExpr::AmbiguousVariableExpression {
                 ident,
@@ -236,7 +234,8 @@ impl MaterializeConstGenerics for TypeId {
                         span: value.span.clone(),
                     }),
                 );
-                has_changes = HasChanges::Yes;
+
+                HasChanges::Yes
             }
             TypeInfo::Ref {
                 to_mutable_value,
@@ -244,17 +243,20 @@ impl MaterializeConstGenerics for TypeId {
                 ..
             } => {
                 let mut referenced_type = referenced_type.clone();
-                has_changes |= referenced_type
+                let has_changes = referenced_type
                     .type_id
                     .materialize_const_generics(engines, handler, name, value)?;
 
-                *self = engines
-                    .te()
-                    .insert_ref(engines, *to_mutable_value, referenced_type);
-                has_changes = HasChanges::Yes;
+                if has_changes.has_changes() {
+                    *self = engines
+                        .te()
+                        .insert_ref(engines, *to_mutable_value, referenced_type);
+                }
+
+                has_changes
             }
-            _ => {}
-        }
+            _ => HasChanges::No,
+        };
 
         Ok(has_changes)
     }

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -13,6 +13,8 @@ use std::ops::Deref;
 pub use substitute::subst_types::SubstTypesContext;
 
 #[cfg(test)]
+use crate::decl_engine::parsed_id::ParsedDeclId;
+#[cfg(test)]
 use crate::language::{CallPath, CallPathType};
 #[cfg(test)]
 use crate::{language::ty::TyEnumDecl, transform::Attributes};
@@ -126,7 +128,7 @@ fn generic_enum_resolution() {
             visibility: crate::language::Visibility::Public,
             attributes: Attributes::default(),
         },
-        None,
+        ParsedDeclId::dummy(),
     );
     let ty_1 = engines.te().insert_enum(&engines, *decl_ref_1.id());
 
@@ -168,7 +170,7 @@ fn generic_enum_resolution() {
             visibility: crate::language::Visibility::Public,
             attributes: Attributes::default(),
         },
-        None,
+        ParsedDeclId::dummy(),
     );
     let ty_2 = engines.te().insert_enum(&engines, *decl_ref_2.id());
 

--- a/sway-core/src/type_system/monomorphization.rs
+++ b/sway-core/src/type_system/monomorphization.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decl_engine::{engine::DeclEngineGetParsedDeclId, DeclEngineInsert, MaterializeConstGenerics},
+    decl_engine::{DeclEngineInsert, MaterializeConstGenerics},
     language::{
         ty::{self, TyExpression},
         CallPath,
@@ -340,12 +340,7 @@ pub(crate) fn type_decl_opt_to_type_id(
             )?
             .has_changes()
             {
-                *decl_engine
-                    .insert(
-                        new_copy,
-                        decl_engine.get_parsed_decl_id(&original_id).as_ref(),
-                    )
-                    .id()
+                *decl_engine.insert_modified(new_copy, original_id).id()
             } else {
                 original_id
             };
@@ -376,12 +371,7 @@ pub(crate) fn type_decl_opt_to_type_id(
             )?
             .has_changes()
             {
-                *decl_engine
-                    .insert(
-                        new_copy,
-                        decl_engine.get_parsed_decl_id(&original_id).as_ref(),
-                    )
-                    .id()
+                *decl_engine.insert_modified(new_copy, original_id).id()
             } else {
                 original_id
             };

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast_elements::type_parameter::ConstGenericExpr,
-    decl_engine::{DeclEngineGetParsedDeclId, DeclEngineInsert, ParsedDeclEngineInsert},
+    decl_engine::{DeclEngineInsert, ParsedDeclEngineInsert},
     engine_threading::{
         DebugWithEngines, Engines, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
@@ -487,8 +487,7 @@ impl TypeSubstMap {
                     }
                 }
                 if need_to_create_new {
-                    let new_decl_ref =
-                        decl_engine.insert(decl, decl_engine.get_parsed_decl_id(&decl_id).as_ref());
+                    let new_decl_ref = decl_engine.insert_modified(decl, decl_id);
                     Some(type_engine.insert_struct(engines, *new_decl_ref.id()))
                 } else {
                     None
@@ -517,8 +516,7 @@ impl TypeSubstMap {
                     }
                 }
                 if need_to_create_new {
-                    let new_decl_ref =
-                        decl_engine.insert(decl, decl_engine.get_parsed_decl_id(&decl_id).as_ref());
+                    let new_decl_ref = decl_engine.insert_modified(decl, decl_id);
                     Some(type_engine.insert_enum(engines, *new_decl_ref.id()))
                 } else {
                     None


### PR DESCRIPTION
## Description

This PR is a prerequisite for an upcoming performance optimization of the `DeclEngine`, aimed at additional removals of copied `TyDecl` entries from the `DeclEngine`.

The PR:
- properly implements `HasChanges` for `MaterializeConstGenerics::materialize_const_generics`. During compilation of the o2 `order-book` contract, this change removes 104 duplicated function decls and 894 duplicated struct decls.
- removes `insert_arc` from the `DeclEngine`. The semantic of this method made no sense for its existing usages. In all usages, we were inserting an existing declaration gotten from the `DeclEngine` and just giving it a different `DeclId`. In other words, calling `DeclEngine::get_...` would for both `DeclId`s return exactly the same declaration. Additionally, all those usages were only in ABI declarations, for ABI's `TyImplItem::Fn/Constant/Type` where none of those can be modified afterwards in any way (e.g., we do not support them being generic in ABIs). As expected, removing `insert_arc` and replacing its returned `DeclRef` with the original didn't change semantic of any calls that were using it.
- adds `insert_modified` method to the `DeclEngine` and forces `insert` to provide `ParsedDeclId`. Previous approach in which callers were responsible for either passing the `ParsedDeclId` for the first time or getting it by `get_parsed_decl_id` was both verbose and error-prone. There were cases in code, some even marked with TODO, where the `ParsedDeclId` was not provided when inserting a modified declaration, essentially inserting declarations that were not connected to their parsed equivalents.
- adds `insert_dummy_func` method to the `DeclEngine` to clearly distinguish the only case in which a typed declaration does not have the corresponding parsed declaration.
- fixes the bug of having two different fields for parsed const generics in the `DeclEngine`: `const_generic_parsed_decl_id_map` and `const_generic**s**_parsed_decl_id_map`. The plural version was used for writing and singular for reading, effectively resulting in const generics never having their corresponding parsed declarations attached.
- wires all instances of `ConstGenericParameter` with their corresponding `ParsedDeclId`s. Previously this was done for const generics in functions and impls, but not in structs, enums, and traits.

Additionally, the PR:
- adds `run-tests.sh` and `just t` recipe for convenient running of the base set of Sway compiler tests.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.