### PR TITLE
Implement `type_check_finalize` for `DeclEngine` optimization

### DIFF
--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -87,7 +87,7 @@ impl<T> DeclId<T> {
     }
 
     pub(crate) fn dummy() -> Self {
-        // we assume that `usize::MAX` id is not possible in practice
+        // We assume that `usize::MAX` id is not possible in practice.
         Self(usize::MAX, PhantomData)
     }
 }

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -127,7 +127,7 @@ impl TypeCheckFinalization for TyAstNode {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         self.content.type_check_finalize(handler, ctx)
     }
 }
@@ -473,14 +473,13 @@ impl TypeCheckFinalization for TyAstNodeContent {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         match self {
-            TyAstNodeContent::Declaration(node) => node.type_check_finalize(handler, ctx)?,
-            TyAstNodeContent::Expression(node) => node.type_check_finalize(handler, ctx)?,
-            TyAstNodeContent::SideEffect(_) => {}
-            TyAstNodeContent::Error(_, _) => {}
+            TyAstNodeContent::Declaration(node) => node.type_check_finalize(handler, ctx),
+            TyAstNodeContent::Expression(node) => node.type_check_finalize(handler, ctx),
+            TyAstNodeContent::SideEffect(_) => Ok(HasChanges::No),
+            TyAstNodeContent::Error(_, _) => Ok(HasChanges::No),
         }
-        Ok(())
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -1,6 +1,6 @@
 use crate::{
     decl_engine::{
-        DeclEngineReplace, DeclRefConstant, DeclRefFunction, DeclRefTraitFn, DeclRefTraitType,
+        DeclEngineInsert, DeclRefConstant, DeclRefFunction, DeclRefTraitFn, DeclRefTraitType,
         MaterializeConstGenerics, ReplaceFunctionImplementingType,
     },
     engine_threading::*,
@@ -256,24 +256,28 @@ impl TypeCheckFinalization for TyTraitItem {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         let decl_engine = ctx.engines.de();
-        match self {
+        let has_changes = match self {
             TyTraitItem::Fn(node) => {
                 let mut item_fn = (*decl_engine.get_function(node)).clone();
-                item_fn.type_check_finalize(handler, ctx)?;
-                decl_engine.replace(*node.id(), item_fn);
+                let has_changes = item_fn.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    *node = decl_engine.insert_modified(item_fn, *node.id())
+                }
+                has_changes
             }
             TyTraitItem::Constant(node) => {
                 let mut item_const = (*decl_engine.get_constant(node)).clone();
-                item_const.type_check_finalize(handler, ctx)?;
-                decl_engine.replace(*node.id(), item_const);
+                let has_changes = item_const.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    *node = decl_engine.insert_modified(item_const, *node.id())
+                }
+                has_changes
             }
-            TyTraitItem::Type(_node) => {
-                // Nothing to finalize
-            }
-        }
-        Ok(())
+            TyTraitItem::Type(_node) => HasChanges::No,
+        };
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -141,13 +141,15 @@ impl TypeCheckFinalization for TyExpression {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        let res = self.expression.type_check_finalize(handler, ctx);
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let mut has_changes = self.expression.type_check_finalize(handler, ctx)?;
         if let TyExpressionVariant::FunctionApplication { fn_ref, .. } = &self.expression {
             let method = ctx.engines.de().get_function(fn_ref);
-            self.return_type = method.return_type.type_id;
+            let new_return_type = method.return_type.type_id;
+            has_changes |= HasChanges::from(self.return_type != new_return_type);
+            self.return_type = new_return_type;
         }
-        res
+        Ok(has_changes)
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -156,7 +156,6 @@ pub enum TyExpressionVariant {
     },
     StorageAccess(TyStorageAccess),
     IntrinsicFunction(TyIntrinsicFunctionKind),
-    /// a zero-sized type-system-only compile-time thing that is used for constructing ABI casts.
     AbiName(AbiName),
     /// grabs the enum tag from the particular enum and variant of the `exp`
     EnumTag {
@@ -799,7 +798,7 @@ impl SubstTypes for TyExpressionVariant {
                 contents.subst(ctx);
             },
             AbiCast { address, .. } => address.subst(ctx),
-            // storage is never generic and cannot be monomorphized
+            // Storage is never generic and cannot be monomorphized.
             StorageAccess { .. } => HasChanges::No,
             IntrinsicFunction(kind) => kind.subst(ctx),
             EnumTag { exp } => exp.subst(ctx),
@@ -1244,129 +1243,104 @@ impl TypeCheckFinalization for TyExpressionVariant {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
+            use TyExpressionVariant::*;
             match self {
-                TyExpressionVariant::ConstGenericExpression { .. } => {}
-                TyExpressionVariant::Literal(_) => {}
-                TyExpressionVariant::FunctionApplication { arguments, .. } => {
-                    for (_, arg) in arguments.iter_mut() {
-                        let _ = arg.type_check_finalize(handler, ctx);
-                    }
-                }
-                TyExpressionVariant::LazyOperator { lhs, rhs, .. } => {
+                ConstGenericExpression { .. } => Ok(HasChanges::No),
+                Literal(_) => Ok(HasChanges::No),
+                FunctionApplication { arguments, .. } => arguments
+                    .iter_mut()
+                    .try_fold(HasChanges::No, |has_changes, (_, arg)| {
+                        Ok(has_changes | arg.type_check_finalize(handler, ctx)?)
+                    }),
+                LazyOperator { lhs, rhs, .. } => Ok(has_changes! {
                     lhs.type_check_finalize(handler, ctx)?;
-                    rhs.type_check_finalize(handler, ctx)?
-                }
-                TyExpressionVariant::ConstantExpression { decl, .. } => {
-                    decl.type_check_finalize(handler, ctx)?
-                }
-                TyExpressionVariant::ConfigurableExpression { decl, .. } => {
-                    decl.type_check_finalize(handler, ctx)?
-                }
-                TyExpressionVariant::VariableExpression { .. } => {}
-                TyExpressionVariant::Tuple { fields } => {
-                    for field in fields.iter_mut() {
-                        field.type_check_finalize(handler, ctx)?
-                    }
-                }
-                TyExpressionVariant::ArrayExplicit { contents, .. } => {
-                    for elem in contents.iter_mut() {
-                        elem.type_check_finalize(handler, ctx)?
-                    }
-                }
-                TyExpressionVariant::ArrayRepeat { value, length, .. } => {
+                    rhs.type_check_finalize(handler, ctx)?;
+                }),
+                ConstantExpression { decl, .. } => decl.type_check_finalize(handler, ctx),
+                ConfigurableExpression { decl, .. } => decl.type_check_finalize(handler, ctx),
+                VariableExpression { .. } => Ok(HasChanges::No),
+                Tuple { fields } => fields
+                    .iter_mut()
+                    .try_fold(HasChanges::No, |has_changes, field| {
+                        Ok(has_changes | field.type_check_finalize(handler, ctx)?)
+                    }),
+                ArrayExplicit { contents, .. } => contents
+                    .iter_mut()
+                    .try_fold(HasChanges::No, |has_changes, elem| {
+                        Ok(has_changes | elem.type_check_finalize(handler, ctx)?)
+                    }),
+                ArrayRepeat { value, length, .. } => Ok(has_changes! {
                     value.type_check_finalize(handler, ctx)?;
                     length.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::ArrayIndex { prefix, index } => {
+                }),
+                ArrayIndex { prefix, index } => Ok(has_changes! {
                     prefix.type_check_finalize(handler, ctx)?;
                     index.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::StructExpression { fields, .. } => {
-                    for field in fields.iter_mut() {
-                        field.type_check_finalize(handler, ctx)?;
-                    }
-                }
-                TyExpressionVariant::CodeBlock(block) => {
-                    block.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::FunctionParameter => {}
-                TyExpressionVariant::MatchExp {
+                }),
+                StructExpression { fields, .. } => fields
+                    .iter_mut()
+                    .try_fold(HasChanges::No, |has_changes, field| {
+                        Ok(has_changes | field.type_check_finalize(handler, ctx)?)
+                    }),
+                CodeBlock(block) => block.type_check_finalize(handler, ctx),
+                FunctionParameter => Ok(HasChanges::No),
+                MatchExp {
                     desugared,
                     scrutinees,
                 } => {
-                    desugared.type_check_finalize(handler, ctx)?;
-                    for scrutinee in scrutinees.iter_mut() {
-                        scrutinee.type_check_finalize(handler, ctx)?
-                    }
+                    let has_changes = desugared.type_check_finalize(handler, ctx)?;
+                    scrutinees
+                        .iter_mut()
+                        .try_fold(has_changes, |has_changes, scrutinee| {
+                            Ok(has_changes | scrutinee.type_check_finalize(handler, ctx)?)
+                        })
                 }
-                TyExpressionVariant::IfExp {
+                IfExp {
                     condition,
                     then,
                     r#else,
-                } => {
+                } => Ok(has_changes! {
                     condition.type_check_finalize(handler, ctx)?;
                     then.type_check_finalize(handler, ctx)?;
-                    if let Some(ref mut r#else) = r#else {
-                        r#else.type_check_finalize(handler, ctx)?;
-                    }
-                }
-                TyExpressionVariant::AsmExpression { .. } => {}
-                TyExpressionVariant::StructFieldAccess { prefix, .. } => {
-                    prefix.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::TupleElemAccess { prefix, .. } => {
-                    prefix.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::EnumInstantiation { contents, .. } => {
-                    for expr in contents.iter_mut() {
-                        expr.type_check_finalize(handler, ctx)?
-                    }
-                }
-                TyExpressionVariant::AbiCast { address, .. } => {
-                    address.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::StorageAccess(_) => {
-                    todo!("")
-                }
-                TyExpressionVariant::IntrinsicFunction(kind) => {
-                    for expr in kind.arguments.iter_mut() {
-                        expr.type_check_finalize(handler, ctx)?;
-                    }
-                }
-                TyExpressionVariant::AbiName(_) => {
-                    todo!("")
-                }
-                TyExpressionVariant::EnumTag { exp } => {
-                    exp.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::UnsafeDowncast { exp, .. } => {
-                    exp.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::WhileLoop { condition, body } => {
+                    r#else
+                        .as_mut()
+                        .map(|r#else| r#else.type_check_finalize(handler, ctx))
+                        .transpose()?
+                        .unwrap_or_default();
+                }),
+                AsmExpression { .. } => Ok(HasChanges::No),
+                StructFieldAccess { prefix, .. } => prefix.type_check_finalize(handler, ctx),
+                TupleElemAccess { prefix, .. } => prefix.type_check_finalize(handler, ctx),
+                EnumInstantiation { contents, .. } => contents
+                    .iter_mut()
+                    .try_fold(HasChanges::No, |has_changes, expr| {
+                        Ok(has_changes | expr.type_check_finalize(handler, ctx)?)
+                    }),
+                AbiCast { address, .. } => address.type_check_finalize(handler, ctx),
+                StorageAccess(_) => Ok(HasChanges::No),
+                IntrinsicFunction(kind) => kind
+                    .arguments
+                    .iter_mut()
+                    .try_fold(HasChanges::No, |has_changes, expr| {
+                        Ok(has_changes | expr.type_check_finalize(handler, ctx)?)
+                    }),
+                AbiName(_) => Ok(HasChanges::No),
+                EnumTag { exp } => exp.type_check_finalize(handler, ctx),
+                UnsafeDowncast { exp, .. } => exp.type_check_finalize(handler, ctx),
+                WhileLoop { condition, body } => Ok(has_changes! {
                     condition.type_check_finalize(handler, ctx)?;
                     body.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::ForLoop { desugared } => {
-                    desugared.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::Break => {}
-                TyExpressionVariant::Continue => {}
-                TyExpressionVariant::Reassignment(node) => {
-                    node.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::ImplicitReturn(exp) | TyExpressionVariant::Return(exp) => {
-                    exp.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::Panic(exp) => {
-                    exp.type_check_finalize(handler, ctx)?;
-                }
-                TyExpressionVariant::Ref(exp) | TyExpressionVariant::Deref(exp) => {
-                    exp.type_check_finalize(handler, ctx)?;
-                }
+                }),
+                ForLoop { desugared } => desugared.type_check_finalize(handler, ctx),
+                Break => Ok(HasChanges::No),
+                Continue => Ok(HasChanges::No),
+                Reassignment(node) => node.type_check_finalize(handler, ctx),
+                ImplicitReturn(exp) | Return(exp) => exp.type_check_finalize(handler, ctx),
+                Panic(exp) => exp.type_check_finalize(handler, ctx),
+                Ref(exp) | Deref(exp) => exp.type_check_finalize(handler, ctx),
             }
-            Ok(())
         })
     }
 }

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -252,23 +252,24 @@ impl TypeCheckFinalization for TyReassignmentTarget {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        match self {
+    ) -> Result<HasChanges, ErrorEmitted> {
+        let has_changes = match self {
             TyReassignmentTarget::DerefAccess { exp, indices } => {
-                exp.type_check_finalize(handler, ctx)?;
-                indices
-                    .iter_mut()
-                    .map(|i| i.type_check_finalize(handler, ctx))
-                    .collect::<Result<Vec<()>, _>>()
-                    .map(|_| ())?;
+                let mut has_changes = exp.type_check_finalize(handler, ctx)?;
+                for index in indices.iter_mut() {
+                    has_changes |= index.type_check_finalize(handler, ctx)?;
+                }
+                has_changes
             }
-            TyReassignmentTarget::ElementAccess { indices, .. } => indices
-                .iter_mut()
-                .map(|i| i.type_check_finalize(handler, ctx))
-                .collect::<Result<Vec<()>, _>>()
-                .map(|_| ())?,
+            TyReassignmentTarget::ElementAccess { indices, .. } => {
+                let mut has_changes = HasChanges::No;
+                for index in indices.iter_mut() {
+                    has_changes |= index.type_check_finalize(handler, ctx)?;
+                }
+                has_changes
+            }
         };
-        Ok(())
+        Ok(has_changes)
     }
 }
 
@@ -277,11 +278,11 @@ impl TypeCheckFinalization for TyReassignment {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        self.lhs.type_check_finalize(handler, ctx)?;
-        self.rhs.type_check_finalize(handler, ctx)?;
-
-        Ok(())
+    ) -> Result<HasChanges, ErrorEmitted> {
+        Ok(has_changes! {
+            self.lhs.type_check_finalize(handler, ctx)?;
+            self.rhs.type_check_finalize(handler, ctx)?;
+        })
     }
 }
 
@@ -448,11 +449,11 @@ impl TypeCheckFinalization for ProjectionKind {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         use ProjectionKind::*;
         match self {
             ArrayIndex { index, .. } => index.type_check_finalize(handler, ctx),
-            _ => Ok(()),
+            _ => Ok(HasChanges::No),
         }
     }
 }

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -54,7 +54,7 @@ impl TypeCheckFinalization for TyStructExpressionField {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         self.value.type_check_finalize(handler, ctx)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -1,7 +1,10 @@
 use super::*;
-use crate::language::{
-    parsed::CodeBlock,
-    ty::{self, TyAstNodeContent, TyCodeBlock},
+use crate::{
+    language::{
+        parsed::CodeBlock,
+        ty::{self, TyAstNodeContent, TyCodeBlock},
+    },
+    HasChanges,
 };
 
 impl ty::TyCodeBlock {
@@ -177,12 +180,13 @@ impl TypeCheckFinalization for ty::TyCodeBlock {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            for node in self.contents.iter_mut() {
-                let _ = node.type_check_finalize(handler, ctx);
-            }
-            Ok(())
+            self.contents
+                .iter_mut()
+                .try_fold(HasChanges::No, |has_changes, node| {
+                    Ok(has_changes | node.type_check_finalize(handler, ctx)?)
+                })
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -12,7 +12,7 @@ use crate::{
         symbol_collection_context::SymbolCollectionContext, TypeCheckAnalysis,
         TypeCheckAnalysisContext, TypeCheckFinalization, TypeCheckFinalizationContext,
     },
-    Engines,
+    Engines, HasChanges,
 };
 use sway_error::handler::{ErrorEmitted, Handler};
 
@@ -443,12 +443,13 @@ impl TypeCheckFinalization for TyAbiDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            for item in self.items.iter_mut() {
-                let _ = item.type_check_finalize(handler, ctx);
-            }
-            Ok(())
+            self.items
+                .iter_mut()
+                .try_fold(HasChanges::No, |has_changes, item| {
+                    Ok(has_changes | item.type_check_finalize(handler, ctx)?)
+                })
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
@@ -17,7 +17,8 @@ use crate::{
         CallPath, CallPathType,
     },
     semantic_analysis::*,
-    EnforceTypeArguments, Engines, GenericArgument, SubstTypes, TypeBinding, TypeCheckTypeBinding,
+    EnforceTypeArguments, Engines, GenericArgument, HasChanges, SubstTypes, TypeBinding,
+    TypeCheckTypeBinding,
 };
 
 impl ty::TyConfigurableDecl {
@@ -227,10 +228,11 @@ impl TypeCheckFinalization for TyConfigurableDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if let Some(value) = self.value.as_mut() {
-            value.type_check_finalize(handler, ctx)?;
+            value.type_check_finalize(handler, ctx)
+        } else {
+            Ok(HasChanges::No)
         }
-        Ok(())
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
@@ -13,7 +13,7 @@ use crate::{
         CallPath,
     },
     semantic_analysis::*,
-    EnforceTypeArguments, Engines, SubstTypes, TypeInfo,
+    EnforceTypeArguments, Engines, HasChanges, SubstTypes, TypeInfo,
 };
 
 impl ty::TyConstantDecl {
@@ -155,10 +155,11 @@ impl TypeCheckFinalization for TyConstantDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if let Some(value) = self.value.as_mut() {
-            value.type_check_finalize(handler, ctx)?;
+            value.type_check_finalize(handler, ctx)
+        } else {
+            Ok(HasChanges::No)
         }
-        Ok(())
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -23,7 +23,7 @@ use crate::{
         TypeCheckFinalization, TypeCheckFinalizationContext,
     },
     type_system::*,
-    Engines,
+    Engines, HasChanges,
 };
 
 impl TyDecl {
@@ -613,61 +613,99 @@ impl TypeCheckFinalization for TyDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         let decl_engine = ctx.engines.de();
         match self {
-            TyDecl::VariableDecl(node) => {
-                node.type_check_finalize(handler, ctx)?;
-            }
+            TyDecl::VariableDecl(node) => node.type_check_finalize(handler, ctx),
             TyDecl::ConstantDecl(node) => {
-                let mut const_decl = (*ctx.engines.de().get_constant(&node.decl_id)).clone();
-                const_decl.type_check_finalize(handler, ctx)?;
+                let mut const_decl = (*decl_engine.get_constant(&node.decl_id)).clone();
+                let has_changes = const_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(const_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
             TyDecl::ConfigurableDecl(node) => {
-                let mut config_decl = (*ctx.engines.de().get_configurable(&node.decl_id)).clone();
-                config_decl.type_check_finalize(handler, ctx)?;
+                let mut config_decl = (*decl_engine.get_configurable(&node.decl_id)).clone();
+                let has_changes = config_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(config_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
             TyDecl::ConstGenericDecl(_) => {
                 unreachable!("ConstGenericDecl is not reachable from AstNode")
             }
             TyDecl::FunctionDecl(node) => {
-                let mut fn_decl = (*ctx.engines.de().get_function(&node.decl_id)).clone();
-                fn_decl.type_check_finalize(handler, ctx)?;
+                let mut fn_decl = (*decl_engine.get_function(&node.decl_id)).clone();
+                let has_changes = fn_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(fn_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
             TyDecl::TraitDecl(node) => {
-                let mut trait_decl = (*ctx.engines.de().get_trait(&node.decl_id)).clone();
-                trait_decl.type_check_finalize(handler, ctx)?;
+                let mut trait_decl = (*decl_engine.get_trait(&node.decl_id)).clone();
+                let has_changes = trait_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(trait_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
             TyDecl::StructDecl(node) => {
-                let mut struct_decl = (*ctx.engines.de().get_struct(&node.decl_id)).clone();
-                struct_decl.type_check_finalize(handler, ctx)?;
+                let mut struct_decl = (*decl_engine.get_struct(&node.decl_id)).clone();
+                let has_changes = struct_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(struct_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
             TyDecl::EnumDecl(node) => {
-                let mut enum_decl = (*ctx.engines.de().get_enum(&node.decl_id)).clone();
-                enum_decl.type_check_finalize(handler, ctx)?;
+                let mut enum_decl = (*decl_engine.get_enum(&node.decl_id)).clone();
+                let has_changes = enum_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(enum_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
-            TyDecl::EnumVariantDecl(_) => {}
+            TyDecl::EnumVariantDecl(_) => Ok(HasChanges::No),
             TyDecl::ImplSelfOrTrait(node) => {
                 let mut impl_trait = (*decl_engine.get_impl_self_or_trait(&node.decl_id)).clone();
-                impl_trait.type_check_finalize(handler, ctx)?;
+                let has_changes = impl_trait.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(impl_trait, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
             TyDecl::AbiDecl(node) => {
                 let mut abi_decl = (*decl_engine.get_abi(&node.decl_id)).clone();
-                abi_decl.type_check_finalize(handler, ctx)?;
+                let has_changes = abi_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(abi_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
-            TyDecl::GenericTypeForFunctionScope(_) => {}
-            TyDecl::ErrorRecovery(_, _) => {}
+            TyDecl::GenericTypeForFunctionScope(_) => Ok(HasChanges::No),
+            TyDecl::ErrorRecovery(_, _) => Ok(HasChanges::No),
             TyDecl::StorageDecl(node) => {
                 let mut storage_decl = (*decl_engine.get_storage(&node.decl_id)).clone();
-                storage_decl.type_check_finalize(handler, ctx)?;
+                let has_changes = storage_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine.insert_modified(storage_decl, node.decl_id).id();
+                }
+                Ok(has_changes)
             }
             TyDecl::TypeAliasDecl(node) => {
                 let mut type_alias_decl = (*decl_engine.get_type_alias(&node.decl_id)).clone();
-                type_alias_decl.type_check_finalize(handler, ctx)?;
+                let has_changes = type_alias_decl.type_check_finalize(handler, ctx)?;
+                if has_changes.has_changes() {
+                    node.decl_id = *decl_engine
+                        .insert_modified(type_alias_decl, node.decl_id)
+                        .id();
+                }
+                Ok(has_changes)
             }
-            TyDecl::TraitTypeDecl(_node) => {}
+            TyDecl::TraitTypeDecl(_node) => Ok(HasChanges::No),
         }
-
-        Ok(())
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -3,7 +3,7 @@ use crate::{
     language::{parsed::*, ty, CallPath},
     semantic_analysis::*,
     type_system::*,
-    Engines,
+    Engines, HasChanges,
 };
 use ast_elements::type_parameter::GenericTypeParameter;
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -122,7 +122,7 @@ impl TypeCheckFinalization for ty::TyEnumDecl {
         &mut self,
         _handler: &Handler,
         _ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        Ok(())
+    ) -> Result<HasChanges, ErrorEmitted> {
+        Ok(HasChanges::No)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     semantic_analysis::*,
     type_system::*,
-    Engines,
+    Engines, HasChanges,
 };
 use ast_elements::type_parameter::GenericTypeParameter;
 use hashbrown::HashMap;
@@ -376,11 +376,8 @@ impl TypeCheckFinalization for ty::TyFunctionDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        handler.scope(|handler| {
-            let _ = self.body.type_check_finalize(handler, ctx);
-            Ok(())
-        })
+    ) -> Result<HasChanges, ErrorEmitted> {
+        handler.scope(|handler| self.body.type_check_finalize(handler, ctx))
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -793,22 +793,29 @@ impl TyImplSelfOrTrait {
                         }
                     }
 
+                    let new_items = &mut impl_trait.items;
                     let mut finalizing_ctx =
                         TypeCheckFinalizationContext::new(ctx.engines, ctx.by_ref());
-                    for item in new_items {
+                    for item in new_items.iter_mut() {
                         match item {
                             TyTraitItem::Fn(decl_ref) => {
                                 let mut fn_decl =
                                     (*decl_engine.get_function(decl_ref.id())).clone();
-                                let _ = fn_decl.type_check_finalize(handler, &mut finalizing_ctx);
-                                decl_engine.replace(*decl_ref.id(), fn_decl);
+                                let has_changes =
+                                    fn_decl.type_check_finalize(handler, &mut finalizing_ctx)?;
+                                if has_changes.has_changes() {
+                                    *decl_ref = decl_engine.insert_modified(fn_decl, *decl_ref.id())
+                                }
                             }
                             TyTraitItem::Constant(decl_ref) => {
                                 let mut const_decl =
                                     (*decl_engine.get_constant(decl_ref.id())).clone();
-                                let _ =
-                                    const_decl.type_check_finalize(handler, &mut finalizing_ctx);
-                                decl_engine.replace(*decl_ref.id(), const_decl);
+                                let has_changes =
+                                    const_decl.type_check_finalize(handler, &mut finalizing_ctx)?;
+                                if has_changes.has_changes() {
+                                    *decl_ref =
+                                        decl_engine.insert_modified(const_decl, *decl_ref.id())
+                                }
                             }
                             _ => {}
                         }
@@ -2032,12 +2039,13 @@ impl TypeCheckFinalization for TyImplSelfOrTrait {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            for item in self.items.iter_mut() {
-                let _ = item.type_check_finalize(handler, ctx);
-            }
-            Ok(())
+            self.items
+                .iter_mut()
+                .try_fold(HasChanges::No, |has_changes, item| {
+                    Ok(has_changes | item.type_check_finalize(handler, ctx)?)
+                })
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
@@ -15,7 +15,7 @@ use crate::{
         symbol_collection_context::SymbolCollectionContext, TypeCheckAnalysis,
         TypeCheckAnalysisContext, TypeCheckFinalization, TypeCheckFinalizationContext,
     },
-    Engines,
+    Engines, HasChanges,
 };
 use fuel_vm::fuel_tx::Bytes32;
 use sway_error::{
@@ -188,12 +188,13 @@ impl TypeCheckFinalization for ty::TyStorageDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            for field in self.fields.iter_mut() {
-                let _ = field.type_check_finalize(handler, ctx);
-            }
-            Ok(())
+            self.fields
+                .iter_mut()
+                .try_fold(HasChanges::No, |has_changes, field| {
+                    Ok(has_changes | field.type_check_finalize(handler, ctx)?)
+                })
         })
     }
 }
@@ -203,7 +204,7 @@ impl TypeCheckFinalization for ty::TyStorageField {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         self.initializer.type_check_finalize(handler, ctx)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -3,7 +3,7 @@ use crate::{
     language::{parsed::*, ty, CallPath},
     semantic_analysis::*,
     type_system::*,
-    Engines,
+    Engines, HasChanges,
 };
 use ast_elements::type_parameter::GenericTypeParameter;
 use sway_error::{
@@ -160,7 +160,7 @@ impl TypeCheckFinalization for ty::TyStructDecl {
         &mut self,
         _handler: &Handler,
         _ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        Ok(())
+    ) -> Result<HasChanges, ErrorEmitted> {
+        Ok(HasChanges::No)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -27,7 +27,7 @@ use crate::{
         TypeCheckFinalization, TypeCheckFinalizationContext,
     },
     type_system::*,
-    Engines,
+    Engines, HasChanges,
 };
 
 impl TyTraitItem {
@@ -663,12 +663,13 @@ impl TypeCheckFinalization for TyTraitDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            for item in self.items.iter_mut() {
-                let _ = item.type_check_finalize(handler, ctx);
-            }
-            Ok(())
+            self.items
+                .iter_mut()
+                .try_fold(HasChanges::No, |has_changes, item| {
+                    Ok(has_changes | item.type_check_finalize(handler, ctx)?)
+                })
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/type_alias.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/type_alias.rs
@@ -8,7 +8,7 @@ use crate::{
         symbol_collection_context::SymbolCollectionContext, TypeCheckFinalization,
         TypeCheckFinalizationContext,
     },
-    Engines,
+    Engines, HasChanges,
 };
 use sway_error::handler::{ErrorEmitted, Handler};
 
@@ -34,7 +34,7 @@ impl TypeCheckFinalization for TyTypeAliasDecl {
         &mut self,
         _handler: &Handler,
         _ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        Ok(())
+    ) -> Result<HasChanges, ErrorEmitted> {
+        Ok(HasChanges::No)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     semantic_analysis::*,
     type_system::*,
-    Engines,
+    Engines, HasChanges,
 };
 use namespace::ResolvedDeclaration;
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -140,7 +140,7 @@ impl TypeCheckFinalization for TyVariableDecl {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         self.body.type_check_finalize(handler, ctx)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     semantic_analysis::{TypeCheckContext, TypeCheckFinalization, TypeCheckFinalizationContext},
     type_system::*,
+    HasChanges,
 };
 
 impl TyScrutinee {
@@ -471,8 +472,8 @@ impl TypeCheckFinalization for TyScrutinee {
         &mut self,
         _handler: &Handler,
         _ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
-        Ok(())
+    ) -> Result<HasChanges, ErrorEmitted> {
+        Ok(HasChanges::No)
     }
 }
 

--- a/sway-core/src/semantic_analysis/type_check_finalization.rs
+++ b/sway-core/src/semantic_analysis/type_check_finalization.rs
@@ -4,7 +4,7 @@
 
 use sway_error::handler::{ErrorEmitted, Handler};
 
-use crate::Engines;
+use crate::{Engines, HasChanges};
 
 use super::TypeCheckContext;
 
@@ -29,7 +29,7 @@ pub(crate) trait TypeCheckFinalization {
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted>;
+    ) -> Result<HasChanges, ErrorEmitted>;
 }
 
 impl<T: TypeCheckFinalization + Clone> TypeCheckFinalization for std::sync::Arc<T> {
@@ -37,14 +37,14 @@ impl<T: TypeCheckFinalization + Clone> TypeCheckFinalization for std::sync::Arc<
         &mut self,
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
-    ) -> Result<(), ErrorEmitted> {
+    ) -> Result<HasChanges, ErrorEmitted> {
         if let Some(item) = std::sync::Arc::get_mut(self) {
             item.type_check_finalize(handler, ctx)
         } else {
             let mut item = self.as_ref().clone();
-            item.type_check_finalize(handler, ctx)?;
+            let has_changes = item.type_check_finalize(handler, ctx)?;
             *self = std::sync::Arc::new(item);
-            Ok(())
+            Ok(has_changes)
         }
     }
 }


### PR DESCRIPTION
## Description

This PR is a prerequisite for upcoming compiler performance optimization: removals of expensive hashing and removals of duplicates from the `DeclEngine`.

The PR:
- returns `HasChanges` from `type_check_finalize`, enabling callers to decide what to do in case of changes happened or not.
- replaces `decl_engine.replace` calls with conditional calls to `decl_engine.insert_modified`. This was the central point of the refactoring. Before removing duplicates from the `DeclEngine` we need to remove the `replace` method. Note that the intended usage of the `replace` method wasn't to replace some shared declaration. The usages were assuming that the replaced declaration is used only from a single usage point, although `DeclEngine` never provided that guarantee. Having `insert_modified` instead of `replace` removes the possibility of unwanted side effects.
- fixes `type_check_finalized` implementation for `TyDecl`. The implementation was `type_check_finalize`ing a cloned `TyDecl` that got discarded without actually affecting the original.
- fixes `type_check_finalized` implementations that were swallowing errors coming from internal `type_check_finalized` calls. All errors are now properly propagated.
- implements two `todo!`s in `TyExpressionVariant::type_check_finalize` by properly returning `HasChanges::No`.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.