### PR TITLE
Split AST to ASM compilation phase to AST -> IR -> ASM

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1770,17 +1770,31 @@ pub fn compile(
         );
     }
 
-    let asm_res = time_expr!(
+    let ir_res = time_expr!(
         pkg.name,
-        "compile ast to asm",
-        "compile_ast_to_asm",
-        sway_core::ast_to_asm(
+        "compile ast to ir",
+        "compile_ast_to_ir",
+        sway_core::ast_to_ir(
             &handler,
             engines,
             &programs,
             &sway_build_config,
             experimental
         ),
+        Some(sway_build_config.clone()),
+        metrics
+    );
+
+    let compiled_ir = match ir_res {
+        Err(_) => return fail(handler),
+        Ok(compiled_ir) => compiled_ir,
+    };
+
+    let asm_res = time_expr!(
+        pkg.name,
+        "compile ir to asm",
+        "compile_ir_to_asm",
+        sway_core::ir_to_asm(&handler, compiled_ir, &sway_build_config),
         Some(sway_build_config.clone()),
         metrics
     );

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -322,15 +322,15 @@ impl PanickingFunctionCache {
     }
 }
 
-pub fn compile_program<'a>(
+pub fn compile_program<'eng>(
     program: &ty::TyProgram,
-    panic_occurrences: &'a mut PanicOccurrences,
-    panicking_call_occurrences: &'a mut PanickingCallOccurrences,
+    panic_occurrences: &mut PanicOccurrences,
+    panicking_call_occurrences: &mut PanickingCallOccurrences,
     include_tests: bool,
-    engines: &'a Engines,
+    engines: &'eng Engines,
     experimental: ExperimentalFeatures,
     backtrace: Backtrace,
-) -> Result<Context<'a>, Vec<CompileError>> {
+) -> Result<Context<'eng>, Vec<CompileError>> {
     let declaration_engine = engines.de();
 
     let test_fns = match include_tests {

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -853,6 +853,18 @@ pub struct CompiledAsm {
     pub panicking_call_occurrences: PanickingCallOccurrences,
 }
 
+/// The result of compiling an AST to IR, i.e. the optimized IR [Context] together
+/// with the occurrence maps collected during IR generation.
+///
+/// This is the intermediate artifact produced by [ast_to_ir] and consumed by
+/// [ir_to_asm], allowing the "AST to IR" and "IR to ASM" phases to be measured
+/// and driven independently.
+pub struct CompiledIr<'eng> {
+    pub ir: Context<'eng>,
+    pub panic_occurrences: PanicOccurrences,
+    pub panicking_call_occurrences: PanickingCallOccurrences,
+}
+
 #[allow(clippy::result_large_err)]
 #[allow(clippy::too_many_arguments)]
 pub fn parsed_to_ast(
@@ -1463,6 +1475,10 @@ pub fn compile_to_asm(
 
 /// Given an AST compilation result, try compiling to a `CompiledAsm`,
 /// containing the asm in opcode form (not raw bytes/bytecode).
+///
+/// This is a convenience wrapper that runs both compilation phases,
+/// [ast_to_ir] followed by [ir_to_asm]. Callers that want to measure the two
+/// phases independently should call those functions directly.
 pub fn ast_to_asm(
     handler: &Handler,
     engines: &Engines,
@@ -1470,6 +1486,23 @@ pub fn ast_to_asm(
     build_config: &BuildConfig,
     experimental: ExperimentalFeatures,
 ) -> Result<CompiledAsm, ErrorEmitted> {
+    let compiled_ir = ast_to_ir(handler, engines, programs, build_config, experimental)?;
+    ir_to_asm(handler, compiled_ir, build_config)
+}
+
+/// Given an AST compilation result, try compiling to the optimized IR [Context],
+/// wrapped in a [CompiledIr] together with the occurrence maps collected during
+/// IR generation.
+///
+/// This is the first half of [ast_to_asm]; the resulting [CompiledIr] is meant to
+/// be passed to [ir_to_asm].
+pub fn ast_to_ir<'eng>(
+    handler: &Handler,
+    engines: &'eng Engines,
+    programs: &Programs,
+    build_config: &BuildConfig,
+    experimental: ExperimentalFeatures,
+) -> Result<CompiledIr<'eng>, ErrorEmitted> {
     let typed_program = match &programs.typed {
         Ok(typed_program) => typed_program,
         Err(err) => return Err(err.error),
@@ -1478,7 +1511,7 @@ pub fn ast_to_asm(
     let mut panic_occurrences = PanicOccurrences::default();
     let mut panicking_call_occurrences = PanickingCallOccurrences::default();
 
-    let asm = match compile_ast_to_ir_to_asm(
+    let ir = match compile_ast_to_ir(
         handler,
         engines,
         typed_program,
@@ -1494,6 +1527,36 @@ pub fn ast_to_asm(
         }
     };
 
+    Ok(CompiledIr {
+        ir,
+        panic_occurrences,
+        panicking_call_occurrences,
+    })
+}
+
+/// Given the optimized IR produced by [ast_to_ir], compile it to a `CompiledAsm`,
+/// containing the asm in opcode form (not raw bytes/bytecode).
+///
+/// This is the second half of [ast_to_asm].
+pub fn ir_to_asm(
+    handler: &Handler,
+    compiled_ir: CompiledIr<'_>,
+    build_config: &BuildConfig,
+) -> Result<CompiledAsm, ErrorEmitted> {
+    let CompiledIr {
+        ir,
+        panic_occurrences,
+        panicking_call_occurrences,
+    } = compiled_ir;
+
+    let asm = match compile_ir_context_to_finalized_asm(handler, &ir, Some(build_config)) {
+        Ok(res) => res,
+        Err(err) => {
+            handler.dedup();
+            return Err(err);
+        }
+    };
+
     Ok(CompiledAsm {
         finalized_asm: asm,
         panic_occurrences,
@@ -1501,15 +1564,15 @@ pub fn ast_to_asm(
     })
 }
 
-pub(crate) fn compile_ast_to_ir_to_asm(
+pub(crate) fn compile_ast_to_ir<'eng>(
     handler: &Handler,
-    engines: &Engines,
+    engines: &'eng Engines,
     program: &ty::TyProgram,
     panic_occurrences: &mut PanicOccurrences,
     panicking_call_occurrences: &mut PanickingCallOccurrences,
     build_config: &BuildConfig,
     experimental: ExperimentalFeatures,
-) -> Result<FinalizedAsm, ErrorEmitted> {
+) -> Result<Context<'eng>, ErrorEmitted> {
     // The IR pipeline relies on type information being fully resolved.
     // If type information is found to still be generic or unresolved inside of
     // IR, this is considered an internal compiler error. To resolve this situation,
@@ -1632,7 +1695,7 @@ pub(crate) fn compile_ast_to_ir_to_asm(
     };
     res?;
 
-    compile_ir_context_to_finalized_asm(handler, &ir, Some(build_config))
+    Ok(ir)
 }
 
 /// Given input Sway source code, compile to [CompiledBytecode], containing the asm in bytecode form.


### PR DESCRIPTION
## Description

This PR splits the `compile_ast_to_asm` compilation phase into two distinctive phases: `compile_ast_to_ir` and `compile_ir_to_asm`. This gives us additional metrics and more insight into how much time each phase is taking. It also allows us to run `forc check` up to the ASM generation phase to collect compilation errors that occur only at the IR stage, if we want to do it. Currently, some checks like, e.g., purity are done at the IR generation stage and are, e.g., not available to LSP which uses `check`. If we decide to extend the `check` phase, this will be done in a separate PR.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.