### PR TITLE
sway-lsp: remove second read from hover_data that can deadlock

### DIFF
--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -71,7 +71,7 @@ pub fn hover_data(
         // The `TypeInfo` of the token does not contain an `Ident`. In this case,
         // we use the `Ident` of the token itself.
         None => hover_format(
-            &state.engines.read(),
+            &state.engines,
             token,
             &ident.name,
             client_config,

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -71,7 +71,7 @@ pub fn hover_data(
         // The `TypeInfo` of the token does not contain an `Ident`. In this case,
         // we use the `Ident` of the token itself.
         None => hover_format(
-            &state.engines,
+            engines,
             token,
             &ident.name,
             client_config,


### PR DESCRIPTION
## Description

Fix #7711

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
