### PR TITLE
Reject references in contract storage

### DIFF
--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -260,7 +260,8 @@ impl TyProgram {
         // Perform other validation based on the tree type.
         let typed_program_kind = match kind {
             parsed::TreeType::Contract => {
-                // Types containing raw_ptr are not allowed in storage (e.g Vec)
+                // Types containing transaction-memory pointers or references are not allowed in
+                // storage. Persisting either would leave a dangling address after the call.
                 for decl in declarations.iter() {
                     if let TyDecl::StorageDecl(StorageDecl { decl_id }) = decl {
                         let storage_decl = decl_engine.get_storage(decl_id);
@@ -273,7 +274,7 @@ impl TyProgram {
                                     TypeInfo::StringSlice => {
                                         Some(TypeNotAllowedReason::StringSliceInConfigurables)
                                     }
-                                    TypeInfo::RawUntypedPtr => Some(
+                                    TypeInfo::RawUntypedPtr | TypeInfo::Ref { .. } => Some(
                                         TypeNotAllowedReason::TypeNotAllowedInContractStorage {
                                             ty: engines.help_out(t).to_string(),
                                         },

--- a/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "reference_in_contract_storage"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-8DD70B98C09F9691"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "reference_in_contract_storage"
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/src/main.sw
@@ -1,0 +1,14 @@
+contract;
+
+use std::storage::storage_vec::*;
+
+struct RefBox {
+    value: &u64,
+}
+
+storage {
+    direct: &u64 = &0,
+    nested: RefBox = RefBox { value: &0 },
+    map: StorageMap<u64, RefBox> = StorageMap {},
+    vec: StorageVec<RefBox> = StorageVec {},
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/reference_in_contract_storage/test.toml
@@ -1,0 +1,6 @@
+category = "fail"
+
+# check-count: 4
+# check: $()The type "&u64" is not allowed in storage.
+
+# check: $()6 errors.


### PR DESCRIPTION
## Description

Reject reference-bearing types in contract storage using the existing recursive validation for storage types. Persisted references point into transaction memory and become dangling after the call ends.

The regression fixture covers references used directly, nested in a struct, and nested in `StorageMap` and `StorageVec` value types.

This addresses the **Forbid references → In the storage** item in #5063.

## Checklist

- [x] `cargo run -p test --release -- reference_in_contract_storage --kind e2e --sequential`
- [x] `cargo check -p sway-core`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`