### PR TITLE
Remove obsolete `CFEI`/`CFSI` optimization from ASM generation

### DIFF
--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -123,10 +123,10 @@ fn to_bytecode_mut(
 ) -> CompiledBytecode {
     fn op_size_in_bytes(data_section: &DataSection, item: &AllocatedOp) -> u64 {
         match &item.opcode {
-            AllocatedInstruction::LoadDataId(_reg, data_label)
+            AllocatedInstruction::LoadDataId(_reg, data_id)
                 if !data_section
-                    .has_copy_type(data_label)
-                    .expect("data label references non existent data -- internal error") =>
+                    .has_copy_type(data_id)
+                    .expect("`data_id` references data non-existent in the data section") =>
             {
                 8
             }
@@ -141,7 +141,6 @@ fn to_bytecode_mut(
             AllocatedInstruction::ConfigurablesOffsetPlaceholder => 8,
             AllocatedInstruction::DataSectionOffsetPlaceholder => 8,
             AllocatedInstruction::BLOB(count) => count.value() as u64 * 4,
-            AllocatedInstruction::CFEI(i) | AllocatedInstruction::CFSI(i) if i.value() == 0 => 0,
             _ => 4,
         }
     }

--- a/sway-core/src/asm_generation/fuel/allocated_abstract_instruction_set.rs
+++ b/sway-core/src/asm_generation/fuel/allocated_abstract_instruction_set.rs
@@ -72,7 +72,7 @@ impl AllocatedAbstractInstructionSet {
     ///  - does not call any functions that spill arguments to the stack
     ///  - does not spill any registers to the stack when allocating registers
     ///
-    /// This is the cases IFF the function contains `CFEI 0`.
+    /// This is the case IFF the function contains `CFEI 0`.
     fn remove_redundant_sp_move_to_locbase(mut self) -> AllocatedAbstractInstructionSet {
         let Some((_fn_name, is_entry)) = &self.function else {
             // Don't optimize if we are not in a function.
@@ -394,26 +394,18 @@ impl AllocatedAbstractInstructionSet {
         match op.opcode {
             Either::Right(Label(_)) => 0,
 
-            // Loads from data section may take up to 2 instructions
+            // Loads from data section may take up to 2 instructions.
             Either::Left(
                 AllocatedInstruction::LoadDataId(_, _) | AllocatedInstruction::AddrDataId(_, _),
             ) => 2,
 
-            // cfei 0 and cfsi 0 are omitted from asm emission, don't count them for offsets
-            Either::Left(AllocatedInstruction::CFEI(ref op))
-            | Either::Left(AllocatedInstruction::CFSI(ref op))
-                if op.value() == 0 =>
-            {
-                0
-            }
-
             // Another special case for the blob opcode, used for testing.
             Either::Left(AllocatedInstruction::BLOB(ref count)) => count.value() as u64,
 
-            // This is a concrete op, size is fixed
+            // This is a concrete op, size is fixed.
             Either::Left(_) => 1,
 
-            // Worst case for jump is 2 opcodes, and 3 for calls
+            // Worst case for jump is 2 opcodes, and 3 for calls.
             Either::Right(Jump { ref type_, .. }) => match type_ {
                 JumpType::Unconditional => 2,
                 JumpType::NotZero(_) => 2,
@@ -423,13 +415,13 @@ impl AllocatedAbstractInstructionSet {
             Either::Right(ReturnFromCall { .. }) => 1,
             Either::Right(Comment) => 0,
             Either::Right(DataSectionOffsetPlaceholder) => {
-                // If the placeholder is 32 bits, this is 1. if 64, this should be 2. We use LW
+                // If the placeholder is 32 bits, this is 1. If 64, this should be 2. We use LW
                 // to load the data, which loads a whole word, so for now this is 2.
                 2
             }
             Either::Right(ConfigurablesOffsetPlaceholder) => 2,
             Either::Right(PushAll(_)) | Either::Right(PopAll(_)) => unreachable!(
-                "fix me, pushall and popall don't really belong in control flow ops \
+                "`PushAll` and `PopAll` don't belong in control flow ops \
                         since they're not about control flow"
             ),
         }
@@ -465,18 +457,10 @@ impl AllocatedAbstractInstructionSet {
                 }
             }
 
-            // cfei 0 and cfsi 0 are omitted from asm emission, don't count them for offsets
-            Either::Left(AllocatedInstruction::CFEI(ref op))
-            | Either::Left(AllocatedInstruction::CFSI(ref op))
-                if op.value() == 0 =>
-            {
-                0
-            }
-
             // Another special case for the blob opcode, used for testing.
             Either::Left(AllocatedInstruction::BLOB(ref count)) => count.value() as u64,
 
-            // This is a concrete op, size is fixed
+            // This is a concrete op, size is fixed.
             Either::Left(_) => 1,
 
             // Far jumps must be handled separately, as they require two instructions.
@@ -485,7 +469,7 @@ impl AllocatedAbstractInstructionSet {
             Either::Right(Comment) => 0,
 
             Either::Right(DataSectionOffsetPlaceholder) => {
-                // If the placeholder is 32 bits, this is 1. if 64, this should be 2. We use LW
+                // If the placeholder is 32 bits, this is 1. If 64, this should be 2. We use LW
                 // to load the data, which loads a whole word, so for now this is 2.
                 2
             }
@@ -493,7 +477,7 @@ impl AllocatedAbstractInstructionSet {
             Either::Right(ConfigurablesOffsetPlaceholder) => 2,
 
             Either::Right(PushAll(_)) | Either::Right(PopAll(_)) => unreachable!(
-                "fix me, pushall and popall don't really belong in control flow ops \
+                "`PushAll` and `PopAll` don't belong in control flow ops \
                         since they're not about control flow"
             ),
 

--- a/sway-core/src/asm_generation/fuel/programs/abstract.rs
+++ b/sway-core/src/asm_generation/fuel/programs/abstract.rs
@@ -388,15 +388,20 @@ impl AbstractProgram {
         });
     }
 
+    /// Allocates stack space for globals.
+    ///
+    /// `cfei` is added to `asm` only if the [Self::globals_section] actually contains globals.
     fn append_globals_allocation(&self, asm: &mut AllocatedAbstractInstructionSet) {
         let len_in_bytes = self.globals_section.len_in_bytes();
-        asm.ops.push(AllocatedAbstractOp {
-            opcode: Either::Left(AllocatedInstruction::CFEI(VirtualImmediate24::new(
-                len_in_bytes,
-            ))),
-            comment: "allocate stack space for globals".into(),
-            owning_span: None,
-        });
+        if len_in_bytes > 0 {
+            asm.ops.push(AllocatedAbstractOp {
+                opcode: Either::Left(AllocatedInstruction::CFEI(VirtualImmediate24::new(
+                    len_in_bytes,
+                ))),
+                comment: "allocate stack space for globals".into(),
+                owning_span: None,
+            });
+        }
     }
 }
 

--- a/sway-core/src/asm_lang/allocated_ops.rs
+++ b/sway-core/src/asm_lang/allocated_ops.rs
@@ -787,9 +787,7 @@ impl AllocatedOp {
 
             /* Memory Instructions */
             ALOC(a) => op::ALOC::new(a.to_reg_id()).into(),
-            CFEI(a) if a.value() == 0 => return FuelAsmData::Instructions(vec![]),
             CFEI(a) => op::CFEI::new(a.value().into()).into(),
-            CFSI(a) if a.value() == 0 => return FuelAsmData::Instructions(vec![]),
             CFSI(a) => op::CFSI::new(a.value().into()).into(),
             CFE(a) => op::CFE::new(a.to_reg_id()).into(),
             CFS(a) => op::CFS::new(a.to_reg_id()).into(),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array/array_repeat/stdout.snap
@@ -337,7 +337,6 @@ CONFIGURABLES_OFFSET[0..32]
 CONFIGURABLES_OFFSET[32..64]
 lw   $$ds $$tmp i1
 add  $$ds $$ds $$tmp
-cfei i0                       ; allocate stack space for globals
 move $$locbase $sp            ; [entry init: __entry]: set locals base register
 jal  $$reta $pc i2            ; [call: main_0]: call function
 retd  $zero $zero             ; [entry end: __entry] return slice

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_empty/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_empty/stdout.snap
@@ -50,7 +50,6 @@ CONFIGURABLES_OFFSET[0..32]
 CONFIGURABLES_OFFSET[32..64]
 lw   $$ds $$tmp i1
 add  $$ds $$ds $$tmp
-cfei i0                       ; allocate stack space for globals
 move $$locbase $sp            ; [entry init: __entry]: set locals base register
 jal  $$reta $pc i2            ; [call: main_0]: call function
 retd  $zero $zero             ; [entry end: __entry] return slice

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_one_u64/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_one_u64/stdout.snap
@@ -67,7 +67,6 @@ CONFIGURABLES_OFFSET[0..32]
 CONFIGURABLES_OFFSET[32..64]
 lw   $$ds $$tmp i1
 add  $$ds $$ds $$tmp
-cfei i0                       ; allocate stack space for globals
 move $$locbase $sp            ; [entry init: __entry]: set locals base register
 cfei i24                      ; [entry init: __entry]: allocate: locals 24 byte(s), call args 0 slot(s)
 gtf  $r0 $zero i10            ; get transaction field

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_two_u64/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_two_u64/stdout.snap
@@ -72,7 +72,6 @@ CONFIGURABLES_OFFSET[0..32]
 CONFIGURABLES_OFFSET[32..64]
 lw   $$ds $$tmp i1
 add  $$ds $$ds $$tmp
-cfei i0                       ; allocate stack space for globals
 move $$locbase $sp            ; [entry init: __entry]: set locals base register
 cfei i56                      ; [entry init: __entry]: allocate: locals 56 byte(s), call args 0 slot(s)
 gtf  $r0 $zero i10            ; get transaction field

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/stdout.snap
@@ -1136,7 +1136,6 @@ CONFIGURABLES_OFFSET[0..32]
 CONFIGURABLES_OFFSET[32..64]
 lw   $$ds $$tmp i1
 add  $$ds $$ds $$tmp
-cfei i0                       ; allocate stack space for globals
 move $$locbase $sp            ; [entry init: __entry]: set locals base register
 cfei i512                     ; [entry init: __entry]: allocate: locals 512 byte(s), call args 0 slot(s)
 gtf  $r0 $zero i10            ; get transaction field


### PR DESCRIPTION
## Description

This PR:
- removes the special handling of `CFEI`/`CFSI` instructions from the `asm_lang` and `asm_generation`. That special handling was introduced in #5588 as an implementation of removal of `CFEI/CFSI` pairs if the allocated size was zero. Later on, #6627 implemented a general `CFE(I)/CFS(I)` removal as a localized optimization of the allocated abstract instruction set, but it did not removed the special handling introduced by #5588.
- removes emitting of a `CFEI` for allocating globals, if the ASM does not have any globals. 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.