### PR TITLE
fix: report unsupported generic ABI declarations

### DIFF
--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -1129,6 +1129,13 @@ fn item_abi_to_abi_declaration(
 
                     let trait_item = match annotated.value {
                         ItemTraitItem::Fn(fn_signature, _) => {
+                            if let Some(generics) = &fn_signature.generics {
+                                return Err(handler.emit_err(
+                                    CompileError::GenericParametersNotSupportedInAbi {
+                                        span: generics.parameters.span(),
+                                    },
+                                ));
+                            }
                             let trait_fn = fn_signature_to_trait_fn(
                                 context,
                                 handler,

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -1036,6 +1036,8 @@ pub enum CompileError {
     },
     #[error("Associated types not supported in ABI.")]
     AssociatedTypeNotSupportedInAbi { span: Span },
+    #[error("Generic parameters are not supported in ABI declarations.")]
+    GenericParametersNotSupportedInAbi { span: Span },
     #[error("Cannot call ABI supertrait's method as a contract method: \"{fn_name}\"")]
     AbiSupertraitMethodCallAsContractCall { fn_name: Ident, span: Span },
     #[error(
@@ -1456,6 +1458,7 @@ impl Spanned for CompileError {
             AbiShadowsSuperAbiMethod { span, .. } => span.clone(),
             ConflictingSuperAbiMethods { span, .. } => span.clone(),
             AssociatedTypeNotSupportedInAbi { span, .. } => span.clone(),
+            GenericParametersNotSupportedInAbi { span, .. } => span.clone(),
             AbiSupertraitMethodCallAsContractCall { span, .. } => span.clone(),
             FunctionSelectorClash { span, .. } => span.clone(),
             TypeNotAllowed { span, .. } => span.clone(),

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'generic_parameters_in_abi'
+source = 'member'
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "generic_parameters_in_abi"
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/src/main.sw
@@ -1,0 +1,5 @@
+contract;
+
+abi Abi {
+    fn fun<T>() -> bool;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_parameters_in_abi/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: $()fn fun<T>() -> bool;
+# nextln: $()Generic parameters are not supported in ABI declarations.


### PR DESCRIPTION
## Issue

Closes #7703. Generic parameters in ABI declarations were either accepted without a useful diagnostic or produced confusing downstream errors when the ABI was implemented.

## Fix

- Detect generic parameters while converting ABI function declarations.
- Emit a dedicated `Generic parameters are not supported in ABI declarations.` diagnostic at the generic parameter span.
- Add an end-to-end compile-fail fixture covering the unsupported syntax.

## Validation

- `cargo test -p sway-core --lib` (20 passed).