### PR TITLE
Add `has_changes_scoped!` and fix emitting of scoped errors

### DIFF
--- a/sway-core/src/decl_engine/mapping.rs
+++ b/sway-core/src/decl_engine/mapping.rs
@@ -15,6 +15,13 @@ type DestinationDecl = AssociatedItemDeclId;
 
 /// The [DeclMapping] is used to create a mapping between a [SourceDecl] (LHS)
 /// and a [DestinationDecl] (RHS).
+///
+/// Note that [DeclMapping] is **not a mapping of arbitrary `DeclId`s**.
+/// Its whole domain is [AssociatedItemDeclId], which is only trait/impl associated items:
+/// functions, constants and associated types. [DeclMapping] maps a trait interface
+/// item reference to its concrete impl counterpart.
+/// For concrete swaps of trait interface item references with their concrete impls,
+/// see [find_match], which is the final step of the trait-method monomorphization.
 #[derive(Clone)]
 pub struct DeclMapping {
     pub mapping: Vec<(SourceDecl, DestinationDecl)>,

--- a/sway-core/src/has_changes.rs
+++ b/sway-core/src/has_changes.rs
@@ -56,3 +56,26 @@ macro_rules! has_changes {
         has_changes
     }};
 }
+
+/// Like [`has_changes!`], but for use inside a [`sway_error::handler::Handler::scope`].
+///
+/// Each statement must evaluate to a `Result<HasChanges, ErrorEmitted>`. Errors are
+/// swallowed instead of short-circuiting: they remain captured by the enclosing scope,
+/// which will still report them, so every statement runs and independent sub-operations
+/// each get to emit their diagnostics.
+///
+/// Use this only inside a `Handler::scope` (or with a scope up the call stack). Outside a
+/// scope, a swallowed error would be lost from the returned `Result` even though it was
+/// emitted.
+#[macro_export]
+macro_rules! has_changes_scoped {
+    ($($stmt:expr);* ;) => {{
+        let mut has_changes = $crate::HasChanges::No;
+        $(
+            if let Ok(r) = $stmt {
+                has_changes |= r;
+            }
+        )*
+        has_changes
+    }};
+}

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -1,7 +1,7 @@
 use crate::{
     decl_engine::*,
     engine_threading::*,
-    has_changes,
+    has_changes, has_changes_scoped,
     language::{ty::*, *},
     semantic_analysis::{
         TyNodeDepGraphEdge, TyNodeDepGraphEdgeInfo, TypeCheckAnalysis, TypeCheckAnalysisContext,
@@ -850,18 +850,22 @@ impl ReplaceDecls for TyExpressionVariant {
 
                     has_changes |= fn_ref.replace_decls(decl_mapping, handler, ctx)?;
 
-                    for (_, arg) in arguments.iter_mut() {
-                        if let Ok(r) = arg.replace_decls(decl_mapping, handler, ctx) {
-                            has_changes |= r;
-                        }
-                    }
+                    has_changes |=
+                        arguments
+                            .iter_mut()
+                            .fold(HasChanges::No, |has_changes, (_, arg)| {
+                                has_changes
+                                    | arg
+                                        .replace_decls(decl_mapping, handler, ctx)
+                                        .unwrap_or_default()
+                            });
 
                     let decl_engine = ctx.engines().de();
                     let mut method = (*decl_engine.get(fn_ref)).clone();
 
                     // Finds method implementation for method dummy and replaces it.
                     // This is required because dummy methods don't have type parameters from impl traits.
-                    // Thus we use the implemented method that already contains all the required type parameters,
+                    // Thus, we use the implemented method that already contains all the required type parameters,
                     // including those from the impl trait.
                     if method.is_trait_method_dummy {
                         if let Some(implementing_for) = method.implementing_for {
@@ -916,7 +920,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     }
 
                     // Handle the trait constraints. This includes checking to see if the trait
-                    // constraints are satisfied and replacing old decl ids based on the
+                    // constraints are satisfied and replacing old decl ids.
                     let mut inner_decl_mapping =
                         GenericTypeParameter::gather_decl_mapping_from_trait_constraints(
                             handler,
@@ -938,11 +942,10 @@ impl ReplaceDecls for TyExpressionVariant {
 
                     Ok(has_changes)
                 }
-                LazyOperator { lhs, rhs, .. } => {
-                    let mut has_changes = (*lhs).replace_decls(decl_mapping, handler, ctx)?;
-                    has_changes |= (*rhs).replace_decls(decl_mapping, handler, ctx)?;
-                    Ok(has_changes)
-                }
+                LazyOperator { lhs, rhs, .. } => Ok(has_changes_scoped! {
+                    lhs.replace_decls(decl_mapping, handler, ctx);
+                    rhs.replace_decls(decl_mapping, handler, ctx);
+                }),
                 ConstantExpression { decl, .. } => decl.replace_decls(decl_mapping, handler, ctx),
                 ConfigurableExpression { decl, .. } => {
                     decl.replace_decls(decl_mapping, handler, ctx)
@@ -950,58 +953,54 @@ impl ReplaceDecls for TyExpressionVariant {
                 ConstGenericExpression { .. } => Ok(HasChanges::No),
                 VariableExpression { .. } => Ok(HasChanges::No),
                 Tuple { fields } => {
-                    let mut has_changes = HasChanges::No;
-                    for item in fields.iter_mut() {
-                        if let Ok(r) = item.replace_decls(decl_mapping, handler, ctx) {
-                            has_changes |= r;
-                        }
-                    }
-                    Ok(has_changes)
+                    Ok(fields.iter_mut().fold(HasChanges::No, |has_changes, item| {
+                        has_changes
+                            | item
+                                .replace_decls(decl_mapping, handler, ctx)
+                                .unwrap_or_default()
+                    }))
                 }
                 ArrayExplicit {
                     elem_type: _,
                     contents,
-                } => {
-                    let mut has_changes = HasChanges::No;
-                    for expr in contents.iter_mut() {
-                        if let Ok(r) = expr.replace_decls(decl_mapping, handler, ctx) {
-                            has_changes |= r;
-                        }
-                    }
-                    Ok(has_changes)
-                }
+                } => Ok(contents
+                    .iter_mut()
+                    .fold(HasChanges::No, |has_changes, expr| {
+                        has_changes
+                            | expr
+                                .replace_decls(decl_mapping, handler, ctx)
+                                .unwrap_or_default()
+                    })),
                 ArrayRepeat {
                     elem_type: _,
                     value,
                     length,
-                } => {
-                    let mut has_changes = (*value).replace_decls(decl_mapping, handler, ctx)?;
-                    has_changes |= (*length).replace_decls(decl_mapping, handler, ctx)?;
-                    Ok(has_changes)
-                }
-                ArrayIndex { prefix, index } => {
-                    let mut has_changes = HasChanges::No;
-                    if let Ok(r) = (*prefix).replace_decls(decl_mapping, handler, ctx) {
-                        has_changes |= r;
-                    }
-                    if let Ok(r) = (*index).replace_decls(decl_mapping, handler, ctx) {
-                        has_changes |= r;
-                    }
-                    Ok(has_changes)
-                }
+                } => Ok(has_changes_scoped! {
+                    value.replace_decls(decl_mapping, handler, ctx);
+                    length.replace_decls(decl_mapping, handler, ctx);
+                }),
+                ArrayIndex { prefix, index } => Ok(has_changes_scoped! {
+                    prefix.replace_decls(decl_mapping, handler, ctx);
+                    index.replace_decls(decl_mapping, handler, ctx);
+                }),
                 StructExpression {
                     struct_id: _,
                     fields,
                     instantiation_span: _,
                     call_path_binding: _,
                 } => {
-                    let mut has_changes = HasChanges::No;
-                    for field in fields.iter_mut() {
-                        if let Ok(r) = field.replace_decls(decl_mapping, handler, ctx) {
-                            has_changes |= r;
-                        }
-                    }
-                    Ok(has_changes)
+                    // The `struct_id` needs no replacement here: `DeclMapping` only maps trait
+                    // associated items (functions, constants, associated types) to their
+                    // implementations, and a struct declaration is never such an item. Substituting
+                    // type parameters into the struct type is handled separately by `SubstTypes`.
+                    Ok(fields
+                        .iter_mut()
+                        .fold(HasChanges::No, |has_changes, field| {
+                            has_changes
+                                | field
+                                    .replace_decls(decl_mapping, handler, ctx)
+                                    .unwrap_or_default()
+                        }))
                 }
                 CodeBlock(block) => block.replace_decls(decl_mapping, handler, ctx),
                 FunctionParameter => Ok(HasChanges::No),
@@ -1010,22 +1009,15 @@ impl ReplaceDecls for TyExpressionVariant {
                     condition,
                     then,
                     r#else,
-                } => {
-                    let mut has_changes = HasChanges::No;
-                    if let Ok(r) = condition.replace_decls(decl_mapping, handler, ctx) {
-                        has_changes |= r;
-                    }
-                    if let Ok(r) = then.replace_decls(decl_mapping, handler, ctx) {
-                        has_changes |= r;
-                    }
-                    if let Some(r) = r#else
+                } => Ok(has_changes_scoped! {
+                    condition.replace_decls(decl_mapping, handler, ctx);
+                    then.replace_decls(decl_mapping, handler, ctx);
+                    r#else
                         .as_mut()
-                        .and_then(|expr| expr.replace_decls(decl_mapping, handler, ctx).ok())
-                    {
-                        has_changes |= r;
-                    }
-                    Ok(has_changes)
-                }
+                        .map(|r#else| r#else.replace_decls(decl_mapping, handler, ctx))
+                        .transpose()
+                        .map(Option::unwrap_or_default);
+                }),
                 AsmExpression { .. } => Ok(HasChanges::No),
                 StructFieldAccess { prefix, .. } => {
                     prefix.replace_decls(decl_mapping, handler, ctx)
@@ -1036,8 +1028,10 @@ impl ReplaceDecls for TyExpressionVariant {
                     contents,
                     ..
                 } => {
-                    // TODO: replace enum decl
-                    //enum_decl.replace_decls(decl_mapping);
+                    // The `enum_ref` needs no replacement here: `DeclMapping` only maps trait
+                    // associated items (functions, constants, associated types) to their
+                    // implementations, and an enum declaration is never such an item. Substituting
+                    // type parameters into the enum type is handled separately by `SubstTypes`.
                     if let Some(ref mut contents) = contents {
                         contents.replace_decls(decl_mapping, handler, ctx)
                     } else {
@@ -1046,31 +1040,24 @@ impl ReplaceDecls for TyExpressionVariant {
                 }
                 AbiCast { address, .. } => address.replace_decls(decl_mapping, handler, ctx),
                 StorageAccess { .. } => Ok(HasChanges::No),
-                IntrinsicFunction(TyIntrinsicFunctionKind { arguments, .. }) => {
-                    let mut has_changes = HasChanges::No;
-                    for expr in arguments.iter_mut() {
-                        if let Ok(r) = expr.replace_decls(decl_mapping, handler, ctx) {
-                            has_changes |= r;
-                        }
-                    }
-                    Ok(has_changes)
-                }
+                IntrinsicFunction(TyIntrinsicFunctionKind { arguments, .. }) => Ok(arguments
+                    .iter_mut()
+                    .fold(HasChanges::No, |has_changes, expr| {
+                        has_changes
+                            | expr
+                                .replace_decls(decl_mapping, handler, ctx)
+                                .unwrap_or_default()
+                    })),
                 EnumTag { exp } => exp.replace_decls(decl_mapping, handler, ctx),
                 UnsafeDowncast { exp, .. } => exp.replace_decls(decl_mapping, handler, ctx),
                 AbiName(_) => Ok(HasChanges::No),
                 WhileLoop {
                     ref mut condition,
                     ref mut body,
-                } => {
-                    let mut has_changes = HasChanges::No;
-                    if let Ok(r) = condition.replace_decls(decl_mapping, handler, ctx) {
-                        has_changes |= r;
-                    }
-                    if let Ok(r) = body.replace_decls(decl_mapping, handler, ctx) {
-                        has_changes |= r;
-                    }
-                    Ok(has_changes)
-                }
+                } => Ok(has_changes_scoped! {
+                    condition.replace_decls(decl_mapping, handler, ctx);
+                    body.replace_decls(decl_mapping, handler, ctx);
+                }),
                 ForLoop { ref mut desugared } => {
                     desugared.replace_decls(decl_mapping, handler, ctx)
                 }
@@ -1244,94 +1231,113 @@ impl TypeCheckFinalization for TyExpressionVariant {
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
     ) -> Result<HasChanges, ErrorEmitted> {
+        // In all arms, we intentionally swallow errors,
+        // because any emitted error is still captured by the below scope.
         handler.scope(|handler| {
             use TyExpressionVariant::*;
             match self {
                 ConstGenericExpression { .. } => Ok(HasChanges::No),
                 Literal(_) => Ok(HasChanges::No),
-                FunctionApplication { arguments, .. } => arguments
-                    .iter_mut()
-                    .try_fold(HasChanges::No, |has_changes, (_, arg)| {
-                        Ok(has_changes | arg.type_check_finalize(handler, ctx)?)
-                    }),
-                LazyOperator { lhs, rhs, .. } => Ok(has_changes! {
-                    lhs.type_check_finalize(handler, ctx)?;
-                    rhs.type_check_finalize(handler, ctx)?;
+                FunctionApplication { arguments, .. } => {
+                    Ok(arguments
+                        .iter_mut()
+                        .fold(HasChanges::No, |has_changes, (_, arg)| {
+                            has_changes | arg.type_check_finalize(handler, ctx).unwrap_or_default()
+                        }))
+                }
+                LazyOperator { lhs, rhs, .. } => Ok(has_changes_scoped! {
+                    lhs.type_check_finalize(handler, ctx);
+                    rhs.type_check_finalize(handler, ctx);
                 }),
                 ConstantExpression { decl, .. } => decl.type_check_finalize(handler, ctx),
                 ConfigurableExpression { decl, .. } => decl.type_check_finalize(handler, ctx),
                 VariableExpression { .. } => Ok(HasChanges::No),
-                Tuple { fields } => fields
-                    .iter_mut()
-                    .try_fold(HasChanges::No, |has_changes, field| {
-                        Ok(has_changes | field.type_check_finalize(handler, ctx)?)
-                    }),
-                ArrayExplicit { contents, .. } => contents
-                    .iter_mut()
-                    .try_fold(HasChanges::No, |has_changes, elem| {
-                        Ok(has_changes | elem.type_check_finalize(handler, ctx)?)
-                    }),
-                ArrayRepeat { value, length, .. } => Ok(has_changes! {
-                    value.type_check_finalize(handler, ctx)?;
-                    length.type_check_finalize(handler, ctx)?;
+                Tuple { fields } => {
+                    Ok(fields
+                        .iter_mut()
+                        .fold(HasChanges::No, |has_changes, field| {
+                            has_changes
+                                | field.type_check_finalize(handler, ctx).unwrap_or_default()
+                        }))
+                }
+                ArrayExplicit { contents, .. } => {
+                    Ok(contents
+                        .iter_mut()
+                        .fold(HasChanges::No, |has_changes, elem| {
+                            has_changes | elem.type_check_finalize(handler, ctx).unwrap_or_default()
+                        }))
+                }
+                ArrayRepeat { value, length, .. } => Ok(has_changes_scoped! {
+                    value.type_check_finalize(handler, ctx);
+                    length.type_check_finalize(handler, ctx);
                 }),
-                ArrayIndex { prefix, index } => Ok(has_changes! {
-                    prefix.type_check_finalize(handler, ctx)?;
-                    index.type_check_finalize(handler, ctx)?;
+                ArrayIndex { prefix, index } => Ok(has_changes_scoped! {
+                    prefix.type_check_finalize(handler, ctx);
+                    index.type_check_finalize(handler, ctx);
                 }),
-                StructExpression { fields, .. } => fields
-                    .iter_mut()
-                    .try_fold(HasChanges::No, |has_changes, field| {
-                        Ok(has_changes | field.type_check_finalize(handler, ctx)?)
-                    }),
+                StructExpression { fields, .. } => {
+                    Ok(fields
+                        .iter_mut()
+                        .fold(HasChanges::No, |has_changes, field| {
+                            has_changes
+                                | field.type_check_finalize(handler, ctx).unwrap_or_default()
+                        }))
+                }
                 CodeBlock(block) => block.type_check_finalize(handler, ctx),
                 FunctionParameter => Ok(HasChanges::No),
                 MatchExp {
                     desugared,
                     scrutinees,
-                } => {
-                    let has_changes = desugared.type_check_finalize(handler, ctx)?;
-                    scrutinees
-                        .iter_mut()
-                        .try_fold(has_changes, |has_changes, scrutinee| {
-                            Ok(has_changes | scrutinee.type_check_finalize(handler, ctx)?)
-                        })
-                }
+                } => Ok(scrutinees.iter_mut().fold(
+                    desugared
+                        .type_check_finalize(handler, ctx)
+                        .unwrap_or_default(),
+                    |has_changes, scrutinee| {
+                        has_changes
+                            | scrutinee
+                                .type_check_finalize(handler, ctx)
+                                .unwrap_or_default()
+                    },
+                )),
                 IfExp {
                     condition,
                     then,
                     r#else,
-                } => Ok(has_changes! {
-                    condition.type_check_finalize(handler, ctx)?;
-                    then.type_check_finalize(handler, ctx)?;
+                } => Ok(has_changes_scoped! {
+                    condition.type_check_finalize(handler, ctx);
+                    then.type_check_finalize(handler, ctx);
                     r#else
                         .as_mut()
                         .map(|r#else| r#else.type_check_finalize(handler, ctx))
-                        .transpose()?
-                        .unwrap_or_default();
+                        .transpose()
+                        .map(Option::unwrap_or_default);
                 }),
                 AsmExpression { .. } => Ok(HasChanges::No),
                 StructFieldAccess { prefix, .. } => prefix.type_check_finalize(handler, ctx),
                 TupleElemAccess { prefix, .. } => prefix.type_check_finalize(handler, ctx),
-                EnumInstantiation { contents, .. } => contents
-                    .iter_mut()
-                    .try_fold(HasChanges::No, |has_changes, expr| {
-                        Ok(has_changes | expr.type_check_finalize(handler, ctx)?)
-                    }),
+                EnumInstantiation { contents, .. } => {
+                    Ok(contents
+                        .iter_mut()
+                        .fold(HasChanges::No, |has_changes, expr| {
+                            has_changes | expr.type_check_finalize(handler, ctx).unwrap_or_default()
+                        }))
+                }
                 AbiCast { address, .. } => address.type_check_finalize(handler, ctx),
                 StorageAccess(_) => Ok(HasChanges::No),
-                IntrinsicFunction(kind) => kind
-                    .arguments
-                    .iter_mut()
-                    .try_fold(HasChanges::No, |has_changes, expr| {
-                        Ok(has_changes | expr.type_check_finalize(handler, ctx)?)
-                    }),
+                IntrinsicFunction(kind) => {
+                    Ok(kind
+                        .arguments
+                        .iter_mut()
+                        .fold(HasChanges::No, |has_changes, expr| {
+                            has_changes | expr.type_check_finalize(handler, ctx).unwrap_or_default()
+                        }))
+                }
                 AbiName(_) => Ok(HasChanges::No),
                 EnumTag { exp } => exp.type_check_finalize(handler, ctx),
                 UnsafeDowncast { exp, .. } => exp.type_check_finalize(handler, ctx),
-                WhileLoop { condition, body } => Ok(has_changes! {
-                    condition.type_check_finalize(handler, ctx)?;
-                    body.type_check_finalize(handler, ctx)?;
+                WhileLoop { condition, body } => Ok(has_changes_scoped! {
+                    condition.type_check_finalize(handler, ctx);
+                    body.type_check_finalize(handler, ctx);
                 }),
                 ForLoop { desugared } => desugared.type_check_finalize(handler, ctx),
                 Break => Ok(HasChanges::No),

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -182,11 +182,12 @@ impl TypeCheckFinalization for ty::TyCodeBlock {
         ctx: &mut TypeCheckFinalizationContext,
     ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            self.contents
+            Ok(self
+                .contents
                 .iter_mut()
-                .try_fold(HasChanges::No, |has_changes, node| {
-                    Ok(has_changes | node.type_check_finalize(handler, ctx)?)
-                })
+                .fold(HasChanges::No, |has_changes, node| {
+                    has_changes | node.type_check_finalize(handler, ctx).unwrap_or_default()
+                }))
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -445,11 +445,12 @@ impl TypeCheckFinalization for TyAbiDecl {
         ctx: &mut TypeCheckFinalizationContext,
     ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            self.items
+            Ok(self
+                .items
                 .iter_mut()
-                .try_fold(HasChanges::No, |has_changes, item| {
-                    Ok(has_changes | item.type_check_finalize(handler, ctx)?)
-                })
+                .fold(HasChanges::No, |has_changes, item| {
+                    has_changes | item.type_check_finalize(handler, ctx).unwrap_or_default()
+                }))
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -377,7 +377,13 @@ impl TypeCheckFinalization for ty::TyFunctionDecl {
         handler: &Handler,
         ctx: &mut TypeCheckFinalizationContext,
     ) -> Result<HasChanges, ErrorEmitted> {
-        handler.scope(|handler| self.body.type_check_finalize(handler, ctx))
+        handler.scope(|handler| {
+            // Swallow the error: any emitted error is still captured by the scope.
+            Ok(self
+                .body
+                .type_check_finalize(handler, ctx)
+                .unwrap_or_default())
+        })
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -2041,11 +2041,12 @@ impl TypeCheckFinalization for TyImplSelfOrTrait {
         ctx: &mut TypeCheckFinalizationContext,
     ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            self.items
+            Ok(self
+                .items
                 .iter_mut()
-                .try_fold(HasChanges::No, |has_changes, item| {
-                    Ok(has_changes | item.type_check_finalize(handler, ctx)?)
-                })
+                .fold(HasChanges::No, |has_changes, item| {
+                    has_changes | item.type_check_finalize(handler, ctx).unwrap_or_default()
+                }))
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
@@ -190,11 +190,12 @@ impl TypeCheckFinalization for ty::TyStorageDecl {
         ctx: &mut TypeCheckFinalizationContext,
     ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            self.fields
+            Ok(self
+                .fields
                 .iter_mut()
-                .try_fold(HasChanges::No, |has_changes, field| {
-                    Ok(has_changes | field.type_check_finalize(handler, ctx)?)
-                })
+                .fold(HasChanges::No, |has_changes, field| {
+                    has_changes | field.type_check_finalize(handler, ctx).unwrap_or_default()
+                }))
         })
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -665,11 +665,12 @@ impl TypeCheckFinalization for TyTraitDecl {
         ctx: &mut TypeCheckFinalizationContext,
     ) -> Result<HasChanges, ErrorEmitted> {
         handler.scope(|handler| {
-            self.items
+            Ok(self
+                .items
                 .iter_mut()
-                .try_fold(HasChanges::No, |has_changes, item| {
-                    Ok(has_changes | item.type_check_finalize(handler, ctx)?)
-                })
+                .fold(HasChanges::No, |has_changes, item| {
+                    has_changes | item.type_check_finalize(handler, ctx).unwrap_or_default()
+                }))
         })
     }
 }

--- a/sway-error/src/handler.rs
+++ b/sway-error/src/handler.rs
@@ -13,7 +13,7 @@ pub struct Handler {
 }
 
 /// Contains the actual data for `Handler`.
-/// Modelled this way to afford an API using interior mutability.
+/// Modeled this way to afford an API using interior mutability.
 #[derive(Default, Debug, Clone)]
 struct HandlerDiagnostics {
     /// The sink through which errors will be emitted.
@@ -45,7 +45,7 @@ impl Handler {
         ErrorEmitted { _priv: () }
     }
 
-    // Compilation should be cancelled.
+    // Compilation should be canceled.
     pub fn cancel(&self) -> ErrorEmitted {
         ErrorEmitted { _priv: () }
     }
@@ -72,6 +72,47 @@ impl Handler {
         !self.inner.borrow().warnings.is_empty()
     }
 
+    /// Aggregate errors emitted when running `f`.
+    ///
+    /// Runs `f` in a fresh error-collecting scope, returning `f`'s result, or an
+    /// aggregated [ErrorEmitted] if *any* error was emitted while running `f`.
+    ///
+    /// A fresh, scoped [Handler] is passed to `f`. After `f` returns, its errors are
+    /// appended to `self`. If at least one error was emitted into the scoped handler,
+    /// the scope returns `Err(ErrorEmitted)` regardless of what `f` returned; otherwise
+    /// it returns `f`'s result.
+    ///
+    /// # Swallowing errors within a scope is intended
+    ///
+    /// Because the scope aggregates *every* error emitted into the scoped handler, code
+    /// inside `f` should keep going after a failing sub-operation instead of
+    /// short-circuiting on the first error. Swallowing an individual sub-operation's
+    /// [Result] and continuing with the next one is therefore the *intended* pattern.
+    /// Independent sub-operations each get to report their own diagnostics, so the user
+    /// sees all of them at once rather than only the first.
+    ///
+    /// When iterating over a collection, use `fold` together with `unwrap_or_default`
+    /// (rather than `try_fold` with `?`) so that every element is still processed:
+    ///
+    /// ```ignore
+    /// handler.scope(|handler| {
+    ///     // Each element's error is swallowed but stays captured by the scope, so
+    ///     // sibling elements can also report their diagnostics.
+    ///     Ok(items.iter_mut().fold(HasChanges::No, |has_changes, item| {
+    ///         has_changes | item.do_something(handler).unwrap_or_default()
+    ///     }))
+    /// })
+    /// ```
+    ///
+    /// For a fixed set of sub-operations, `sway_core`'s `has_changes_scoped!` macro
+    /// applies the same swallow-and-continue behavior.
+    ///
+    /// Use `?` only when a later step genuinely depends on an earlier step succeeding,
+    /// i.e. when continuing would panic or produce misleading cascade errors.
+    ///
+    /// Note that swallowing an [ErrorEmitted] is only sound *inside* a scope (or with
+    /// a scope somewhere up the call stack). Outside a scope, a swallowed error is lost
+    /// from the returned [Result] even though it was emitted.
     pub fn scope<T>(
         &self,
         f: impl FnOnce(&Handler) -> Result<T, ErrorEmitted>,


### PR DESCRIPTION
## Description

Emitting errors within a `handler.scope` call was not always done as intended by the `scope` semantics. Sometimes errors were, as expected by semantics, swallowed within the `scope` closure, but not always.

This PR:
- documents in detail the intended `scope` semantics and explains the patterns to be used when dealing with failing calls within a `scope`.
- introduces `has_changes_scoped` macro. The macro offers the same convenience as `has_changes` but but it expects and accepts statements that return `Result<HasChanges, ...> and swallows the errors, which makes it compatible with the `scope` semantics.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.